### PR TITLE
fix: keep VAR=value and env NAME=val command-scoped

### DIFF
--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -1,6 +1,6 @@
 import { Word, WordPart, wordToString } from '../ast.js';
 import { Handler, lookup, parseWords, psStr, registeredNames } from '../registry.js';
-import { exprOfWord, operandExpr, translateSimple } from '../translator.js';
+import { exprOfWord, operandExpr, translateSimple, wrapTempEnv } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
 /* ------------------------------------------------------------------ */
@@ -210,10 +210,6 @@ const env: Handler = (args, ctx) => {
     break;
   }
   const lines: string[] = [];
-  for (const u of unsets) {
-    lines.push("Remove-Item -LiteralPath ('Env:\\' + " + psStr(u) + ') -ErrorAction SilentlyContinue');
-  }
-  for (const s of sets) lines.push('$env:' + s.name + ' = ' + exprOfWord(s.value));
   if (cmdIdx >= 0 && cmdIdx < args.length) {
     const cmdWords = args.slice(cmdIdx);
     lines.push(
@@ -226,7 +222,8 @@ const env: Handler = (args, ctx) => {
   } else {
     lines.push(ENV_LIST_PS);
   }
-  return lines.join('\n');
+  // `env NAME=val cmd` / `env -u NAME cmd` must not leak into the session.
+  return wrapTempEnv(sets, lines.join('\n'), { unsets });
 };
 
 const printenv: Handler = (args) => {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1,10 +1,12 @@
 import {
+  Assignment,
   CommandList,
   FauxnixParseError,
   Redirect,
   SimpleCommand,
   Word,
   WordPart,
+  wordToString,
 } from './ast.js';
 import { parseCommand } from './parser.js';
 import { PipelineCtx, lookup, psStr } from './registry.js';
@@ -215,14 +217,115 @@ export function translateSimple(
     ].join('\n');
   }
 
-  // `VAR=value cmd ...` prefix — set process env for the invocation.
+  // `VAR=value cmd` is command-scoped. Values are captured in the
+  // current environment, then applied, then restored — including when
+  // the command throws — so they never leak into later list segments
+  // or the persisted MCP session. `VAR=x export VAR` keeps VAR (bash).
   if (cmd.assignments.length > 0) {
-    const sets = cmd.assignments
-      .map((a) => '$env:' + a.name + ' = ' + exprOfWord(a.value))
-      .join('; ');
-    body = sets + '\n' + body;
+    body = wrapTempEnv(cmd.assignments, body, {
+      persist: exportPersistNames(nameLit, cmd.args),
+    });
   }
   return body;
+}
+
+let tempEnvSeq = 0;
+
+/** Names `export` will leave in the shell after this simple command. */
+function exportPersistNames(nameLit: string | null, args: Word[]): Set<string> {
+  const keep = new Set<string>();
+  if (nameLit !== 'export') return keep;
+  for (const w of args) {
+    const t = wordToString(w);
+    if (t.startsWith('-')) continue;
+    const eq = t.indexOf('=');
+    const n = eq >= 0 ? t.slice(0, eq) : t;
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(n)) keep.add(n);
+  }
+  return keep;
+}
+
+/**
+ * Apply env assignments (and optional unsets) only for `body`, then restore.
+ * All assignment *values* are evaluated before any name is mutated.
+ */
+export function wrapTempEnv(
+  sets: Assignment[],
+  body: string,
+  extra?: { unsets?: string[]; persist?: Set<string> },
+): string {
+  const unsets = extra?.unsets ?? [];
+  const persist = extra?.persist ?? new Set<string>();
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const s of sets) {
+    if (!seen.has(s.name)) {
+      seen.add(s.name);
+      names.push(s.name);
+    }
+  }
+  for (const u of unsets) {
+    if (!seen.has(u)) {
+      seen.add(u);
+      names.push(u);
+    }
+  }
+  if (names.length === 0) return body;
+
+  const id = tempEnvSeq++;
+  const save = '$fx_es' + id;
+  const lines: string[] = [save + ' = @{}'];
+  for (const n of names) {
+    const p = psStr('Env:\\' + n);
+    lines.push(
+      save +
+        '[' +
+        psStr(n) +
+        '] = $(if (Test-Path -LiteralPath ' +
+        p +
+        ') { [string](Get-Item -LiteralPath ' +
+        p +
+        ').Value } else { $null })',
+    );
+  }
+  const valVars: string[] = [];
+  for (let i = 0; i < sets.length; i++) {
+    const vn = '$fx_ev' + id + '_' + i;
+    valVars.push(vn);
+    lines.push(vn + ' = ' + exprOfWord(sets[i].value));
+  }
+  lines.push('try {');
+  for (const u of unsets) {
+    lines.push(
+      '  Remove-Item -LiteralPath ' + psStr('Env:\\' + u) + ' -ErrorAction SilentlyContinue',
+    );
+  }
+  for (let i = 0; i < sets.length; i++) {
+    lines.push('  $env:' + sets[i].name + ' = ' + valVars[i]);
+  }
+  for (const l of body.split('\n')) lines.push(l ? '  ' + l : l);
+  lines.push('} finally {');
+  for (const n of names) {
+    if (persist.has(n)) continue;
+    const p = psStr('Env:\\' + n);
+    lines.push(
+      '  if ($null -eq ' +
+        save +
+        '[' +
+        psStr(n) +
+        ']) { Remove-Item -LiteralPath ' +
+        p +
+        ' -ErrorAction SilentlyContinue } else { Set-Item -LiteralPath ' +
+        p +
+        ' -Value ' +
+        save +
+        '[' +
+        psStr(n) +
+        '] }',
+    );
+  }
+  lines.push('}');
+  return lines.join('\n');
 }
 
 /** Unique suffix for generated stage functions (nested pipelines included). */

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -139,6 +139,24 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
     expect((await run('echo $(echo nested)')).stdout.trim()).toBe('nested');
   });
 
