### PR TITLE
fix: resolve redirects against cwd after each segment

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,6 +1,6 @@
 import { spawn, ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { promises as fs, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { promises as fs, readFileSync, writeFileSync, existsSync, openSync, closeSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { Redirect } from './ast.js';
@@ -39,6 +39,30 @@ interface SegmentRedirects {
   appendStderr: boolean;
   mergeStderr: boolean;
   devNull: boolean;
+}
+
+/**
+ * Open a redirect target the way bash does: before the command runs.
+ * `>` truncates; `>>` appends. Failure means the command must not run
+ * (so a redirected `cd` cannot change the session cwd).
+ */
+function appendRedirectText(file: string, text: string): void {
+  const prev = existsSync(file) ? readFileSync(file) : Buffer.alloc(0);
+  writeFileSync(file, Buffer.concat([prev, Buffer.from(text, 'utf8')]));
+}
+
+function prepareRedirectFile(file: string, append: boolean): string | null {
+  try {
+    const fd = openSync(file, append ? 'a' : 'w');
+    closeSync(fd);
+    return null;
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') return file + ': No such file or directory';
+    if (err.code === 'EACCES' || err.code === 'EPERM') return file + ': Permission denied';
+    if (err.code === 'EISDIR') return file + ': Is a directory';
+    return file + ': cannot create: ' + err.message;
+  }
 }
 
 function planRedirects(redirects: Redirect[]): SegmentRedirects {
@@ -195,10 +219,13 @@ async function runPlans(
   // skips b AND c when a fails. chainOk models the value of the current
   // &&/|| chain; `;` segments always run and restart the chain.
   let chainOk = true;
-  // redirect targets are relative to the session cwd, not this node process
-  const baseDir = opts.cwd ?? session.cwd ?? process.cwd();
+  // Redirect targets are relative to the *current* session cwd, not this
+  // Node process. Re-read after every segment so `cd src && echo x > out.txt`
+  // writes under src (same as two separate session calls). A one-shot
+  // capture of the entry cwd would land the file in the old directory.
+  let currentDir = opts.cwd ?? session.cwd ?? process.cwd();
   const resolveTarget = (t: string): string =>
-    path.isAbsolute(t) || /^[A-Za-z]:[\\/]/.test(t) ? t : path.resolve(baseDir, t);
+    path.isAbsolute(t) || /^[A-Za-z]:[\\/]/.test(t) ? t : path.resolve(currentDir, t);
 
   for (const plan of plans) {
     if (plan.op === '&&' && !chainOk) continue;
@@ -209,9 +236,81 @@ async function runPlans(
     red.stdoutFile = red.stdoutFile ? resolveTarget(red.stdoutFile) : null;
     red.stderrFile = red.stderrFile ? resolveTarget(red.stderrFile) : null;
 
-    // bash: a missing `< file` target aborts the segment before running it
-    if (red.stdinFile && !existsSync(red.stdinFile)) {
-      stderr += 'bash: ' + red.stdinFile + ': No such file or directory\n';
+    // bash applies redirects left-to-right *before* the command runs.
+    // Walk the parsed list in source order so a failing earlier redirect
+    // (e.g. `2>nosuch/err >important.txt`) does not truncate a later file,
+    // and a failing redirected `cd` cannot change cwd. Setup errors after
+    // an earlier `2>file` go to that file, not the caller (bash already
+    // applied the stderr redirect).
+    let redirectPrepFailed = false;
+    let prepStderrFile: string | null = null;
+    let prepStdoutFile: string | null = null;
+    let prepSwallowStderr = false;
+    let prepMergeStderr = false;
+    const emitPrepError = (msg: string) => {
+      if (prepSwallowStderr && !prepMergeStderr) return;
+      const dest = prepMergeStderr ? prepStdoutFile : prepStderrFile;
+      if (dest) {
+        try {
+          appendRedirectText(dest, msg);
+        } catch {
+          stderr += msg;
+        }
+        return;
+      }
+      stderr += msg;
+    };
+    for (const r of plan.redirects) {
+      if (r.op === '2>&1') {
+        prepMergeStderr = true;
+        prepSwallowStderr = false;
+        continue;
+      }
+      if (r.op === '1>&2') {
+        prepMergeStderr = false;
+        continue;
+      }
+      const target = resolveTarget(winTarget(r.target));
+      if (r.op === '<') {
+        if (!existsSync(target)) {
+          emitPrepError('bash: ' + target + ': No such file or directory\n');
+          redirectPrepFailed = true;
+          break;
+        }
+        continue;
+      }
+      if (target === 'NUL') {
+        if (r.op === '2>' || r.op === '2>>') {
+          prepSwallowStderr = true;
+          prepStderrFile = null;
+          prepMergeStderr = false;
+        } else if (r.op === '&>' || r.op === '&>>') {
+          prepSwallowStderr = true;
+          prepStdoutFile = null;
+          prepStderrFile = null;
+        }
+        continue;
+      }
+      const append = r.op === '>>' || r.op === '2>>' || r.op === '&>>';
+      const fail = prepareRedirectFile(target, append);
+      if (fail) {
+        emitPrepError('bash: ' + fail + '\n');
+        redirectPrepFailed = true;
+        break;
+      }
+      if (r.op === '>' || r.op === '>>') prepStdoutFile = target;
+      else if (r.op === '2>' || r.op === '2>>') {
+        prepStderrFile = target;
+        prepSwallowStderr = false;
+        prepMergeStderr = false;
+      } else if (r.op === '&>' || r.op === '&>>') {
+        prepStdoutFile = target;
+        prepStderrFile = target;
+        prepSwallowStderr = false;
+        prepMergeStderr = false;
+      }
+    }
+    if (redirectPrepFailed) {
       exitCode = 1;
       session.prevExit = exitCode;
       chainOk = false;
@@ -232,7 +331,7 @@ async function runPlans(
     }
 
     const child = spawn('powershell.exe', psArgs, {
-      env: session.childEnv(opts.cwd, red.stdinFile),
+      env: session.childEnv(currentDir, red.stdinFile),
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
     });
@@ -291,6 +390,7 @@ async function runPlans(
     if (swallowStderr) segErr = '';
 
     // redirect stdout to file instead of the result stream
+    let redirectOk = true;
     if (red.stdoutFile) {
       try {
         if (red.appendStdout) {
@@ -303,6 +403,7 @@ async function runPlans(
       } catch (e) {
         segErr += 'bash: ' + red.stdoutFile + ': cannot create: ' + (e as Error).message + '\n';
         exitCode = 1;
+        redirectOk = false;
       }
     }
     if (red.stderrFile) {
@@ -328,6 +429,10 @@ async function runPlans(
     exitCode = code ?? 0;
     session.prevExit = exitCode;
     chainOk = exitCode === 0;
+    // Only inherit cwd from a segment that actually ran and whose
+    // output redirects succeeded. A failed `cd dir > missing/out` must
+    // not move later relative redirects.
+    if (redirectOk && session.cwd) currentDir = session.cwd;
   }
 
   return { stdout, stderr, exitCode };

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -4,7 +4,7 @@
  */
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parseCommand } from '../src/parser.js';
@@ -175,6 +175,87 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
     await run('gunzip g.txt.gz');
     const back = await run('cat g.txt');
     expect(back.stdout).toContain('apple pie');
+  });
+
+  it('cd then redirect writes under the new cwd, not the entry cwd', async () => {
+    try {
+      const r = await run('cd sub && echo nested > nested.txt');
+      expect(r.exitCode).toBe(0);
+      expect(existsSync(join(dir, 'nested.txt'))).toBe(false);
+      const raw = readFileSync(join(dir, 'sub', 'nested.txt'), 'utf8');
+      expect(raw.replace(/\r/g, '')).toBe('nested\n');
+    } finally {
+      await run('cd "' + dir.replace(/\\/g, '/') + '"');
+    }
+  });
+
+  it('cd then stdin redirect reads from the new cwd', async () => {
+    try {
+      const r = await run('cd sub && wc -l < b.txt');
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe('1');
+    } finally {
+      await run('cd "' + dir.replace(/\\/g, '/') + '"');
+    }
+  });
+
+  it('failed redirect on cd does not move later relative redirects', async () => {
+    try {
+      const r = await run('cd sub > nosuchdir/out.txt; echo ok > after.txt');
+      expect(r.exitCode).toBe(0);
+      expect(r.stderr).toMatch(/nosuchdir\/out\.txt|No such file or directory/);
+      expect(existsSync(join(dir, 'sub', 'after.txt'))).toBe(false);
+      expect(readFileSync(join(dir, 'after.txt'), 'utf8').replace(/\r/g, '')).toBe('ok\n');
+    } finally {
+      await run('cd "' + dir.replace(/\\/g, '/') + '"');
+    }
+  });
+
+  it('stderr redirect already applied receives a later setup error', async () => {
+    const r = await run('echo hi 2>err.txt >nosuch/out.txt');
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toBe('');
+    expect(readFileSync(join(dir, 'err.txt'), 'utf8')).toMatch(/No such file or directory/);
+  });
+
+  it('2>/dev/null swallows a later failed stdout redirect', async () => {
+    const r = await run('echo hi 2>/dev/null >nosuch/out.txt');
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toBe('');
+  });
+
+  it('opts.cwd plus cd keeps command cwd and redirect cwd in sync', async () => {
+    const extra = new FauxnixSession();
+    try {
+      const r = await extra.run(
+        translateCommandList(parseCommand('cd sub && cat b.txt > copy.txt')),
+        { cwd: dir },
+      );
+      expect(r.exitCode).toBe(0);
+      expect(existsSync(join(dir, 'copy.txt'))).toBe(false);
+      expect(readFileSync(join(dir, 'sub', 'copy.txt'), 'utf8')).toContain('third line');
+    } finally {
+      await extra.dispose();
+    }
+  });
+
+  it('earlier failed redirect does not truncate a later output file', async () => {
+    writeFileSync(join(dir, 'important.txt'), 'keep\n', 'utf8');
+    const r = await run('echo hi 2>nosuch/err >important.txt');
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toMatch(/No such file or directory/);
+    expect(readFileSync(join(dir, 'important.txt'), 'utf8')).toBe('keep\n');
+  });
+
+  it('redirect before cd still writes in the entry cwd', async () => {
+    try {
+      const r = await run('echo stay > stay.txt && cd sub');
+      expect(r.exitCode).toBe(0);
+      expect(existsSync(join(dir, 'stay.txt'))).toBe(true);
+      expect(existsSync(join(dir, 'sub', 'stay.txt'))).toBe(false);
+    } finally {
+      await run('cd "' + dir.replace(/\\/g, '/') + '"');
+    }
   });
 
   it('redirects write LF line endings (GNU parity)', async () => {


### PR DESCRIPTION
## Problem

Codex flagged this as P2 on #2: `runPlans` captured `baseDir` once from the session entry cwd and reused it for every segment. Combined with the MCP `bash` tool telling models to batch `cd` with later commands, that is a real write-to-the-wrong-file bug.

```
cd src && echo data > out.txt
```

wrote `out.txt` in the *old* directory. Two separate session calls wrote it under `src`.

Follow-ups from Codex on earlier drafts of this change:

- bash sets up output redirects *before* the command runs, so `cd sub > missing/out; echo ok > after` must not change cwd.
- redirects are applied left-to-right, so `echo hi 2>nosuch/err >important.txt` must not truncate `important.txt`.
- when `ExecOptions.cwd` is set, later segments must spawn in the post-`cd` directory.
- a setup error after `2>err` must go to `err` (and `2>/dev/null >nosuch/out` must be silent).

## Fix

- Track `currentDir` through the list; refresh it from `session.cwd` only after a successful segment; pass it into `childEnv`.
- Open redirects in parsed source order before spawning. If an earlier target cannot be created, skip the command.
- Route a later setup error to any stderr redirect already applied in that walk.

## Verification

- `npx vitest run test/unit.test.ts test/integration.windows.test.ts` — 70/70 pass
- `npm run typecheck` — clean

Supersedes #7 (same change, single commit).