### PR TITLE
feat:  subscript expansion and BASH_REMATCH groups

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -6,7 +6,7 @@
  *   - lists:                cmd1 ; cmd2 && cmd3 || cmd4   (newlines act as ';')
  *   - redirections:         > >> 2> 2>> &> 2>&1 1>&2 <
  *   - quoting:              'literal'  "interp $VAR $(cmd)"
- *   - variables:            $VAR ${VAR} plus special cases ($HOME $USER $PATH ...)
+ *   - variables:            $VAR ${VAR} ${VAR[n]} plus special cases ($HOME $USER $PATH ...)
  *   - command substitution: $(...) (recursively translated)
  *   - env assignment prefix: VAR=value cmd
  *
@@ -64,7 +64,7 @@ export type WordPart =
   | { kind: 'Text'; text: string; escaped?: boolean }
   | { kind: 'SingleQuoted'; text: string }
   | { kind: 'DoubleQuoted'; parts: WordPart[] }
-  | { kind: 'Var'; name: string }
+  | { kind: 'Var'; name: string; index?: string }
   | { kind: 'CmdSub'; cmd: string };
 
 export function wordToString(w: Word): string {
@@ -94,7 +94,7 @@ function partToString(p: WordPart): string {
     case 'DoubleQuoted':
       return p.parts.map(partToString).join('');
     case 'Var':
-      return `$${p.name}`;
+      return p.index !== undefined ? `\${${p.name}[${p.index}]}` : `$${p.name}`;
     case 'CmdSub':
       return '$(' + p.cmd + ')';
   }

--- a/src/commands/archive.ts
+++ b/src/commands/archive.ts
@@ -1,6 +1,6 @@
 import { Word, wordToString } from '../ast.js';
 import { Handler, PipelineCtx, parseWords, psStr } from '../registry.js';
-import { exprOfWord, operandExpr } from '../translator.js';
+import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
 /* gzip family — .NET GZipStream helpers                               */
@@ -222,7 +222,7 @@ function gzBlock(args: Word[], ctx: PipelineCtx, forced: Partial<GzOpts>): strin
 
   return [
     PS_GZ_FNS,
-    '$fx_files = @(' + (p.files.length ? p.files.map(operandExpr).join(', ') : '') + ')',
+    '$fx_files = ' + (p.files.length ? argListExpr(p.files, operandExpr) : '@()'),
     'if ($fx_files.Count -eq 0) {',
     stdinBranch,
     '} else {',
@@ -243,7 +243,7 @@ const zcat: Handler = (args, ctx) => gzBlock(args, ctx, { decompress: true, stdo
 
 const tar: Handler = (args) => {
   return [
-    "$fx_args = @(" + args.map(exprOfWord).join(', ') + ')',
+    '$fx_args = ' + argListExpr(args, exprOfWord),
     // Prefer the Windows-shipped bsdtar (System32): it accepts both path
     // styles. A PATH lookup could resolve to Git Bash's GNU tar, which
     // misreads `C:\...` argv as a remote-host spec (host:path syntax).
@@ -296,10 +296,10 @@ const zip: Handler = (args) => {
     );
   }
   const arc = operandExpr(rest[0]);
-  const inputs = rest.slice(1).map(operandExpr).join(', ');
+  const inputs = argListExpr(rest.slice(1), operandExpr);
   return [
     note + '$fx_arc = ' + arc,
-    '$fx_inputs = @(' + inputs + ')',
+    '$fx_inputs = ' + inputs,
     '$fx_valid = @()',
     'foreach ($fx_p in $fx_inputs) {',
     '  if (Test-Path -LiteralPath $fx_p) { $fx_valid += $fx_p }',

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,6 +1,6 @@
 import { Word, wordToString } from '../ast.js';
 import { Handler, parseWords, psStr } from '../registry.js';
-import { exprOfWord, operandExpr } from '../translator.js';
+import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
 /* Shared PS snippets                                                  */
@@ -51,8 +51,7 @@ const PS_HSIZE_FN = [
 
 /** Operand Words → PS array expression of string exprs. */
 function psArray(words: Word[], fn: (w: Word) => string = operandExpr): string {
-  if (words.length === 0) return '@()';
-  return '@(' + words.map(fn).join(', ') + ')';
+  return argListExpr(words, fn);
 }
 
 /* ------------------------------------------------------------------ */
@@ -70,7 +69,7 @@ const ls: Handler = (args) => {
   const sortByTime = flags.has('t');
   const sortBySize = flags.has('S');
   const reverse = flags.has('r');
-  const targets = operandWords.length ? operandWords.map((w) => operandExpr(w)) : ["'.'"];
+  const targets = operandWords.length ? argListExpr(operandWords) : "@('.')";
 
   return [
     PS_GLOB_FN,
@@ -92,7 +91,7 @@ const ls: Handler = (args) => {
     '  }',
     '  return $n',
     '}',
-    '$fx_targets = @(' + targets.join(', ') + ')',
+    '$fx_targets = ' + targets,
     '$fx_all = @()',
     'foreach ($fx_t in $fx_targets) {',
     '  foreach ($fx_g in (fx-glob $fx_t)) {',
@@ -457,7 +456,7 @@ const du: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args, [], ['--max-depth']);
   const sum = flags.has('s') || longs.has('--summarize');
   const human = flags.has('h') || longs.has('--human-readable');
-  const targets = operandWords.length ? operandWords.map((w) => operandExpr(w)) : ["'.'"];
+  const targets = operandWords.length ? argListExpr(operandWords) : "@('.')";
   return [
     PS_HSIZE_FN,
     'function fx-size($p) {',
@@ -465,7 +464,7 @@ const du: Handler = (args) => {
     '  Get-ChildItem -LiteralPath $p -Recurse -Force -File -ErrorAction SilentlyContinue | ForEach-Object { $t += $_.Length }',
     '  return [math]::Ceiling($t / 1KB)',
     '}',
-    '$fx_ts = @(' + targets.join(', ') + ')',
+    '$fx_ts = ' + targets,
     'foreach ($fx_t in $fx_ts) {',
     '  if (-not (Test-Path -LiteralPath $fx_t)) { [Console]::Error.WriteLine("du: cannot access \'" + $fx_t + "\': No such file or directory"); $script:fx_exit = 1; continue }',
     '  if (' + (sum ? '$true' : '$false') + ') {',
@@ -538,7 +537,7 @@ const find: Handler = (args) => {
   const sizeExpr = extractValue(preds, ['-size']);
   const mtimeExpr = extractValue(preds, ['-mtime']);
   const wantDelete = preds.includes('-delete');
-  const paths = pathWords.length ? pathWords.map((w) => operandExpr(w)) : ["'.'"];
+  const paths = pathWords.length ? argListExpr(pathWords) : "@('.')";
 
   const conditions: string[] = [];
   if (namePat !== null) conditions.push("($fx_i.Name -like '" + likeOf(namePat) + "')");
@@ -553,7 +552,7 @@ const find: Handler = (args) => {
   const mtimeCond = mtimeOf(mtimeExpr);
 
   return [
-    '$fx_paths = @(' + paths.join(', ') + ')',
+    '$fx_paths = ' + paths,
     'foreach ($fx_p in $fx_paths) {',
     '  if (-not (Test-Path -LiteralPath $fx_p)) { [Console]::Error.WriteLine("find: \'" + $fx_p + "\': No such file or directory"); $script:fx_exit = 1; continue }',
     '  $fx_root = (Get-Item -LiteralPath $fx_p -Force).FullName',

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -354,7 +354,7 @@ const basename: Handler = (args) => {
     ].join('\n');
   }
   return [
-    '$fx_ps = @(' + args.map(exprOfWord).join(', ') + ')',
+    '$fx_ps = ' + argListExpr(args, exprOfWord),
     "if ($fx_ps.Count -eq 0) { [Console]::Error.WriteLine('basename: missing operand'); $script:fx_exit = 1 }",
     'foreach ($fx_p in $fx_ps) {',
     "  $fx_n = [IO.Path]::GetFileName(($fx_p.TrimEnd('/')).TrimEnd('\\'))",
@@ -366,7 +366,7 @@ const basename: Handler = (args) => {
 
 const dirname: Handler = (args) => {
   return [
-    '$fx_ps = @(' + args.map(exprOfWord).join(', ') + ')',
+    '$fx_ps = ' + argListExpr(args, exprOfWord),
     "if ($fx_ps.Count -eq 0) { [Console]::Error.WriteLine('dirname: missing operand'); $script:fx_exit = 1 }",
     'foreach ($fx_p in $fx_ps) {',
     "  $fx_n = ($fx_p.TrimEnd('/')).TrimEnd('\\')",

--- a/src/commands/net.ts
+++ b/src/commands/net.ts
@@ -1,6 +1,6 @@
 import { Word, wordToString } from '../ast.js';
 import { Handler, parseWords, psErr, psStr } from '../registry.js';
-import { exprOfWord, literalOfWord, operandExpr } from '../translator.js';
+import { argListExpr, exprOfWord, literalOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
 /* Shared PS snippets                                                  */
@@ -101,7 +101,7 @@ const curl: Handler = (args) => {
   // refuses private/loopback URLs before the process is even started.
   return [
     PS_NETGUARD_FNS,
-    "$fx_args = @(" + args.map(exprOfWord).join(', ') + ')',
+    '$fx_args = ' + argListExpr(args, exprOfWord),
     '$fx_bad = $false',
     "foreach ($fx_a in $fx_args) { if (fx-netguard 'curl' $fx_a) { $fx_bad = $true } }",
     'if ($fx_bad) { $script:fx_exit = 1 }',
@@ -222,7 +222,7 @@ const wget: Handler = (args) => {
   const mapped = mapWgetArgs(args);
   return [
     PS_NETGUARD_FNS,
-    '$fx_args = @(' + orig.join(', ') + ')',
+    '$fx_args = ' + argListExpr(args, exprOfWord),
     '$fx_margs = @(' + mapped.margs.join(', ') + ')',
     '$fx_bad = $false',
     "foreach ($fx_a in $fx_args) { if (fx-netguard 'wget' $fx_a) { $fx_bad = $true } }",
@@ -473,7 +473,11 @@ const ifconfig: Handler = (args) => {
 /* nslookup / dig / host                                               */
 /* ------------------------------------------------------------------ */
 
-const nslookup: Handler = (args) => nativeCall('nslookup.exe', args.map(exprOfWord).join(', '));
+const nslookup: Handler = (args) =>
+  [
+    '$fx_args = ' + argListExpr(args, exprOfWord),
+    nativeCall('nslookup.exe', '$fx_args'),
+  ].join('\n');
 
 const dig: Handler = (args) => {
   const raw = args.map(wordToString);

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -1,6 +1,7 @@
 import { FauxnixParseError, Word, WordPart, isUnquotedLiteral, wordToString } from '../ast.js';
 import { Handler, lookup, parseWords, psStr, registeredNames } from '../registry.js';
 import {
+  argListExpr,
   exprOfWord,
   operandExpr,
   translateSimple,
@@ -82,8 +83,7 @@ function splitAssignWord(w: Word): AssignSplit | null {
 
 /** Text Words -> PS array expression. */
 function textArgs(words: Word[]): string {
-  if (words.length === 0) return '@()';
-  return '@(' + words.map(exprOfWord).join(', ') + ')';
+  return argListExpr(words, exprOfWord);
 }
 
 /** Drop dash-arguments, return operand words. */
@@ -1475,7 +1475,16 @@ const FX_ISSET_FN = [
   'function fx-isset($n) {',
   '  $n = [string]$n',
   "  if ($n -eq '') { return $false }",
-  "  if ($n -match '^([A-Za-z_][A-Za-z0-9_]*)\\[(0|@|\\*)\\]$') { $n = $Matches[1] }",
+  "  if ($n -match '^([A-Za-z_][A-Za-z0-9_]*)\\[([0-9]+|@|\\*)\\]$') {",
+  '    $fx_ib = $Matches[1]; $fx_ix = [string]$Matches[2]',
+  "    if ($fx_ix -eq '@' -or $fx_ix -eq '*' -or $fx_ix -eq '0') { $n = $fx_ib }",
+  '    else {',
+  '      $fx_ia = @(fx-arrload $fx_ib)',
+  '      $fx_ii = 0',
+  '      if (-not [int]::TryParse($fx_ix, [ref]$fx_ii)) { return $false }',
+  '      return ($fx_ii -ge 0 -and $fx_ii -lt $fx_ia.Count)',
+  '    }',
+  '  }',
   "  elseif ($n -match '^[A-Za-z_][A-Za-z0-9_]*\\[') { return $false }",
   "  if (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ceq $n }).Count -gt 0) { return $false }",
   "  if (@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ceq $n }).Count -gt 0) { return $true }",

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -1430,6 +1430,9 @@ function kshExprOfWord(w: Word): string {
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
+    if (expanded[0].index !== undefined) {
+      return '(fx-subget ' + psStr(expanded[0].name) + ' ' + psStr(expanded[0].index) + ')';
+    }
     return '(fx-envget ' + psStr(expanded[0].name) + ')';
   }
   const literal =
@@ -1450,7 +1453,10 @@ function kshExprOfWord(w: Word): string {
         for (const q of p.parts) emitPart(q);
         break;
       case 'Var':
-        out += '$(fx-envget ' + psStr(p.name) + ')';
+        out +=
+          p.index !== undefined
+            ? '$(fx-subget ' + psStr(p.name) + ' ' + psStr(p.index) + ')'
+            : '$(fx-envget ' + psStr(p.name) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd) + ')';
@@ -1518,18 +1524,11 @@ const FX_RE_FN = [
   '  try {',
   '    $fx_rm = [regex]::Match([string]$a, (fx-posixre ([string]$b)), [Text.RegularExpressions.RegexOptions]::Singleline)',
   '    if ($fx_rm.Success) {',
-  '      $env:BASH_REMATCH = [string]$fx_rm.Value',
-  "      $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne 'BASH_REMATCH' }) + 'BASH_REMATCH') -join ';')",
-  "      $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne 'BASH_REMATCH' }) -join ';')",
-  '      $fx_enc = ([string]$fx_rm.Value).Replace([string][char]92, ([string][char]92 + [string][char]92)).Replace([string][char]13, ([string][char]92 + [char]114)).Replace([string][char]10, ([string][char]92 + [char]110))',
-  "      $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne 'BASH_REMATCH') { $fx_sv += $fx_pair } }",
-  "      $fx_sv += ('BASH_REMATCH' + [string][char]61 + $fx_enc); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
+  '      $fx_gs = @(); foreach ($fx_g in $fx_rm.Groups) { $fx_gs += ,[string]$fx_g.Value }',
+  "      fx-arrput 'BASH_REMATCH' $fx_gs",
   '      return $true',
   '    }',
-  "    Remove-Item -LiteralPath 'Env:\\BASH_REMATCH' -ErrorAction SilentlyContinue",
-  "    $env:FAUXNIX_SETVARS = (@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne 'BASH_REMATCH' }) -join ';')",
-  "    $env:FAUXNIX_UNSETVARS = ((@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne 'BASH_REMATCH' }) + 'BASH_REMATCH') -join ';')",
-  "    $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne 'BASH_REMATCH') { $fx_sv += $fx_pair } }; $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
+  "    fx-arrclr 'BASH_REMATCH'",
   '    return $false',
   '  }',
   "  catch { [Console]::Error.WriteLine('bash: [[: invalid regular expression'); $script:fx_exit = 2; return $false }",

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -23,6 +23,7 @@ const NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 function emitSetValPut(nameLit: string, valueExpr: string): string {
   const n = nameLit.replace(/'/g, "''");
   return [
+    "fx-arrdrop '" + n + "'",
     '$fx_sv = @()',
     'foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) {',
     '  $fx_eq = $fx_pair.IndexOf([char]61)',
@@ -36,6 +37,7 @@ function emitSetValPut(nameLit: string, valueExpr: string): string {
 
 function emitSetValDelRuntime(nameVar: string): string {
   return [
+    'fx-arrdrop ' + nameVar,
     '$fx_sv = @()',
     'foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) {',
     '  $fx_eq = $fx_pair.IndexOf([char]61)',
@@ -967,6 +969,7 @@ const FX_TNK_FN = [
   '  $fx_ev = Get-ChildItem Env: | Where-Object { $_.Name -ceq $n } | Select-Object -First 1',
   '  $nm = if ($fx_ev) { $fx_ev.Name } else { $n }',
   "  Set-Item -LiteralPath ('Env:' + $nm) -Value ([string][long]$v)",
+  '  fx-arrdrop $n',
   "  $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",
   "  $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
   '  $fx_sv = @()',

--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { FauxnixParseError, Word, wordToString } from '../ast.js';
 import { Handler, parseWords, psStr } from '../registry.js';
-import { exprOfWord, literalOfWord, operandExpr } from '../translator.js';
+import { argListExpr, exprOfWord, literalOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
 /* Shared PS snippets (same shape as files.ts)                         */
@@ -40,8 +40,7 @@ const STDIN_LINES = '@($input | ForEach-Object { [string]$_ })';
 
 /** Operand Words → PS array expression of string exprs. */
 function psArray(words: Word[], fn: (w: Word) => string = operandExpr): string {
-  if (words.length === 0) return '@()';
-  return '@(' + words.map(fn).join(', ') + ')';
+  return argListExpr(words, fn);
 }
 
 /** PS boolean literal. */

--- a/src/commands/text-io.ts
+++ b/src/commands/text-io.ts
@@ -1,6 +1,6 @@
 import { Word, wordToString } from '../ast.js';
 import { Handler, lookup, parseWords, psStr } from '../registry.js';
-import { exprOfWord, operandExpr } from '../translator.js';
+import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
 /* Shared PS snippets (same shape as files.ts / text-filters.ts)       */
@@ -129,8 +129,7 @@ function qErr(cmd: string, g: string, msg: string, lead = 'cannot open '): strin
 
 /** Operand Words → PS array expression of string exprs. */
 function psArray(words: Word[], fn: (w: Word) => string = operandExpr): string {
-  if (words.length === 0) return '@()';
-  return '@(' + words.map(fn).join(', ') + ')';
+  return argListExpr(words, fn);
 }
 
 /**

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -241,7 +241,11 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     const end = input.indexOf('}', j);
     if (end === -1) throw new FauxnixParseError('fauxnix: unclosed ${');
     const name = input.slice(j + 1, end);
-    if (!isNameStart(name[0]) || !name.split('').every(isNameChar)) {
+    const sub = name.match(/^([A-Za-z_][A-Za-z0-9_]*)\[([0-9]+|@|\*)\]$/);
+    if (sub) {
+      return { part: { kind: 'Var', name: sub[1], index: sub[2] }, next: end + 1 };
+    }
+    if (!name || !isNameStart(name[0]) || !name.split('').every(isNameChar)) {
       // ${VAR:-default} etc. — unsupported, kept as raw text
       return { part: { kind: 'Text', text: input.slice(i, end + 1) }, next: end + 1 };
     }

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -167,6 +167,32 @@ export function operandExpr(w: Word): string {
   return exprOfWord(w);
 }
 
+/** Whole word is `${name[@]}` or `"${name[@]}"` (bash: one argv per element). */
+export function atSplatName(w: Word): string | null {
+  if (w.length === 1 && w[0].kind === 'Var' && w[0].index === '@') return w[0].name;
+  if (w.length === 1 && w[0].kind === 'DoubleQuoted' && w[0].parts.length === 1) {
+    const p = w[0].parts[0];
+    if (p.kind === 'Var' && p.index === '@') return p.name;
+  }
+  return null;
+}
+
+/** PS expression of a string[]: `@` words splat, others stay one element. */
+export function argListExpr(words: Word[], fn: (w: Word) => string = exprOfWord): string {
+  if (words.length === 0) return '@()';
+  return (
+    '(' +
+    words
+      .map((w) => {
+        const n = atSplatName(w);
+        if (n) return '@(fx-arrload ' + psStr(n) + ')';
+        return '@(' + fn(w) + ')';
+      })
+      .join(' + ') +
+    ')'
+  );
+}
+
 /* ------------------------------------------------------------------ */
 /* Command substitution                                                */
 /* ------------------------------------------------------------------ */
@@ -217,23 +243,21 @@ export function translateSimple(
       // invoked with the call operator and an argv-style argument array —
       // no string re-parsing of user text.
       const nameExpr = psStr(nameLit);
-      const argExprs = cmd.args.map((a) => exprOfWord(a));
-      const args = argExprs.length ? ' @(' + argExprs.join(', ') + ')' : '';
-      const call = '& ' + nameExpr + args;
+      const invoke = '& ' + nameExpr + ' @fx_na';
       body = [
+        '$fx_na = ' + argListExpr(cmd.args),
         // feed pipeline stdin into the native process when we are a non-first stage
-        (hasStdin ? '($input | ' + call + ')' : call) + ' | ForEach-Object { [string]$_ }',
+        (hasStdin ? '($input | ' + invoke + ')' : invoke) + ' | ForEach-Object { [string]$_ }',
         'if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 }',
       ].join('\n');
     }
   } else {
     // dynamic command name — evaluate it
     const nameExpr = exprOfWord(cmd.name);
-    const argExprs = cmd.args.map((a) => exprOfWord(a));
-    const args = argExprs.length ? ' @(' + argExprs.join(', ') + ')' : '';
-    const call = '& (' + nameExpr + ')' + args;
+    const invoke = '& (' + nameExpr + ') @fx_na';
     body = [
-      (hasStdin ? '($input | ' + call + ')' : call) + ' | ForEach-Object { [string]$_ }',
+      '$fx_na = ' + argListExpr(cmd.args),
+      (hasStdin ? '($input | ' + invoke + ')' : invoke) + ' | ForEach-Object { [string]$_ }',
       'if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 }',
     ].join('\n');
   }
@@ -350,6 +374,7 @@ export function wrapTempEnv(
     lines.push(
       '  Remove-Item -LiteralPath ' + psStr('Env:\\' + u) + ' -ErrorAction SilentlyContinue',
     );
+    lines.push('  fx-arrdrop ' + psStr(u));
     // `env -u NAME` must hide NAME from fx-envget / fx-isset for the
     // wrapped body. Removing Env:\NAME is not enough: an earlier
     // `export NAME=x` still lives in SETVARS/SETVALS, and special
@@ -376,6 +401,7 @@ export function wrapTempEnv(
     const n = sets[i].name;
     const nq = n.replace(/'/g, "''");
     lines.push('  $env:' + n + ' = ' + valVars[i]);
+    lines.push('  fx-arrdrop ' + psStr(n));
     lines.push(
       "  $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne '" +
         nq +
@@ -698,6 +724,9 @@ export function wrapScript(body: string): string {
     "  $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
     '  $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sv += $fx_pair } }',
     "  $fx_sv += ($n + [string][char]61 + (fx-svenc $fx_0)); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
+    '}',
+    'function fx-arrdrop($n) {',
+    "  Remove-Item -LiteralPath ('Env:\\FAUXNIX_ARR_' + [string]$n) -ErrorAction SilentlyContinue",
     '}',
     'function fx-arrclr($n) {',
     '  $n = [string]$n',

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -167,14 +167,30 @@ export function operandExpr(w: Word): string {
   return exprOfWord(w);
 }
 
-/** Whole word is `${name[@]}` or `"${name[@]}"` (bash: one argv per element). */
-export function atSplatName(w: Word): string | null {
-  if (w.length === 1 && w[0].kind === 'Var' && w[0].index === '@') return w[0].name;
-  if (w.length === 1 && w[0].kind === 'DoubleQuoted' && w[0].parts.length === 1) {
-    const p = w[0].parts[0];
-    if (p.kind === 'Var' && p.index === '@') return p.name;
+function wordPartsForSplat(w: Word): WordPart[] {
+  if (w.length === 1 && w[0].kind === 'DoubleQuoted') return w[0].parts;
+  return w;
+}
+
+/** `${name[@]}` / `"pre${name[@]}post"` — one argv per element. */
+export function splatSpec(w: Word): { name: string; prefix: string; suffix: string } | null {
+  const parts = wordPartsForSplat(w);
+  let name: string | null = null;
+  let prefix = '';
+  let suffix = '';
+  let seen = false;
+  for (const p of parts) {
+    if (p.kind === 'Var' && p.index === '@') {
+      if (seen) return null;
+      seen = true;
+      name = p.name;
+      continue;
+    }
+    if (p.kind !== 'Text' && p.kind !== 'SingleQuoted') return null;
+    if (seen) suffix += p.text;
+    else prefix += p.text;
   }
-  return null;
+  return name ? { name, prefix, suffix } : null;
 }
 
 /** PS expression of a string[]: `@` words splat, others stay one element. */
@@ -184,9 +200,18 @@ export function argListExpr(words: Word[], fn: (w: Word) => string = exprOfWord)
     '(' +
     words
       .map((w) => {
-        const n = atSplatName(w);
-        if (n) return '@(fx-arrload ' + psStr(n) + ')';
-        return '@(' + fn(w) + ')';
+        const s = splatSpec(w);
+        if (!s) return '@(' + fn(w) + ')';
+        if (!s.prefix && !s.suffix) return '@(fx-arrload ' + psStr(s.name) + ')';
+        return (
+          '@($( $fx_sp = @(fx-arrload ' +
+          psStr(s.name) +
+          '); if ($fx_sp.Count -gt 0) { $fx_sp[0] = ' +
+          psStr(s.prefix) +
+          ' + $fx_sp[0]; $fx_sp[$fx_sp.Count-1] = $fx_sp[$fx_sp.Count-1] + ' +
+          psStr(s.suffix) +
+          ' }; $fx_sp ))'
+        );
       })
       .join(' + ') +
     ')'
@@ -339,6 +364,7 @@ export function wrapTempEnv(
     }
   }
   if (names.length === 0) return body;
+  const assigned = new Set(sets.map((s) => s.name));
 
   const id = tempEnvSeq++;
   const save = '$fx_es' + id;
@@ -350,6 +376,7 @@ export function wrapTempEnv(
     '$fx_sv0' + id + ' = $env:FAUXNIX_SETVARS',
     '$fx_uv0' + id + ' = $env:FAUXNIX_UNSETVARS',
     '$fx_xv0' + id + ' = $env:FAUXNIX_SETVALS',
+    '$fx_as0' + id + ' = $env:FAUXNIX_ARRS',
   ];
   for (const n of names) {
     const p = psStr('Env:\\' + n);
@@ -464,6 +491,10 @@ export function wrapTempEnv(
   lines.push('  $env:FAUXNIX_SETVARS = $fx_sv0' + id);
   lines.push('  $env:FAUXNIX_UNSETVARS = $fx_uv0' + id);
   lines.push('  $env:FAUXNIX_SETVALS = $fx_xv0' + id);
+  lines.push('  $env:FAUXNIX_ARRS = $fx_as0' + id);
+  for (const n of persistNames) {
+    if (assigned.has(n)) lines.push('  fx-arrdrop ' + psStr(n));
+  }
   for (const n of names) {
     if (persistNames.has(n)) continue;
     const p = psStr('Env:\\' + n);
@@ -524,7 +555,6 @@ export function wrapTempEnv(
       lines.push('  ' + restoreArr);
     }
   }
-  const assigned = new Set(sets.map((s) => s.name));
   for (const n of persistNames) {
     const nq = n.replace(/'/g, "''");
     const ep = psStr('Env:\\' + n);
@@ -735,38 +765,49 @@ export function wrapScript(body: string): string {
     '  return [string]$sb',
     '}',
     'function fx-arrload($n) {',
-    "  $enc = [Environment]::GetEnvironmentVariable('FAUXNIX_ARR_' + [string]$n)",
-    '  if ($null -ne $enc) {',
+    '  $n = [string]$n',
+    '  foreach ($fx_pair in @($env:FAUXNIX_ARRS -split [string][char]10)) {',
+    '    $fx_eq = $fx_pair.IndexOf([char]61)',
+    '    if ($fx_eq -lt 1) { continue }',
+    '    if ($fx_pair.Substring(0, $fx_eq) -cne $n) { continue }',
     '    $out = @()',
-    '    foreach ($line in @($enc -split [string][char]10)) { $out += ,(fx-svdec $line) }',
+    '    foreach ($el in @($fx_pair.Substring($fx_eq + 1) -split [string][char]30)) { $out += ,(fx-svdec $el) }',
     '    return $out',
     '  }',
-    '  $ev = Get-ChildItem Env: | Where-Object { $_.Name -ceq [string]$n } | Select-Object -First 1',
+    '  $ev = Get-ChildItem Env: | Where-Object { $_.Name -ceq $n } | Select-Object -First 1',
     '  if ($ev) { return @([string]$ev.Value) }',
-    '  $v = [Environment]::GetEnvironmentVariable([string]$n)',
+    '  $v = [Environment]::GetEnvironmentVariable($n)',
     '  if ($null -ne $v) { return @([string]$v) }',
     '  return @()',
+    '}',
+    'function fx-arrdrop($n) {',
+    '  $n = [string]$n',
+    '  $fx_sm = @()',
+    '  foreach ($fx_pair in @($env:FAUXNIX_ARRS -split [string][char]10)) {',
+    '    $fx_eq = $fx_pair.IndexOf([char]61)',
+    '    if ($fx_eq -lt 1) { continue }',
+    '    if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sm += $fx_pair }',
+    '  }',
+    '  $env:FAUXNIX_ARRS = ($fx_sm -join [string][char]10)',
     '}',
     'function fx-arrput($n, $vals) {',
     '  $n = [string]$n',
     '  $vals = @($vals)',
-    '  if ($vals.Count -eq 0) { fx-arrdrop $n } else {',
-    '  $encs = @(); foreach ($v in $vals) { $encs += (fx-svenc $v) }',
-    "  Set-Item -LiteralPath ('Env:\\FAUXNIX_ARR_' + $n) -Value ($encs -join [string][char]10)",
+    '  fx-arrdrop $n',
+    '  if ($vals.Count -eq 0) { } else {',
+    '    $encs = @(); foreach ($v in $vals) { $encs += (fx-svenc $v) }',
+    "    $env:FAUXNIX_ARRS = ((@($env:FAUXNIX_ARRS -split [string][char]10 | Where-Object { $_ -ne '' }) + ($n + [string][char]61 + ($encs -join [string][char]30))) -join [string][char]10)",
+    '  }',
     "  $fx_0 = $(if ($vals.Count -gt 0) { [string]$vals[0] } else { '' })",
     '  Set-Item -LiteralPath (\'Env:\\\' + $n) -Value $fx_0',
     "  $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",
     "  $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
     '  $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sv += $fx_pair } }',
     "  $fx_sv += ($n + [string][char]61 + (fx-svenc $fx_0)); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
-    '  }',
-    '}',
-    'function fx-arrdrop($n) {',
-    "  Remove-Item -LiteralPath ('Env:\\FAUXNIX_ARR_' + [string]$n) -ErrorAction SilentlyContinue",
     '}',
     'function fx-arrclr($n) {',
     '  $n = [string]$n',
-    "  Remove-Item -LiteralPath ('Env:\\FAUXNIX_ARR_' + $n) -ErrorAction SilentlyContinue",
+    '  fx-arrdrop $n',
     "  Remove-Item -LiteralPath ('Env:\\' + $n) -ErrorAction SilentlyContinue",
     "  $env:FAUXNIX_SETVARS = (@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
     "  $env:FAUXNIX_UNSETVARS = ((@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -342,9 +342,11 @@ export function wrapTempEnv(
 
   const id = tempEnvSeq++;
   const save = '$fx_es' + id;
+  const arrSave = '$fx_ar' + id;
   const keep = persistWords && persistWords.length > 0 ? '$fx_ek' + id : '';
   const lines: string[] = [
     save + ' = @{}',
+    arrSave + ' = @{}',
     '$fx_sv0' + id + ' = $env:FAUXNIX_SETVARS',
     '$fx_uv0' + id + ' = $env:FAUXNIX_UNSETVARS',
     '$fx_xv0' + id + ' = $env:FAUXNIX_SETVALS',
@@ -359,6 +361,17 @@ export function wrapTempEnv(
         p +
         ') { [string](Get-Item -LiteralPath ' +
         p +
+        ').Value } else { $null })',
+    );
+    const ap = psStr('Env:\\FAUXNIX_ARR_' + n);
+    lines.push(
+      arrSave +
+        '[' +
+        psStr(n) +
+        '] = $(if (Test-Path -LiteralPath ' +
+        ap +
+        ') { [string](Get-Item -LiteralPath ' +
+        ap +
         ').Value } else { $null })',
     );
   }
@@ -487,6 +500,28 @@ export function wrapTempEnv(
           psStr(n) +
           '] }',
       );
+    }
+    const ap = psStr('Env:\\FAUXNIX_ARR_' + n);
+    const restoreArr =
+      'if ($null -eq ' +
+      arrSave +
+      '[' +
+      psStr(n) +
+      ']) { Remove-Item -LiteralPath ' +
+      ap +
+      ' -ErrorAction SilentlyContinue } else { Set-Item -LiteralPath ' +
+      ap +
+      ' -Value ' +
+      arrSave +
+      '[' +
+      psStr(n) +
+      '] }';
+    if (keep) {
+      lines.push(
+        '  if (-not $fx_skip) { ' + restoreArr + ' }',
+      );
+    } else {
+      lines.push('  ' + restoreArr);
     }
   }
   const assigned = new Set(sets.map((s) => s.name));
@@ -702,7 +737,6 @@ export function wrapScript(body: string): string {
     'function fx-arrload($n) {',
     "  $enc = [Environment]::GetEnvironmentVariable('FAUXNIX_ARR_' + [string]$n)",
     '  if ($null -ne $enc) {',
-    "    if ($enc -eq '') { return @() }",
     '    $out = @()',
     '    foreach ($line in @($enc -split [string][char]10)) { $out += ,(fx-svdec $line) }',
     '    return $out',
@@ -716,6 +750,7 @@ export function wrapScript(body: string): string {
     'function fx-arrput($n, $vals) {',
     '  $n = [string]$n',
     '  $vals = @($vals)',
+    '  if ($vals.Count -eq 0) { fx-arrdrop $n } else {',
     '  $encs = @(); foreach ($v in $vals) { $encs += (fx-svenc $v) }',
     "  Set-Item -LiteralPath ('Env:\\FAUXNIX_ARR_' + $n) -Value ($encs -join [string][char]10)",
     "  $fx_0 = $(if ($vals.Count -gt 0) { [string]$vals[0] } else { '' })",
@@ -724,6 +759,7 @@ export function wrapScript(body: string): string {
     "  $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
     '  $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sv += $fx_pair } }',
     "  $fx_sv += ($n + [string][char]61 + (fx-svenc $fx_0)); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
+    '  }',
     '}',
     'function fx-arrdrop($n) {',
     "  Remove-Item -LiteralPath ('Env:\\FAUXNIX_ARR_' + [string]$n) -ErrorAction SilentlyContinue",

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -16,7 +16,10 @@ import { PipelineCtx, lookup, psStr } from './registry.js';
 /* ------------------------------------------------------------------ */
 
 /** Map a bash $VAR name to a PowerShell expression (usable inside $(...)). */
-export function varExpr(name: string): string {
+export function varExpr(name: string, index?: string): string {
+  if (index !== undefined) {
+    return '(fx-subget ' + psStr(name) + ' ' + psStr(index) + ')';
+  }
   switch (name) {
     case 'HOME':
       return '$HOME';
@@ -111,7 +114,7 @@ export function exprOfWord(w: Word): string {
 
   // single bare variable → bare expression
   if (expanded.length === 1 && expanded[0].kind === 'Var') {
-    return varExpr(expanded[0].name);
+    return varExpr(expanded[0].name, expanded[0].index);
   }
 
   const literal = expanded.every((p) => p.kind === 'Text' || p.kind === 'SingleQuoted');
@@ -134,7 +137,7 @@ export function exprOfWord(w: Word): string {
         for (const q of p.parts) emitPart(q);
         break;
       case 'Var':
-        out += '$(' + varExpr(p.name) + ')';
+        out += '$(' + varExpr(p.name, p.index) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd) + ')';
@@ -649,6 +652,68 @@ export function wrapScript(body: string): string {
     "  if ($parts.Count -eq 1 -and $parts[0] -eq '') { return @() }",
     "  if ($parts[$parts.Count - 1] -eq '') { $parts = $parts[0..($parts.Count - 2)] }",
     '  return $parts',
+    '}',
+    'function fx-svenc($s) {',
+    '  return ([string]$s).Replace([string][char]92, ([string][char]92 + [string][char]92)).Replace([string][char]13, ([string][char]92 + [char]114)).Replace([string][char]10, ([string][char]92 + [char]110))',
+    '}',
+    'function fx-svdec($s) {',
+    '  $s = [string]$s',
+    '  $sb = New-Object System.Text.StringBuilder',
+    '  $i = 0',
+    '  while ($i -lt $s.Length) {',
+    '    $c = $s[$i]',
+    '    if ($c -eq [char]92 -and ($i + 1) -lt $s.Length) {',
+    '      $n2 = $s[$i + 1]',
+    '      if ($n2 -eq [char]110) { [void]$sb.Append([char]10); $i += 2; continue }',
+    '      if ($n2 -eq [char]114) { [void]$sb.Append([char]13); $i += 2; continue }',
+    '      if ($n2 -eq [char]92) { [void]$sb.Append([char]92); $i += 2; continue }',
+    '    }',
+    '    [void]$sb.Append($c)',
+    '    $i++',
+    '  }',
+    '  return [string]$sb',
+    '}',
+    'function fx-arrload($n) {',
+    "  $enc = [Environment]::GetEnvironmentVariable('FAUXNIX_ARR_' + [string]$n)",
+    '  if ($null -ne $enc) {',
+    "    if ($enc -eq '') { return @() }",
+    '    $out = @()',
+    '    foreach ($line in @($enc -split [string][char]10)) { $out += ,(fx-svdec $line) }',
+    '    return $out',
+    '  }',
+    '  $ev = Get-ChildItem Env: | Where-Object { $_.Name -ceq [string]$n } | Select-Object -First 1',
+    '  if ($ev) { return @([string]$ev.Value) }',
+    '  $v = [Environment]::GetEnvironmentVariable([string]$n)',
+    '  if ($null -ne $v) { return @([string]$v) }',
+    '  return @()',
+    '}',
+    'function fx-arrput($n, $vals) {',
+    '  $n = [string]$n',
+    '  $vals = @($vals)',
+    '  $encs = @(); foreach ($v in $vals) { $encs += (fx-svenc $v) }',
+    "  Set-Item -LiteralPath ('Env:\\FAUXNIX_ARR_' + $n) -Value ($encs -join [string][char]10)",
+    "  $fx_0 = $(if ($vals.Count -gt 0) { [string]$vals[0] } else { '' })",
+    '  Set-Item -LiteralPath (\'Env:\\\' + $n) -Value $fx_0',
+    "  $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",
+    "  $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
+    '  $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sv += $fx_pair } }',
+    "  $fx_sv += ($n + [string][char]61 + (fx-svenc $fx_0)); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
+    '}',
+    'function fx-arrclr($n) {',
+    '  $n = [string]$n',
+    "  Remove-Item -LiteralPath ('Env:\\FAUXNIX_ARR_' + $n) -ErrorAction SilentlyContinue",
+    "  Remove-Item -LiteralPath ('Env:\\' + $n) -ErrorAction SilentlyContinue",
+    "  $env:FAUXNIX_SETVARS = (@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
+    "  $env:FAUXNIX_UNSETVARS = ((@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",
+    '  $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sv += $fx_pair } }; $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)',
+    '}',
+    'function fx-subget($n, $ix) {',
+    '  $arr = @(fx-arrload $n)',
+    "  if ([string]$ix -eq '@' -or [string]$ix -eq '*') { return ($arr -join ' ') }",
+    '  $i = 0',
+    '  if (-not [int]::TryParse([string]$ix, [ref]$i)) { return \'\' }',
+    "  if ($i -lt 0 -or $i -ge $arr.Count) { return '' }",
+    '  return [string]$arr[$i]',
     '}',
     'try {',
     ...body.split('\n').map((l) => '  ' + l),

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -206,7 +206,9 @@ export function argListExpr(words: Word[], fn: (w: Word) => string = exprOfWord)
         return (
           '@($( $fx_sp = @(fx-arrload ' +
           psStr(s.name) +
-          '); if ($fx_sp.Count -gt 0) { $fx_sp[0] = ' +
+          '); if ($fx_sp.Count -eq 0) { $fx_sp = @(' +
+          psStr(s.prefix + s.suffix) +
+          ') } else { $fx_sp[0] = ' +
           psStr(s.prefix) +
           ' + $fx_sp[0]; $fx_sp[$fx_sp.Count-1] = $fx_sp[$fx_sp.Count-1] + ' +
           psStr(s.suffix) +
@@ -774,11 +776,34 @@ export function wrapScript(body: string): string {
     '    foreach ($el in @($fx_pair.Substring($fx_eq + 1) -split [string][char]30)) { $out += ,(fx-svdec $el) }',
     '    return $out',
     '  }',
+    '  $s0 = fx-scalar0 $n',
+    '  if ($null -eq $s0) { return @() }',
+    '  return @([string]$s0)',
+    '}',
+    'function fx-scalar0($n) {',
+    '  $n = [string]$n',
+    "  if (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ceq $n }).Count -gt 0) { return $null }",
+    '  foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) {',
+    '    $fx_eq = $fx_pair.IndexOf([char]61)',
+    '    if ($fx_eq -lt 1) { continue }',
+    '    if ($fx_pair.Substring(0, $fx_eq) -ceq $n) { return (fx-svdec $fx_pair.Substring($fx_eq + 1)) }',
+    '  }',
+    "  if ($n -ceq 'HOME') { return [string]$HOME }",
+    "  if ($n -ceq 'PWD') { return [string]$PWD.Path }",
+    "  if ($n -ceq 'USER' -or $n -ceq 'LOGNAME') { return [string]$env:USERNAME }",
+    "  if ($n -ceq 'PATH') { return [string]$env:PATH }",
+    "  if ($n -ceq 'SHELL') { return 'powershell' }",
+    "  if ($n -ceq 'TERM') { return 'xterm-256color' }",
+    "  if ($n -ceq 'OLDPWD') { return $(if ($env:FAUXNIX_OLDPWD) { [string]$env:FAUXNIX_OLDPWD } else { $null }) }",
+    "  if ($n -ceq 'HOSTNAME') { return [string]$env:COMPUTERNAME }",
     '  $ev = Get-ChildItem Env: | Where-Object { $_.Name -ceq $n } | Select-Object -First 1',
-    '  if ($ev) { return @([string]$ev.Value) }',
-    '  $v = [Environment]::GetEnvironmentVariable($n)',
-    '  if ($null -ne $v) { return @([string]$v) }',
-    '  return @()',
+    '  if ($ev) { return [string]$ev.Value }',
+    '  return $null',
+    '}',
+    'function fx-ifs1 {',
+    "  if ($null -eq $env:IFS) { return ' ' }",
+    "  if ([string]$env:IFS -eq '') { return '' }",
+    '  return [string]([string]$env:IFS)[0]',
     '}',
     'function fx-arrdrop($n) {',
     '  $n = [string]$n',
@@ -815,9 +840,12 @@ export function wrapScript(body: string): string {
     '}',
     'function fx-subget($n, $ix) {',
     '  $arr = @(fx-arrload $n)',
-    "  if ([string]$ix -eq '@' -or [string]$ix -eq '*') { return ($arr -join ' ') }",
+    '  $ix = [string]$ix',
+    // argv-level `@` is expanded by argListExpr; this is the scalar/quoted-* join.
+    "  if ($ix -eq '*') { return ($arr -join (fx-ifs1)) }",
+    "  if ($ix -eq '@') { return ($arr -join (fx-ifs1)) }",
     '  $i = 0',
-    '  if (-not [int]::TryParse([string]$ix, [ref]$i)) { return \'\' }',
+    '  if (-not [int]::TryParse($ix, [ref]$i)) { return \'\' }',
     "  if ($i -lt 0 -or $i -ge $arr.Count) { return '' }",
     '  return [string]$arr[$i]',
     '}',

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -360,6 +360,18 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
     expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${BASH_REMATCH[0]}')).stdout.trim()).toBe('abc');
     expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${BASH_REMATCH[1]}')).stdout.trim()).toBe('b');
     expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${BASH_REMATCH[@]}')).stdout.trim()).toBe('abc b');
+    expect((await run("[[ abc =~ ^a(.)c$ ]]; printf '<%s>\\n' \"${BASH_REMATCH[@]}\"")).stdout).toBe(
+      '<abc>\n<b>\n',
+    );
+    expect((await run("[[ abc =~ ^a(.)c$ ]]; printf '<%s>\\n' \"${BASH_REMATCH[*]}\"")).stdout).toBe(
+      '<abc b>\n',
+    );
+    expect(
+      (await run('[[ abc =~ ^a(.)c$ ]]; unset BASH_REMATCH; echo ${BASH_REMATCH[0]}')).stdout.trim(),
+    ).toBe('');
+    expect(
+      (await run('[[ abc =~ ^a(.)c$ ]]; BASH_REMATCH=x; echo ${BASH_REMATCH[0]}; echo ${BASH_REMATCH[1]}')).stdout.trim(),
+    ).toBe('x');
     expect((await run('[[ abc =~ z ]]; echo ${BASH_REMATCH[1]}')).stdout.trim()).toBe('');
     expect(
       (await run('export BASH_REMATCH=old; [[ abc =~ b ]]; [[ $BASH_REMATCH == b ]]; echo $?; unset BASH_REMATCH')).stdout.trim(),
@@ -469,7 +481,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
       (await run('SA_Z=out; SA_Z=in [[ $SA_Z == in ]] && echo YES || echo NO')).stdout.trim(),
     ).toBe('YES');
     await run('unset SA_V SA_N SA_E SA_Z');
-  });
+  }, 20000);
 
   it('session cwd persists across calls', async () => {
     await run('cd sub');

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -379,6 +379,12 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
       (await run('[[ abc =~ ^a(.)c$ ]]; BASH_REMATCH=x true; echo ${BASH_REMATCH[1]}')).stdout.trim(),
     ).toBe('b');
     expect(
+      (await run("[[ abc =~ ^a(.)c$ ]]; printf '<%s>\\n' \"pre${BASH_REMATCH[@]}post\"")).stdout,
+    ).toBe('<preabc>\n<bpost>\n');
+    expect(
+      (await run('[[ abc =~ ^a(.)c$ ]]; bash_rematch=x; echo ${BASH_REMATCH[1]}')).stdout.trim(),
+    ).toBe('b');
+    expect(
       (await run('export BASH_REMATCH=old; [[ abc =~ b ]]; [[ $BASH_REMATCH == b ]]; echo $?; unset BASH_REMATCH')).stdout.trim(),
     ).toBe('0');
     expect((await run('[[ abc =~ b ]]; [[ abc =~ z ]]; echo "$BASH_REMATCH"')).stdout.trim()).toBe('');

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -373,6 +373,11 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
       (await run('[[ abc =~ ^a(.)c$ ]]; BASH_REMATCH=x; echo ${BASH_REMATCH[0]}; echo ${BASH_REMATCH[1]}')).stdout.trim(),
     ).toBe('x');
     expect((await run('[[ abc =~ z ]]; echo ${BASH_REMATCH[1]}')).stdout.trim()).toBe('');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; [[ -v BASH_REMATCH[1] ]]')).exitCode).toBe(0);
+    expect((await run('[[ x =~ ^ ]]; printf "<%s>\\n" "${BASH_REMATCH[@]}"')).stdout).toBe('<>\n');
+    expect(
+      (await run('[[ abc =~ ^a(.)c$ ]]; BASH_REMATCH=x true; echo ${BASH_REMATCH[1]}')).stdout.trim(),
+    ).toBe('b');
     expect(
       (await run('export BASH_REMATCH=old; [[ abc =~ b ]]; [[ $BASH_REMATCH == b ]]; echo $?; unset BASH_REMATCH')).stdout.trim(),
     ).toBe('0');

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -357,6 +357,10 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
     expect((await run("[[ 'a>b' =~ (a>b) ]]")).exitCode).toBe(0);
     expect((await run("[[ 'a&&b' =~ (a&&b) ]]")).exitCode).toBe(0);
     expect((await run('[[ abc =~ b ]]; echo "$BASH_REMATCH"')).stdout.trim()).toBe('b');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${BASH_REMATCH[0]}')).stdout.trim()).toBe('abc');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${BASH_REMATCH[1]}')).stdout.trim()).toBe('b');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${BASH_REMATCH[@]}')).stdout.trim()).toBe('abc b');
+    expect((await run('[[ abc =~ z ]]; echo ${BASH_REMATCH[1]}')).stdout.trim()).toBe('');
     expect(
       (await run('export BASH_REMATCH=old; [[ abc =~ b ]]; [[ $BASH_REMATCH == b ]]; echo $?; unset BASH_REMATCH')).stdout.trim(),
     ).toBe('0');

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -382,8 +382,18 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
       (await run("[[ abc =~ ^a(.)c$ ]]; printf '<%s>\\n' \"pre${BASH_REMATCH[@]}post\"")).stdout,
     ).toBe('<preabc>\n<bpost>\n');
     expect(
-      (await run('[[ abc =~ ^a(.)c$ ]]; bash_rematch=x; echo ${BASH_REMATCH[1]}')).stdout.trim(),
+      (await run('[[ abc =~ ^a(.)c$ ]]; bash_rematch=x; echo ${BASH_REMATCH[1]}; unset bash_rematch')).stdout.trim(),
     ).toBe('b');
+    expect((await run('unset X; printf "<%s>\\n" "pre${X[@]}post"')).stdout).toBe('<prepost>\n');
+    expect((await run('echo ${PWD[0]}')).stdout.trim()).toBe(
+      (await run('echo $PWD')).stdout.trim(),
+    );
+    expect(
+      (await run('unset bash_rematch; [[ abc =~ ^a(.)c$ ]]; echo ${bash_rematch[0]}')).stdout.trim(),
+    ).toBe('');
+    expect(
+      (await run("IFS=','; [[ abc =~ ^a(.)c$ ]]; echo \"${BASH_REMATCH[*]}\"")).stdout.trim(),
+    ).toBe('abc,b');
     expect(
       (await run('export BASH_REMATCH=old; [[ abc =~ b ]]; [[ $BASH_REMATCH == b ]]; echo $?; unset BASH_REMATCH')).stdout.trim(),
     ).toBe('0');

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -69,6 +69,13 @@ describe('parser', () => {
     expect(parts.some((p) => p.kind === 'CmdSub' && p.cmd === 'date +%Y')).toBe(true);
   });
 
+  it('parses ${name[index]} subscripts', () => {
+    const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
+    expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);
+    expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'PATH', index: '0' }]);
+    expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'x', index: '@' }]);
+  });
+
   it('rejects heredocs with a helpful message', () => {
     expect(() => parse('cat <<EOF')).toThrow(FauxnixParseError);
     expect(() => parse('cat <<EOF')).toThrow(/heredoc/);


### PR DESCRIPTION
Closes #84.

## Why

`=~` already captured .NET `Groups`, but `$BASH_REMATCH` was scalar-only. Scripts that need `${BASH_REMATCH[1]}` had no expander for `${name[n]}`.

## What

- Parser accepts `${name[0]}`, `${name[1]}`, `${name[@]}`, `${name[*]}`
- Runtime array shadow `FAUXNIX_ARR_<name>` (encoded like SETVALS)
- `fx-subget` / `fx-arrput` / `fx-arrclr` in the script preamble so `echo` and `[[` both work
- Successful `=~` stores every capture group; a miss clears the array
- Scalar `${PATH[0]}` is the value; `${PATH[1]}` is empty

## Verification

- 105/105 tests, tsc clean