+  it('VAR=value prefixes do not leak past the command', async () => {
+    expect((await run('FX_P=bar echo $FX_P')).stdout.trim()).toBe('bar');
+    expect((await run('FX_P=bar echo $FX_P; echo x$FX_P')).stdout.trim()).toBe('bar\nx');
+    expect((await run('export FX_K=old; FX_K=new echo $FX_K; echo $FX_K')).stdout.trim()).toBe(
+      'new\nold',
+    );
+    expect((await run('FX_A=1 FX_B=$FX_A echo x$FX_B')).stdout.trim()).toBe('x');
+    expect((await run('FX_P=bar true; printenv FX_P; echo $?')).stdout.trim()).toBe('1');
+    expect((await run('env FX_P=bar printenv FX_P; printenv FX_P; echo done')).stdout.trim()).toBe(
+      'bar\ndone',
+    );
+    expect((await run('FX_P=bar export FX_P; echo $FX_P')).stdout.trim()).toBe('bar');
+    // export + prefix keeps the name in the session; a bare prefix must not
+    expect((await run('echo $FX_P')).stdout.trim()).toBe('bar');
+    await run('unset FX_P FX_K FX_A FX_B');
+    expect((await run('FX_P=bar true; echo x$FX_P')).stdout.trim()).toBe('x');
+  }, 20000);
+
   it('session cwd persists across calls', async () => {
     await run('cd sub');
     const r = await run('pwd');

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -130,6 +130,22 @@ describe('translator', () => {
     expect(plan.script).toMatch(/function __fx_s\d+/);
     expect(plan.script).toMatch(/__fx_s\d+ \| __fx_s\d+ \| __fx_s\d+/);
   });
+
+  it('scopes VAR=value prefixes and evaluates values before applying them', () => {
+    const leak = translateCommandList(parse('FOO=bar echo x'))[0].script;
+    expect(leak).toContain('try {');
+    expect(leak).toContain('finally {');
+    expect(leak).toMatch(/Remove-Item -LiteralPath 'Env:\\FOO'/);
+    const both = translateCommandList(parse('A=1 B=$A echo x'))[0].script;
+    const evalB = both.indexOf('$env:A');
+    const applyA = both.indexOf('$env:A =');
+    // `$env:A` in the B value is captured before `$env:A =` applies A=1
+    expect(evalB).toBeGreaterThan(-1);
+    expect(applyA).toBeGreaterThan(evalB);
+    const exported = translateCommandList(parse('FOO=bar export FOO'))[0].script;
+    expect(exported).toContain('$env:FOO =');
+    expect(exported).not.toMatch(/finally \{[\s\S]*Remove-Item -LiteralPath 'Env:\\FOO'/);
+  });
 });
 
 /* ---------------------------- registry ---------------------------- */


### PR DESCRIPTION
## Why

`VAR=value cmd` is advertised as a prefix, but the translator wrote `$env:VAR` and the executor then persisted the whole environment. Later `;` / `&&` segments and the next MCP call still saw `VAR`. Agents that write `FOO=bar some_cmd; echo $FOO` got a silent wrong answer.

`env NAME=val cmd` had the same leak.

## What

Command-scoped environment:

1. Snapshot the names about to change.
2. Evaluate every assignment **value** in the current environment (`A=1 B=$A` does not see `A=1`).
3. Apply assignments (and `env -u` unsets).
4. Run the command.
5. Restore in `finally` so a throw cannot leak into the session dump.

`VAR=x export VAR` still keeps `VAR` (bash: export publishes the prefix into the shell). Bare `export` / other commands restore.

## Verification

- 64/64 tests, tsc clean
- Covers prefix, restore of a prior `export`, `A=1 B=$A`, `env NAME=val cmd`, and `VAR=x export VAR`
