### PR TITLE
fix: resolve redirects against cwd after each segment

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -195,10 +195,13 @@ async function runPlans(
   // skips b AND c when a fails. chainOk models the value of the current
   // &&/|| chain; `;` segments always run and restart the chain.
   let chainOk = true;
-  // redirect targets are relative to the session cwd, not this node process
-  const baseDir = opts.cwd ?? session.cwd ?? process.cwd();
+  // Redirect targets are relative to the *current* session cwd, not this
+  // Node process. Re-read after every segment so `cd src && echo x > out.txt`
+  // writes under src (same as two separate session calls). A one-shot
+  // capture of the entry cwd would land the file in the old directory.
+  let currentDir = opts.cwd ?? session.cwd ?? process.cwd();
   const resolveTarget = (t: string): string =>
-    path.isAbsolute(t) || /^[A-Za-z]:[\\/]/.test(t) ? t : path.resolve(baseDir, t);
+    path.isAbsolute(t) || /^[A-Za-z]:[\\/]/.test(t) ? t : path.resolve(currentDir, t);
 
   for (const plan of plans) {
     if (plan.op === '&&' && !chainOk) continue;
@@ -266,6 +269,7 @@ async function runPlans(
     clearTimeout(timer);
 
     afterSegment();
+    if (session.cwd) currentDir = session.cwd;
 
     const decodePref = resolveNativePref();
     // GNU line discipline: PowerShell's console layer terminates every line

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -4,7 +4,7 @@
  */
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parseCommand } from '../src/parser.js';
@@ -175,6 +175,39 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
     await run('gunzip g.txt.gz');
     const back = await run('cat g.txt');
     expect(back.stdout).toContain('apple pie');
+  });
+
+  it('cd then redirect writes under the new cwd, not the entry cwd', async () => {
+    try {
+      const r = await run('cd sub && echo nested > nested.txt');
+      expect(r.exitCode).toBe(0);
+      expect(existsSync(join(dir, 'nested.txt'))).toBe(false);
+      const raw = readFileSync(join(dir, 'sub', 'nested.txt'), 'utf8');
+      expect(raw.replace(/\r/g, '')).toBe('nested\n');
+    } finally {
+      await run('cd "' + dir.replace(/\\/g, '/') + '"');
+    }
+  });
+
+  it('cd then stdin redirect reads from the new cwd', async () => {
+    try {
+      const r = await run('cd sub && wc -l < b.txt');
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe('1');
+    } finally {
+      await run('cd "' + dir.replace(/\\/g, '/') + '"');
+    }
+  });
+
+  it('redirect before cd still writes in the entry cwd', async () => {
+    try {
+      const r = await run('echo stay > stay.txt && cd sub');
+      expect(r.exitCode).toBe(0);
+      expect(existsSync(join(dir, 'stay.txt'))).toBe(true);
+      expect(existsSync(join(dir, 'sub', 'stay.txt'))).toBe(false);
+    } finally {
+      await run('cd "' + dir.replace(/\\/g, '/') + '"');
+    }
   });
 
   it('redirects write LF line endings (GNU parity)', async () => {


### PR DESCRIPTION
## Problem

Codex flagged this as P2 on #2: `runPlans` captured `baseDir` once from the session entry cwd and reused it for every segment. Combined with the MCP `bash` tool telling models to batch `cd` with later commands, that is a real write-to-the-wrong-file bug.

```
cd src && echo data > out.txt
```

wrote `out.txt` in the *old* directory. Two separate session calls (`cd src` then `echo data > out.txt`) wrote it under `src`.

## Fix

Track `currentDir` through the list and refresh it from `session.cwd` after each completed segment. Relative `>`, `>>`, `2>`, and `<` targets then resolve against the directory the preceding `cd` actually reached.

## Verification

- `npx vitest run test/unit.test.ts test/integration.windows.test.ts` — 65/65 pass
- `npm run typecheck` — clean
- New integration cases:
  - `cd sub && echo nested > nested.txt` writes `sub/nested.txt`, not the entry cwd
  - `cd sub && wc -l < b.txt` reads from `sub/b.txt`
  - `echo stay > stay.txt && cd sub` still writes in the entry cwd