### PR TITLE
fix: resolve redirects against cwd after each segment

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,6 +1,6 @@
 import { spawn, ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { promises as fs, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { promises as fs, readFileSync, writeFileSync, existsSync, openSync, closeSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { Redirect } from './ast.js';
@@ -39,6 +39,25 @@ interface SegmentRedirects {
   appendStderr: boolean;
   mergeStderr: boolean;
   devNull: boolean;
+}
+
+/**
+ * Open a redirect target the way bash does: before the command runs.
+ * `>` truncates; `>>` appends. Failure means the command must not run
+ * (so a redirected `cd` cannot change the session cwd).
+ */
+function prepareRedirectFile(file: string, append: boolean): string | null {
+  try {
+    const fd = openSync(file, append ? 'a' : 'w');
+    closeSync(fd);
+    return null;
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') return file + ': No such file or directory';
+    if (err.code === 'EACCES' || err.code === 'EPERM') return file + ': Permission denied';
+    if (err.code === 'EISDIR') return file + ': Is a directory';
+    return file + ': cannot create: ' + err.message;
+  }
 }
 
 function planRedirects(redirects: Redirect[]): SegmentRedirects {
@@ -195,10 +214,13 @@ async function runPlans(
   // skips b AND c when a fails. chainOk models the value of the current
   // &&/|| chain; `;` segments always run and restart the chain.
   let chainOk = true;
-  // redirect targets are relative to the session cwd, not this node process
-  const baseDir = opts.cwd ?? session.cwd ?? process.cwd();
+  // Redirect targets are relative to the *current* session cwd, not this
+  // Node process. Re-read after every segment so `cd src && echo x > out.txt`
+  // writes under src (same as two separate session calls). A one-shot
+  // capture of the entry cwd would land the file in the old directory.
+  let currentDir = opts.cwd ?? session.cwd ?? process.cwd();
   const resolveTarget = (t: string): string =>
-    path.isAbsolute(t) || /^[A-Za-z]:[\\/]/.test(t) ? t : path.resolve(baseDir, t);
+    path.isAbsolute(t) || /^[A-Za-z]:[\\/]/.test(t) ? t : path.resolve(currentDir, t);
 
   for (const plan of plans) {
     if (plan.op === '&&' && !chainOk) continue;
@@ -216,6 +238,28 @@ async function runPlans(
       session.prevExit = exitCode;
       chainOk = false;
       continue;
+    }
+
+    // bash sets up output redirects before executing the command. If the
+    // target cannot be created, the command (including `cd`) must not run,
+    // or later segments would inherit a cwd the redirected cd never reached.
+    const outPrep = red.stdoutFile ? prepareRedirectFile(red.stdoutFile, red.appendStdout) : null;
+    if (outPrep) {
+      stderr += 'bash: ' + outPrep + '\n';
+      exitCode = 1;
+      session.prevExit = exitCode;
+      chainOk = false;
+      continue;
+    }
+    if (red.stderrFile && red.stderrFile !== red.stdoutFile) {
+      const errPrep = prepareRedirectFile(red.stderrFile, red.appendStderr);
+      if (errPrep) {
+        stderr += 'bash: ' + errPrep + '\n';
+        exitCode = 1;
+        session.prevExit = exitCode;
+        chainOk = false;
+        continue;
+      }
     }
 
     const encoded = encodeCommand(plan.script);
@@ -291,6 +335,7 @@ async function runPlans(
     if (swallowStderr) segErr = '';
 
     // redirect stdout to file instead of the result stream
+    let redirectOk = true;
     if (red.stdoutFile) {
       try {
         if (red.appendStdout) {
@@ -303,6 +348,7 @@ async function runPlans(
       } catch (e) {
         segErr += 'bash: ' + red.stdoutFile + ': cannot create: ' + (e as Error).message + '\n';
         exitCode = 1;
+        redirectOk = false;
       }
     }
     if (red.stderrFile) {
@@ -328,6 +374,10 @@ async function runPlans(
     exitCode = code ?? 0;
     session.prevExit = exitCode;
     chainOk = exitCode === 0;
+    // Only inherit cwd from a segment that actually ran and whose
+    // output redirects succeeded. A failed `cd dir > missing/out` must
+    // not move later relative redirects.
+    if (redirectOk && session.cwd) currentDir = session.cwd;
   }
 
   return { stdout, stderr, exitCode };

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -4,7 +4,7 @@
  */
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parseCommand } from '../src/parser.js';
@@ -175,6 +175,51 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
     await run('gunzip g.txt.gz');
     const back = await run('cat g.txt');
     expect(back.stdout).toContain('apple pie');
+  });
+
+  it('cd then redirect writes under the new cwd, not the entry cwd', async () => {
+    try {
+      const r = await run('cd sub && echo nested > nested.txt');
+      expect(r.exitCode).toBe(0);
+      expect(existsSync(join(dir, 'nested.txt'))).toBe(false);
+      const raw = readFileSync(join(dir, 'sub', 'nested.txt'), 'utf8');
+      expect(raw.replace(/\r/g, '')).toBe('nested\n');
+    } finally {
+      await run('cd "' + dir.replace(/\\/g, '/') + '"');
+    }
+  });
+
+  it('cd then stdin redirect reads from the new cwd', async () => {
+    try {
+      const r = await run('cd sub && wc -l < b.txt');
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe('1');
+    } finally {
+      await run('cd "' + dir.replace(/\\/g, '/') + '"');
+    }
+  });
+
+  it('failed redirect on cd does not move later relative redirects', async () => {
+    try {
+      const r = await run('cd sub > nosuchdir/out.txt; echo ok > after.txt');
+      expect(r.exitCode).toBe(0);
+      expect(r.stderr).toMatch(/nosuchdir\/out\.txt|No such file or directory/);
+      expect(existsSync(join(dir, 'sub', 'after.txt'))).toBe(false);
+      expect(readFileSync(join(dir, 'after.txt'), 'utf8').replace(/\r/g, '')).toBe('ok\n');
+    } finally {
+      await run('cd "' + dir.replace(/\\/g, '/') + '"');
+    }
+  });
+
+  it('redirect before cd still writes in the entry cwd', async () => {
+    try {
+      const r = await run('echo stay > stay.txt && cd sub');
+      expect(r.exitCode).toBe(0);
+      expect(existsSync(join(dir, 'stay.txt'))).toBe(true);
+      expect(existsSync(join(dir, 'sub', 'stay.txt'))).toBe(false);
+    } finally {
+      await run('cd "' + dir.replace(/\\/g, '/') + '"');
+    }
   });
 
   it('redirects write LF line endings (GNU parity)', async () => {


### PR DESCRIPTION
## Problem

Codex flagged this as P2 on #2: `runPlans` captured `baseDir` once from the session entry cwd and reused it for every segment. Combined with the MCP `bash` tool telling models to batch `cd` with later commands, that is a real write-to-the-wrong-file bug.

```
cd src && echo data > out.txt
```

wrote `out.txt` in the *old* directory. Two separate session calls (`cd src` then `echo data > out.txt`) wrote it under `src`.

A follow-up from Codex on the first draft of this change: bash sets up output redirects *before* the command runs. `cd sub > missing/out; echo ok > after` must leave cwd unchanged so `after` lands in the entry directory.

## Fix

- Track `currentDir` through the list and refresh it from `session.cwd` only after a segment actually ran and its output redirects succeeded.
- Open `>` / `>>` / `2>` targets before spawning powershell (bash order). If the target cannot be created, skip the command so a redirected `cd` cannot change cwd.

## Verification

- `npx vitest run test/unit.test.ts test/integration.windows.test.ts` — 66/66 pass
- `npm run typecheck` — clean
- New integration cases:
  - `cd sub && echo nested > nested.txt` writes `sub/nested.txt`
  - `cd sub && wc -l < b.txt` reads from `sub/b.txt`
  - `cd sub > nosuchdir/out.txt; echo ok > after.txt` writes `after.txt` in the entry cwd
  - `echo stay > stay.txt && cd sub` still writes in the entry cwd

Supersedes #4 (same change, single commit).