### PR TITLE
feat: nudge models toward command batching in tool description

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -18,7 +18,7 @@ Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), vari
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
 Not supported: heredocs, backticks, control flow (if/for/while), background jobs.
 
-CWD, environment variables, export/unset and cd persist across calls within this session.
+CWD, environment variables, export/unset and cd persist across calls within this session — but prefer COMBINING related commands in one call with ; or && (e.g. 'cd src && ls | wc -l'); each call is a fresh translation+process, so batching is faster than many tiny calls.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).`;
 
 export async function startMcpServer(): Promise<void> {


### PR DESCRIPTION
## Motivation

Benchmark finding (see docs/benchmark-deepseek-v4-pro.md addendum): fauxnix wall-time vs bundled native shells scales with call granularity — models making 2-3 tiny calls per task paid ~30% overhead (MCP round-trip + fresh translation/process per call), while one-shot bundlers matched native speed.

## Change

One sentence in the MCP `bash` tool description: prefer combining related commands with `;` / `&&`. This flips the default toward bash-idiomatic batching without changing any semantics — session persistence still works either way.