### PR TITLE
fix: keep intentional CRLF from exact writers

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -42,6 +42,23 @@ export function decodeOutput(buf: Buffer, prefer: NativeEncodingPref = 'utf8'): 
   }
 }
 
+/**
+ * Convert PowerShell-host CRLF line endings to LF without destroying
+ * intentional CR/CRLF from exact writers (`fx-write`, `printf`, `echo -n`).
+ *
+ * The console host terminates each Write-Output object with CRLF and a
+ * final newline. Exact writers do not. So we only rewrite when every LF
+ * is part of a CRLF pair *and* the buffer ends with a newline.
+ */
+export function normalizeHostNewlines(s: string): string {
+  if (s.length === 0 || !s.includes('\n')) return s;
+  if (!s.endsWith('\n')) return s;
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '\n' && (i === 0 || s[i - 1] !== '\r')) return s;
+  }
+  return s.replace(/\r\n/g, '\n');
+}
+
 /** Encode a PowerShell script for -EncodedCommand (UTF-16LE base64). */
 export function encodeCommand(script: string): string {
   return Buffer.from(script, 'utf16le').toString('base64');

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { Redirect } from './ast.js';
 import { SegmentPlan, normalizeLiteralPath } from './translator.js';
-import { decodeOutput, encodeCommand, resolveNativePref } from './encoding.js';
+import { decodeOutput, encodeCommand, normalizeHostNewlines, resolveNativePref } from './encoding.js';
 import { normalizeStderr } from './errors.js';
 
 export interface ExecResult {
@@ -268,11 +268,13 @@ async function runPlans(
     afterSegment();
 
     const decodePref = resolveNativePref();
-    // GNU line discipline: PowerShell's console layer terminates every line
-    // with CRLF; bash tools expect LF (redirect-written files and byte counts
-    // must match coreutils, e.g. `head -2 f > out.txt; wc -c out.txt`)
-    let segOut = decodeOutput(Buffer.concat(outBufs), decodePref).replace(/\r\n/g, '\n');
-    let segErr = normalizeStderr(decodeOutput(Buffer.concat(errBufs), decodePref)).replace(/\r\n/g, '\n');
+    // GNU line discipline: the PS host terminates Write-Output lines with
+    // CRLF. Exact writers (fx-write / printf / echo -n) must keep embedded
+    // CR so `printf 'a\r\nb' > out` stays 4 bytes.
+    let segOut = normalizeHostNewlines(decodeOutput(Buffer.concat(outBufs), decodePref));
+    let segErr = normalizeHostNewlines(
+      normalizeStderr(decodeOutput(Buffer.concat(errBufs), decodePref)),
+    );
 
     if (running.killed) {
       segErr += '\nbash: command timed out after ' + Math.round(timeoutMs / 1000) + 's';

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -177,6 +177,13 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
     expect(back.stdout).toContain('apple pie');
   });
 
+  it('printf CRLF without a trailing LF is preserved on redirect', async () => {
+    const r = await run("printf 'a\\r\\nb' > cr.txt; wc -c cr.txt");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toMatch(/4 .*cr\.txt/);
+    expect(readFileSync(join(dir, 'cr.txt'))).toEqual(Buffer.from('a\r\nb'));
+  });
+
   it('redirects write LF line endings (GNU parity)', async () => {
     const r = await run('head -2 fruits.txt > out.txt; wc -c out.txt');
     // fruits.txt first two lines: "apple\nBanana\n" = 13 bytes with LF endings

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -10,7 +10,7 @@ import {
   wrapScript,
 } from '../src/translator.js';
 import { parseWords, psStr } from '../src/registry.js';
-import { decodeOutput, encodeCommand } from '../src/encoding.js';
+import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import { normalizeStderr } from '../src/errors.js';
 
 /* ---------------------------- parser ---------------------------- */
@@ -175,6 +175,13 @@ describe('encoding', () => {
   it('falls back to GBK for non-UTF-8 bytes', () => {
     // "中文" in GBK
     expect(decodeOutput(Buffer.from([0xd6, 0xd0, 0xce, 0xc4]))).toBe('中文');
+  });
+
+  it('normalizeHostNewlines strips PS-host CRLF but keeps exact payloads', () => {
+    expect(normalizeHostNewlines('apple\r\nBanana\r\n')).toBe('apple\nBanana\n');
+    expect(normalizeHostNewlines('a\r\nb')).toBe('a\r\nb');
+    expect(normalizeHostNewlines('a\r\nb\n')).toBe('a\r\nb\n');
+    expect(normalizeHostNewlines('abc')).toBe('abc');
   });
 
   it('encodes -EncodedCommand as UTF-16LE base64', () => {


### PR DESCRIPTION
## Problem

Codex flagged this as P2 on #1: blindly replacing every `\r\n` with `\n` in captured stdout corrupts exact writers.

```
printf 'a\r\nb' > out.txt
```

should write 4 bytes `a\r\nb`. The global replace turned it into `a\nb`.

PowerShell's host *does* terminate Write-Output lines with CRLF, so line-oriented tools (`head -2 f > out`) still need LF normalization for GNU byte counts.

## Fix

`normalizeHostNewlines` only rewrites when every LF is part of a CRLF pair *and* the buffer ends with a newline — the shape of Write-Output. Exact payloads (`fx-write` / `printf` / `echo -n`) are left byte-for-byte.

## Verification

- `npx vitest run test/unit.test.ts test/integration.windows.test.ts` — 64/64 pass
- `npm run typecheck` — clean
- New cases: unit coverage of the three shapes; `printf 'a\r\nb' > cr.txt; wc -c` is 4 and the file is `a\r\nb`