### PR TITLE
feat: standalone assignment segments (X=1; cmd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ agent ◀── GNU-style output, bash-style errors ◀── decoder (UTF-8 →
 
 fauxnix optimizes for the commands agents actually run. Documented deviations:
 
+- `X=1` standalone assignments follow `export` semantics (one session-wide environment; bash's
+  shell-var vs exported-var distinction does not exist), and a same-segment prefix is visible to
+  `$VAR` inside the command's own words (`Z=in [[ $Z == in ]]` is true here, false in bash where
+  word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
 - `tail -f`, `source`, `eval`, `alias`, heredocs, backticks, shell control flow (`if`/`for`/`while`)

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -36,7 +36,8 @@ export interface SimpleCommand {
   kind: 'SimpleCommand';
   /** `VAR=value` prefixes before the command name. */
   assignments: Assignment[];
-  name: Word;
+  /** Command word; null for an assignment-only segment (`X=1; cmd`). */
+  name: Word | null;
   args: Word[];
   redirects: Redirect[];
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -740,7 +740,13 @@ export function parseCommand(input: string): CommandList {
       }
     }
 
-    if (!name) throw new FauxnixParseError('fauxnix: expected a command');
+    if (!name) {
+      // assignment-only segment (`X=1; cmd`) — no command word
+      if (assignments.length > 0) {
+        return { kind: 'SimpleCommand', assignments, name: null, args: [], redirects };
+      }
+      throw new FauxnixParseError('fauxnix: expected a command');
+    }
     if (isUnquotedLiteral(name, '[[')) {
       const close = args.findIndex((w) => isUnquotedLiteral(w, ']]'));
       if (close < 0) throw new FauxnixParseError("fauxnix: [[: missing `]]'");

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -189,6 +189,19 @@ export function translateSimple(
   position: PipelineCtx['position'],
   hasStdin: boolean,
 ): string {
+  // assignment-only segment (`X=1; cmd`): bash semantics are "set for the
+  // rest of the shell". Reuse the export code path — persist + env shadow —
+  // so empty values (`X=`) and `[[ -v X ]]` behave like bash (documented
+  // deviation: shell var vs exported var are indistinguishable here).
+  if (cmd.name === null) {
+    const exportHandler = lookup('export');
+    const words = cmd.assignments.map((a) => [
+      { kind: 'Text' as const, text: a.name + '=' },
+      ...a.value,
+    ]);
+    return exportHandler ? exportHandler(words, { position, hasStdin }) : '';
+  }
+
   const nameLit = literalOfWord(cmd.name);
 
   let body: string;

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -450,6 +450,23 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
     expect((await run('FX_P=bar true; echo x$FX_P')).stdout.trim()).toBe('x');
   }, 20000);
 
+  it('standalone assignment segments persist and feed later commands (#82)', async () => {
+    expect((await run('SA_V=hello; echo $SA_V')).stdout.trim()).toBe('hello');
+    expect((await run('SA_N=7; [[ $SA_N -gt 3 ]] && echo YES || echo NO')).stdout.trim()).toBe(
+      'YES',
+    );
+    expect((await run('SA_E=; [[ -v SA_E ]] && echo SET || echo UNSET')).stdout.trim()).toBe(
+      'SET',
+    );
+    // bash: word expansion happens BEFORE the same-segment prefix applies,
+    // so `Z=temp [[ $Z == temp ]]` is false there. fauxnix evaluates at
+    // runtime after applying the prefix — documented deviation (README).
+    expect(
+      (await run('SA_Z=out; SA_Z=in [[ $SA_Z == in ]] && echo YES || echo NO')).stdout.trim(),
+    ).toBe('YES');
+    await run('unset SA_V SA_N SA_E SA_Z');
+  });
+
   it('session cwd persists across calls', async () => {
     await run('cd sub');
     const r = await run('pwd');


### PR DESCRIPTION
Closes #82.

## Why
Differential testing on #80 showed the top [[ divergence was not a [[ bug: `X=hello; [[ $X == hello ]]` failed at the parser ('expected a command') because assignment-only segments were unsupported — a gap that predates #80.

## What
- Parser accepts a segment that is only assignments (`SimpleCommand.name` becomes nullable)
- Translator routes it through the `export` handler — inheriting persist + env-shadow, so `X=` empty values and `[[ -v X ]]` behave like bash
- Documented deviation (README): export semantics for plain assignments; same-segment prefix visible to word expansion (bash expands words first)

## Evidence
- Differential vs real Git Bash: **52/53** (up from 46/53); sole remaining case is the documented corner
- Suite 104/104 (new integration test: persist, [[ -gt, empty -v, prefix-visibility)