### PR TITLE
fix: command substitution newline contract

### DIFF
--- a/src/commands/text-io.ts
+++ b/src/commands/text-io.ts
@@ -89,6 +89,9 @@ const PS_UNESQ_FN = [
 const PS_WRITE_FN = [
   'function fx-write($s, $term) {',
   "  if ($s -eq '') { return }",
+  // Inside $(...) the collector wants one string object so interior
+  // newlines survive (PS would otherwise join line items with spaces).
+  '  if ($script:fx_csub) { $s; return }',
   '  if (-not $term) { $s; return }',
   '  if (-not $s.EndsWith([string][char]10)) { [Console]::Out.Write($s); return }',
   '  $t = $s.Substring(0, $s.Length - 1)',

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -177,7 +177,8 @@ export function translateCmdSub(cmdText: string): string {
     );
   }
   const { defs, call } = translatePipelineBody(list.segments[0].pipeline);
-  return defs ? defs + '\n' + call : call;
+  const inner = defs ? defs + '\n' + call : call;
+  return 'fx-csub { ' + inner + ' }';
 }
 
 /* ------------------------------------------------------------------ */
@@ -649,6 +650,17 @@ export function wrapScript(body: string): string {
     "  if ($parts.Count -eq 1 -and $parts[0] -eq '') { return @() }",
     "  if ($parts[$parts.Count - 1] -eq '') { $parts = $parts[0..($parts.Count - 2)] }",
     '  return $parts',
+    '}',
+    'function fx-csub([scriptblock]$b) {',
+    '  $fx_prevcs = $script:fx_csub',
+    '  $script:fx_csub = $true',
+    '  try { $fx_o = @(& $b | ForEach-Object { [string]$_ }) }',
+    '  finally { $script:fx_csub = $fx_prevcs }',
+    '  $fx_s = ($fx_o -join [string][char]10)',
+    '  while ($fx_s.Length -gt 0 -and $fx_s[$fx_s.Length - 1] -eq [char]10) {',
+    '    $fx_s = $fx_s.Substring(0, $fx_s.Length - 1)',
+    '  }',
+    '  return $fx_s',
     '}',
     'try {',
     ...body.split('\n').map((l) => '  ' + l),

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -427,6 +427,10 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
   it('variables and command substitution', async () => {
     expect((await run('export GREET=hi; echo $GREET/there')).stdout.trim()).toBe('hi/there');
     expect((await run('echo $(echo nested)')).stdout.trim()).toBe('nested');
+    expect((await run("echo \"[$(printf 'a\\nb')]\"")).stdout).toBe('[a\nb]\n');
+    expect((await run("[[ \"$(printf 'a\\nb')\" == \"a\nb\" ]]")).exitCode).toBe(0);
+    expect((await run("X=$(printf 'a\\nb'); echo \"[$X]\"")).stdout).toBe('[a\nb]\n');
+    expect((await run("echo \"[$(printf 'a\\n')]\"")).stdout).toBe('[a]\n');
   });
 
   it('VAR=value prefixes do not leak past the command', async () => {


### PR DESCRIPTION
Closes #83.

## Why

`$(…)` captured PowerShell pipeline objects and interpolated them inside a double-quoted string, so interior newlines became spaces. `echo "$(printf 'a\nb')"` and `[[ "$(printf 'a\nb')" == $'a\nb' ]]` both diverged from bash.

## What

- `fx-csub` joins success output with `\n` and strips trailing newlines (bash/POSIX)
- While collecting, `fx-write` emits the raw string so interior newlines survive

## Verification

- 104/104 tests, tsc clean
