### PR TITLE
release: v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Fauxnix — run Linux-style commands on Windows via deterministic PowerShell translation. No VM, no WSL. MCP server + CLI for AI agents.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ export async function runCli(argv: string[]): Promise<void> {
   const [verb, ...rest] = argv;
 
   if (verb === '--version' || verb === '-v') {
-    console.log('fauxnix 0.2.1');
+    console.log('fauxnix 0.3.0');
     return;
   }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -23,7 +23,7 @@ Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command n
 
 export async function startMcpServer(): Promise<void> {
   const server = new McpServer(
-    { name: 'fauxnix', version: '0.2.1' },
+    { name: 'fauxnix', version: '0.3.0' },
     { capabilities: { tools: {} } },
   );
   const session = new FauxnixSession();


### PR DESCRIPTION
Ships [[ ]] as a real builtin (#80, RFC #81 accepted) and standalone assignment segments (#85/#82). Follow-ups tracked in #83/#84.