### PR TITLE
feat: expand name subscripts and store BASH_REMATCH groups

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -6,7 +6,7 @@
  *   - lists:                cmd1 ; cmd2 && cmd3 || cmd4   (newlines act as ';')
  *   - redirections:         > >> 2> 2>> &> 2>&1 1>&2 <
  *   - quoting:              'literal'  "interp $VAR $(cmd)"
- *   - variables:            $VAR ${VAR} plus special cases ($HOME $USER $PATH ...)
+ *   - variables:            $VAR ${VAR} ${VAR[n]} plus special cases ($HOME $USER $PATH ...)
  *   - command substitution: $(...) (recursively translated)
  *   - env assignment prefix: VAR=value cmd
  *
@@ -64,7 +64,7 @@ export type WordPart =
   | { kind: 'Text'; text: string; escaped?: boolean }
   | { kind: 'SingleQuoted'; text: string }
   | { kind: 'DoubleQuoted'; parts: WordPart[] }
-  | { kind: 'Var'; name: string }
+  | { kind: 'Var'; name: string; index?: string }
   | { kind: 'CmdSub'; cmd: string };
 
 export function wordToString(w: Word): string {
@@ -94,7 +94,7 @@ function partToString(p: WordPart): string {
     case 'DoubleQuoted':
       return p.parts.map(partToString).join('');
     case 'Var':
-      return `$${p.name}`;
+      return p.index !== undefined ? `\${${p.name}[${p.index}]}` : `$${p.name}`;
     case 'CmdSub':
       return '$(' + p.cmd + ')';
   }

--- a/src/commands/archive.ts
+++ b/src/commands/archive.ts
@@ -1,6 +1,6 @@
 import { Word, wordToString } from '../ast.js';
 import { Handler, PipelineCtx, parseWords, psStr } from '../registry.js';
-import { exprOfWord, operandExpr } from '../translator.js';
+import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
 /* gzip family — .NET GZipStream helpers                               */
@@ -222,7 +222,7 @@ function gzBlock(args: Word[], ctx: PipelineCtx, forced: Partial<GzOpts>): strin
 
   return [
     PS_GZ_FNS,
-    '$fx_files = @(' + (p.files.length ? p.files.map(operandExpr).join(', ') : '') + ')',
+    '$fx_files = ' + (p.files.length ? argListExpr(p.files, operandExpr) : '@()'),
     'if ($fx_files.Count -eq 0) {',
     stdinBranch,
     '} else {',
@@ -243,7 +243,7 @@ const zcat: Handler = (args, ctx) => gzBlock(args, ctx, { decompress: true, stdo
 
 const tar: Handler = (args) => {
   return [
-    "$fx_args = @(" + args.map(exprOfWord).join(', ') + ')',
+    '$fx_args = ' + argListExpr(args, exprOfWord),
     // Prefer the Windows-shipped bsdtar (System32): it accepts both path
     // styles. A PATH lookup could resolve to Git Bash's GNU tar, which
     // misreads `C:\...` argv as a remote-host spec (host:path syntax).
@@ -296,10 +296,10 @@ const zip: Handler = (args) => {
     );
   }
   const arc = operandExpr(rest[0]);
-  const inputs = rest.slice(1).map(operandExpr).join(', ');
+  const inputs = argListExpr(rest.slice(1), operandExpr);
   return [
     note + '$fx_arc = ' + arc,
-    '$fx_inputs = @(' + inputs + ')',
+    '$fx_inputs = ' + inputs,
     '$fx_valid = @()',
     'foreach ($fx_p in $fx_inputs) {',
     '  if (Test-Path -LiteralPath $fx_p) { $fx_valid += $fx_p }',

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,6 +1,6 @@
 import { Word, wordToString } from '../ast.js';
 import { Handler, parseWords, psStr } from '../registry.js';
-import { exprOfWord, operandExpr } from '../translator.js';
+import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
 /* Shared PS snippets                                                  */
@@ -51,8 +51,7 @@ const PS_HSIZE_FN = [
 
 /** Operand Words → PS array expression of string exprs. */
 function psArray(words: Word[], fn: (w: Word) => string = operandExpr): string {
-  if (words.length === 0) return '@()';
-  return '@(' + words.map(fn).join(', ') + ')';
+  return argListExpr(words, fn);
 }
 
 /* ------------------------------------------------------------------ */
@@ -70,7 +69,7 @@ const ls: Handler = (args) => {
   const sortByTime = flags.has('t');
   const sortBySize = flags.has('S');
   const reverse = flags.has('r');
-  const targets = operandWords.length ? operandWords.map((w) => operandExpr(w)) : ["'.'"];
+  const targets = operandWords.length ? argListExpr(operandWords) : "@('.')";
 
   return [
     PS_GLOB_FN,
@@ -92,7 +91,7 @@ const ls: Handler = (args) => {
     '  }',
     '  return $n',
     '}',
-    '$fx_targets = @(' + targets.join(', ') + ')',
+    '$fx_targets = ' + targets,
     '$fx_all = @()',
     'foreach ($fx_t in $fx_targets) {',
     '  foreach ($fx_g in (fx-glob $fx_t)) {',
@@ -136,12 +135,10 @@ const cp: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args);
   const recurse = flags.has('r') || flags.has('R') || longs.has('--recursive');
   const verbose = flags.has('v') || longs.has('--verbose');
-  const srcs = psArray(operandWords.slice(0, -1));
-  const dst = operandWords.length >= 2 ? operandExpr(operandWords[operandWords.length - 1]) : "''";
   return [
     PS_GLOB_FN,
-    '$fx_srcs = ' + srcs,
-    '$fx_dst = ' + dst,
+    '$fx_all = ' + argListExpr(operandWords),
+    "if ($fx_all.Count -lt 2) { $fx_srcs = @(); $fx_dst = '' } else { $fx_dst = [string]$fx_all[$fx_all.Count - 1]; $fx_srcs = @($fx_all[0..($fx_all.Count - 2)]) }",
     "if ($fx_srcs.Count -eq 0) { [Console]::Error.WriteLine('cp: missing file operand'); $script:fx_exit = 1 }",
     "elseif ($fx_dst -eq '') { [Console]::Error.WriteLine('cp: missing destination file operand'); $script:fx_exit = 1 }",
     'else {',
@@ -165,12 +162,10 @@ const cp: Handler = (args) => {
 const mv: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args);
   const verbose = flags.has('v') || longs.has('--verbose');
-  const srcs = psArray(operandWords.slice(0, -1));
-  const dst = operandWords.length >= 2 ? operandExpr(operandWords[operandWords.length - 1]) : "''";
   return [
     PS_GLOB_FN,
-    '$fx_srcs = ' + srcs,
-    '$fx_dst = ' + dst,
+    '$fx_all = ' + argListExpr(operandWords),
+    "if ($fx_all.Count -lt 2) { $fx_srcs = @(); $fx_dst = '' } else { $fx_dst = [string]$fx_all[$fx_all.Count - 1]; $fx_srcs = @($fx_all[0..($fx_all.Count - 2)]) }",
     "if ($fx_srcs.Count -eq 0) { [Console]::Error.WriteLine('mv: missing file operand'); $script:fx_exit = 1 }",
     "elseif ($fx_dst -eq '') { [Console]::Error.WriteLine('mv: missing destination file operand'); $script:fx_exit = 1 }",
     'elseif ($fx_srcs.Count -gt 1 -and -not (Test-Path -LiteralPath $fx_dst -PathType Container)) { [Console]::Error.WriteLine("mv: target \'" + $fx_dst + "\' is not a directory"); $script:fx_exit = 1 }',
@@ -293,13 +288,11 @@ const mktemp: Handler = (args) => {
 const ln: Handler = (args) => {
   const { flags, operandWords } = parseWords(args);
   const sym = flags.has('s');
-  const src = operandWords.length >= 2 ? operandExpr(operandWords[0]) : "''";
-  const dst = operandWords.length >= 2 ? operandExpr(operandWords[1]) : "''";
   const kind = sym ? 'SymbolicLink' : 'HardLink';
   const label = sym ? 'symbolic link' : 'hard link';
   return [
-    '$fx_src = ' + src,
-    '$fx_dst = ' + dst,
+    '$fx_ops = ' + argListExpr(operandWords),
+    "if ($fx_ops.Count -lt 2) { $fx_src = ''; $fx_dst = '' } else { $fx_src = [string]$fx_ops[0]; $fx_dst = [string]$fx_ops[1] }",
     "if ($fx_src -eq '' -or $fx_dst -eq '') { [Console]::Error.WriteLine('ln: missing file operand'); $script:fx_exit = 1 }",
     'else {',
     '  if (Test-Path -LiteralPath $fx_dst -PathType Container) { $fx_dst = Join-Path $fx_dst (Split-Path $fx_src -Leaf) }',
@@ -344,30 +337,29 @@ const realpath: Handler = (args) => {
 /* ------------------------------------------------------------------ */
 
 const basename: Handler = (args) => {
-  if (args.length === 2) {
-    return [
-      '$fx_p = ' + exprOfWord(args[0]),
-      '$fx_sfx = ' + exprOfWord(args[1]),
-      "$fx_n = [IO.Path]::GetFileName(($fx_p.TrimEnd('/')).TrimEnd('\\'))",
-      "if ($fx_n -eq '') { $fx_n = '/' }",
-      "if ($fx_sfx -ne '' -and $fx_n.EndsWith($fx_sfx) -and ($fx_n.Length -gt $fx_sfx.Length)) { $fx_n = $fx_n.Substring(0, $fx_n.Length - $fx_sfx.Length) }",
-      '$fx_n',
-    ].join('\n');
-  }
   return [
-    '$fx_ps = @(' + args.map(exprOfWord).join(', ') + ')',
+    '$fx_ps = ' + argListExpr(args, exprOfWord),
     "if ($fx_ps.Count -eq 0) { [Console]::Error.WriteLine('basename: missing operand'); $script:fx_exit = 1 }",
-    'foreach ($fx_p in $fx_ps) {',
+    'elseif ($fx_ps.Count -eq 2) {',
+    '  $fx_p = [string]$fx_ps[0]',
+    '  $fx_sfx = [string]$fx_ps[1]',
     "  $fx_n = [IO.Path]::GetFileName(($fx_p.TrimEnd('/')).TrimEnd('\\'))",
     "  if ($fx_n -eq '') { $fx_n = '/' }",
+    "  if ($fx_sfx -ne '' -and $fx_n.EndsWith($fx_sfx) -and ($fx_n.Length -gt $fx_sfx.Length)) { $fx_n = $fx_n.Substring(0, $fx_n.Length - $fx_sfx.Length) }",
     '  $fx_n',
+    '} else {',
+    '  foreach ($fx_p in $fx_ps) {',
+    "    $fx_n = [IO.Path]::GetFileName(($fx_p.TrimEnd('/')).TrimEnd('\\'))",
+    "    if ($fx_n -eq '') { $fx_n = '/' }",
+    '    $fx_n',
+    '  }',
     '}',
   ].join('\n');
 };
 
 const dirname: Handler = (args) => {
   return [
-    '$fx_ps = @(' + args.map(exprOfWord).join(', ') + ')',
+    '$fx_ps = ' + argListExpr(args, exprOfWord),
     "if ($fx_ps.Count -eq 0) { [Console]::Error.WriteLine('dirname: missing operand'); $script:fx_exit = 1 }",
     'foreach ($fx_p in $fx_ps) {',
     "  $fx_n = ($fx_p.TrimEnd('/')).TrimEnd('\\')",
@@ -457,7 +449,7 @@ const du: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args, [], ['--max-depth']);
   const sum = flags.has('s') || longs.has('--summarize');
   const human = flags.has('h') || longs.has('--human-readable');
-  const targets = operandWords.length ? operandWords.map((w) => operandExpr(w)) : ["'.'"];
+  const targets = operandWords.length ? argListExpr(operandWords) : "@('.')";
   return [
     PS_HSIZE_FN,
     'function fx-size($p) {',
@@ -465,7 +457,7 @@ const du: Handler = (args) => {
     '  Get-ChildItem -LiteralPath $p -Recurse -Force -File -ErrorAction SilentlyContinue | ForEach-Object { $t += $_.Length }',
     '  return [math]::Ceiling($t / 1KB)',
     '}',
-    '$fx_ts = @(' + targets.join(', ') + ')',
+    '$fx_ts = ' + targets,
     'foreach ($fx_t in $fx_ts) {',
     '  if (-not (Test-Path -LiteralPath $fx_t)) { [Console]::Error.WriteLine("du: cannot access \'" + $fx_t + "\': No such file or directory"); $script:fx_exit = 1; continue }',
     '  if (' + (sum ? '$true' : '$false') + ') {',
@@ -538,7 +530,7 @@ const find: Handler = (args) => {
   const sizeExpr = extractValue(preds, ['-size']);
   const mtimeExpr = extractValue(preds, ['-mtime']);
   const wantDelete = preds.includes('-delete');
-  const paths = pathWords.length ? pathWords.map((w) => operandExpr(w)) : ["'.'"];
+  const paths = pathWords.length ? argListExpr(pathWords) : "@('.')";
 
   const conditions: string[] = [];
   if (namePat !== null) conditions.push("($fx_i.Name -like '" + likeOf(namePat) + "')");
@@ -553,7 +545,7 @@ const find: Handler = (args) => {
   const mtimeCond = mtimeOf(mtimeExpr);
 
   return [
-    '$fx_paths = @(' + paths.join(', ') + ')',
+    '$fx_paths = ' + paths,
     'foreach ($fx_p in $fx_paths) {',
     '  if (-not (Test-Path -LiteralPath $fx_p)) { [Console]::Error.WriteLine("find: \'" + $fx_p + "\': No such file or directory"); $script:fx_exit = 1; continue }',
     '  $fx_root = (Get-Item -LiteralPath $fx_p -Force).FullName',
@@ -664,13 +656,11 @@ const diff: Handler = (args) => {
   const unified = flags.has('u') || flags.has('U');
   const brief = flags.has('q') || flags.has('brief');
   void unified;
-  const a = operandWords.length > 0 ? operandExpr(operandWords[0]) : "''";
-  const b = operandWords.length > 1 ? operandExpr(operandWords[1]) : "''";
   return [
     PS_READTEXT_FN,
     'function fx-dr($x, $y) { if ($x -eq $y) { return [string]$x } else { return ([string]$x) + \',\' + ([string]$y) } }',
-    '$fx_a = ' + a,
-    '$fx_b = ' + b,
+    '$fx_ops = ' + argListExpr(operandWords),
+    "if ($fx_ops.Count -lt 2) { $fx_a = ''; $fx_b = '' } else { $fx_a = [string]$fx_ops[0]; $fx_b = [string]$fx_ops[1] }",
     "if ($fx_a -eq '' -or $fx_b -eq '') { [Console]::Error.WriteLine('diff: missing operand'); $script:fx_exit = 2 }",
     'elseif (-not (Test-Path -LiteralPath $fx_a)) { [Console]::Error.WriteLine("diff: " + $fx_a + ": No such file or directory"); $script:fx_exit = 2 }',
     'elseif (-not (Test-Path -LiteralPath $fx_b)) { [Console]::Error.WriteLine("diff: " + $fx_b + ": No such file or directory"); $script:fx_exit = 2 }',

--- a/src/commands/net.ts
+++ b/src/commands/net.ts
@@ -1,6 +1,6 @@
 import { Word, wordToString } from '../ast.js';
 import { Handler, parseWords, psErr, psStr } from '../registry.js';
-import { exprOfWord, literalOfWord, operandExpr } from '../translator.js';
+import { argListExpr, exprOfWord, literalOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
 /* Shared PS snippets                                                  */
@@ -101,7 +101,7 @@ const curl: Handler = (args) => {
   // refuses private/loopback URLs before the process is even started.
   return [
     PS_NETGUARD_FNS,
-    "$fx_args = @(" + args.map(exprOfWord).join(', ') + ')',
+    '$fx_args = ' + argListExpr(args, exprOfWord),
     '$fx_bad = $false',
     "foreach ($fx_a in $fx_args) { if (fx-netguard 'curl' $fx_a) { $fx_bad = $true } }",
     'if ($fx_bad) { $script:fx_exit = 1 }',
@@ -222,7 +222,7 @@ const wget: Handler = (args) => {
   const mapped = mapWgetArgs(args);
   return [
     PS_NETGUARD_FNS,
-    '$fx_args = @(' + orig.join(', ') + ')',
+    '$fx_args = ' + argListExpr(args, exprOfWord),
     '$fx_margs = @(' + mapped.margs.join(', ') + ')',
     '$fx_bad = $false',
     "foreach ($fx_a in $fx_args) { if (fx-netguard 'wget' $fx_a) { $fx_bad = $true } }",
@@ -473,7 +473,11 @@ const ifconfig: Handler = (args) => {
 /* nslookup / dig / host                                               */
 /* ------------------------------------------------------------------ */
 
-const nslookup: Handler = (args) => nativeCall('nslookup.exe', args.map(exprOfWord).join(', '));
+const nslookup: Handler = (args) =>
+  [
+    '$fx_args = ' + argListExpr(args, exprOfWord),
+    nativeCall('nslookup.exe', '$fx_args'),
+  ].join('\n');
 
 const dig: Handler = (args) => {
   const raw = args.map(wordToString);

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -1,6 +1,7 @@
 import { FauxnixParseError, Word, WordPart, isUnquotedLiteral, wordToString } from '../ast.js';
 import { Handler, lookup, parseWords, psStr, registeredNames } from '../registry.js';
 import {
+  argListExpr,
   exprOfWord,
   operandExpr,
   translateSimple,
@@ -23,6 +24,7 @@ const NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 function emitSetValPut(nameLit: string, valueExpr: string): string {
   const n = nameLit.replace(/'/g, "''");
   return [
+    "fx-arrdrop '" + n + "'",
     '$fx_sv = @()',
     'foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) {',
     '  $fx_eq = $fx_pair.IndexOf([char]61)',
@@ -36,6 +38,7 @@ function emitSetValPut(nameLit: string, valueExpr: string): string {
 
 function emitSetValDelRuntime(nameVar: string): string {
   return [
+    'fx-arrdrop ' + nameVar,
     '$fx_sv = @()',
     'foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) {',
     '  $fx_eq = $fx_pair.IndexOf([char]61)',
@@ -80,8 +83,7 @@ function splitAssignWord(w: Word): AssignSplit | null {
 
 /** Text Words -> PS array expression. */
 function textArgs(words: Word[]): string {
-  if (words.length === 0) return '@()';
-  return '@(' + words.map(exprOfWord).join(', ') + ')';
+  return argListExpr(words, exprOfWord);
 }
 
 /** Drop dash-arguments, return operand words. */
@@ -156,10 +158,12 @@ const cd: Handler = (args) => {
     ].join('\n');
   }
   return [
-    '$fx_d = ' + operandExpr(args[0]),
+    '$fx_ds = ' + argListExpr([args[0]]),
+    "if ($fx_ds.Count -ne 1) { [Console]::Error.WriteLine('bash: cd: too many arguments'); $script:fx_exit = 1 }",
+    'else { $fx_d = [string]$fx_ds[0]',
     'if (-not (Test-Path -LiteralPath $fx_d)) { [Console]::Error.WriteLine("bash: cd: " + $fx_d + ": No such file or directory"); $script:fx_exit = 1 }',
     'elseif (-not (Test-Path -LiteralPath $fx_d -PathType Container)) { [Console]::Error.WriteLine("bash: cd: " + $fx_d + ": Not a directory"); $script:fx_exit = 1 }',
-    'else { try { Set-Location -LiteralPath $fx_d } catch { [Console]::Error.WriteLine("bash: cd: " + $fx_d + ": No such file or directory"); $script:fx_exit = 1 } }',
+    'else { try { Set-Location -LiteralPath $fx_d } catch { [Console]::Error.WriteLine("bash: cd: " + $fx_d + ": No such file or directory"); $script:fx_exit = 1 } } }',
   ].join('\n');
 };
 
@@ -967,6 +971,7 @@ const FX_TNK_FN = [
   '  $fx_ev = Get-ChildItem Env: | Where-Object { $_.Name -ceq $n } | Select-Object -First 1',
   '  $nm = if ($fx_ev) { $fx_ev.Name } else { $n }',
   "  Set-Item -LiteralPath ('Env:' + $nm) -Value ([string][long]$v)",
+  '  fx-arrdrop $n',
   "  $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",
   "  $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
   '  $fx_sv = @()',
@@ -1430,6 +1435,9 @@ function kshExprOfWord(w: Word): string {
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
+    if (expanded[0].index !== undefined) {
+      return '(fx-subget ' + psStr(expanded[0].name) + ' ' + psStr(expanded[0].index) + ')';
+    }
     return '(fx-envget ' + psStr(expanded[0].name) + ')';
   }
   const literal =
@@ -1450,7 +1458,10 @@ function kshExprOfWord(w: Word): string {
         for (const q of p.parts) emitPart(q);
         break;
       case 'Var':
-        out += '$(fx-envget ' + psStr(p.name) + ')';
+        out +=
+          p.index !== undefined
+            ? '$(fx-subget ' + psStr(p.name) + ' ' + psStr(p.index) + ')'
+            : '$(fx-envget ' + psStr(p.name) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd) + ')';
@@ -1466,7 +1477,16 @@ const FX_ISSET_FN = [
   'function fx-isset($n) {',
   '  $n = [string]$n',
   "  if ($n -eq '') { return $false }",
-  "  if ($n -match '^([A-Za-z_][A-Za-z0-9_]*)\\[(0|@|\\*)\\]$') { $n = $Matches[1] }",
+  "  if ($n -match '^([A-Za-z_][A-Za-z0-9_]*)\\[([0-9]+|@|\\*)\\]$') {",
+  '    $fx_ib = $Matches[1]; $fx_ix = [string]$Matches[2]',
+  "    if ($fx_ix -eq '@' -or $fx_ix -eq '*' -or $fx_ix -eq '0') { $n = $fx_ib }",
+  '    else {',
+  '      $fx_ia = @(fx-arrload $fx_ib)',
+  '      $fx_ii = 0',
+  '      if (-not [int]::TryParse($fx_ix, [ref]$fx_ii)) { return $false }',
+  '      return ($fx_ii -ge 0 -and $fx_ii -lt $fx_ia.Count)',
+  '    }',
+  '  }',
   "  elseif ($n -match '^[A-Za-z_][A-Za-z0-9_]*\\[') { return $false }",
   "  if (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ceq $n }).Count -gt 0) { return $false }",
   "  if (@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ceq $n }).Count -gt 0) { return $true }",
@@ -1518,18 +1538,11 @@ const FX_RE_FN = [
   '  try {',
   '    $fx_rm = [regex]::Match([string]$a, (fx-posixre ([string]$b)), [Text.RegularExpressions.RegexOptions]::Singleline)',
   '    if ($fx_rm.Success) {',
-  '      $env:BASH_REMATCH = [string]$fx_rm.Value',
-  "      $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne 'BASH_REMATCH' }) + 'BASH_REMATCH') -join ';')",
-  "      $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne 'BASH_REMATCH' }) -join ';')",
-  '      $fx_enc = ([string]$fx_rm.Value).Replace([string][char]92, ([string][char]92 + [string][char]92)).Replace([string][char]13, ([string][char]92 + [char]114)).Replace([string][char]10, ([string][char]92 + [char]110))',
-  "      $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne 'BASH_REMATCH') { $fx_sv += $fx_pair } }",
-  "      $fx_sv += ('BASH_REMATCH' + [string][char]61 + $fx_enc); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
+  '      $fx_gs = @(); foreach ($fx_g in $fx_rm.Groups) { $fx_gs += ,[string]$fx_g.Value }',
+  "      fx-arrput 'BASH_REMATCH' $fx_gs",
   '      return $true',
   '    }',
-  "    Remove-Item -LiteralPath 'Env:\\BASH_REMATCH' -ErrorAction SilentlyContinue",
-  "    $env:FAUXNIX_SETVARS = (@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne 'BASH_REMATCH' }) -join ';')",
-  "    $env:FAUXNIX_UNSETVARS = ((@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne 'BASH_REMATCH' }) + 'BASH_REMATCH') -join ';')",
-  "    $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne 'BASH_REMATCH') { $fx_sv += $fx_pair } }; $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
+  "    fx-arrclr 'BASH_REMATCH'",
   '    return $false',
   '  }',
   "  catch { [Console]::Error.WriteLine('bash: [[: invalid regular expression'); $script:fx_exit = 2; return $false }",

--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { FauxnixParseError, Word, wordToString } from '../ast.js';
 import { Handler, parseWords, psStr } from '../registry.js';
-import { exprOfWord, literalOfWord, operandExpr } from '../translator.js';
+import { argListExpr, exprOfWord, literalOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
 /* Shared PS snippets (same shape as files.ts)                         */
@@ -40,8 +40,7 @@ const STDIN_LINES = '@($input | ForEach-Object { [string]$_ })';
 
 /** Operand Words → PS array expression of string exprs. */
 function psArray(words: Word[], fn: (w: Word) => string = operandExpr): string {
-  if (words.length === 0) return '@()';
-  return '@(' + words.map(fn).join(', ') + ')';
+  return argListExpr(words, fn);
 }
 
 /** PS boolean literal. */

--- a/src/commands/text-io.ts
+++ b/src/commands/text-io.ts
@@ -1,6 +1,6 @@
 import { Word, wordToString } from '../ast.js';
 import { Handler, lookup, parseWords, psStr } from '../registry.js';
-import { exprOfWord, operandExpr } from '../translator.js';
+import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
 /* Shared PS snippets (same shape as files.ts / text-filters.ts)       */
@@ -129,8 +129,7 @@ function qErr(cmd: string, g: string, msg: string, lead = 'cannot open '): strin
 
 /** Operand Words → PS array expression of string exprs. */
 function psArray(words: Word[], fn: (w: Word) => string = operandExpr): string {
-  if (words.length === 0) return '@()';
-  return '@(' + words.map(fn).join(', ') + ')';
+  return argListExpr(words, fn);
 }
 
 /**
@@ -160,8 +159,8 @@ function psCollectFiles(
     const lit = w.every((p) => p.kind === 'Text' || p.kind === 'SingleQuoted')
       ? w.map((p) => (p as { text: string }).text).join('')
       : null;
-    out.push('$fx_d = ' + (lit !== null ? psStr(lit) : exprOfWord(w)));
-    out.push('foreach ($fx_g in (fx-glob ' + operandExpr(w) + ')) {');
+    out.push('foreach ($fx_d in ' + argListExpr([w], lit !== null ? operandExpr : exprOfWord) + ') {');
+    out.push('foreach ($fx_g in (fx-glob $fx_d)) {');
     if (dirErr) {
       const dis = lit !== null && /[*?]/.test(lit) ? '$fx_g' : '$fx_d';
       out.push(
@@ -183,7 +182,7 @@ function psCollectFiles(
           ? '$fx_names += $fx_g'
           : '$fx_names += $fx_d'),
     );
-    out.push('}');
+    out.push('}', '}');
   }
   return out;
 }
@@ -1067,16 +1066,6 @@ const base64: Handler = (args, ctx) => {
 const seq: Handler = (args, ctx) => {
   const { flags, values, operandWords } = parseWords(args, ['s']);
   const eq = flags.has('w');
-  const nums = operandWords.map((w) => exprOfWord(w));
-  if (nums.length === 0) {
-    return psErrExpr(psStr('seq: missing operand'));
-  }
-  if (nums.length > 3) {
-    return psErrExpr(psStr('seq: extra operand ') + ' + ' + nums[3]);
-  }
-  const first = nums.length >= 2 ? nums[0] : '1';
-  const inc = nums.length === 3 ? nums[1] : '1';
-  const last = nums.length === 3 ? nums[2] : nums[nums.length - 1];
   const sepExpr = values.has('-s') ? psStr(values.get('-s')!) : '[string][char]10';
 
   return [
@@ -1090,9 +1079,17 @@ const seq: Handler = (args, ctx) => {
     "  if ([string]$s -match '^[+-]?[0-9]*\\.([0-9]+)') { return $Matches[1].Length }",
     '  return 0',
     '}',
-    '$fx_a = [string](' + first + ')',
-    '$fx_b = [string](' + inc + ')',
-    '$fx_c = [string](' + last + ')',
+    '$fx_nums = ' + argListExpr(operandWords),
+    "if ($fx_nums.Count -eq 0) { " +
+      psErrExpr(psStr('seq: missing operand')) +
+      ' }',
+    "elseif ($fx_nums.Count -gt 3) { " +
+      psErrExpr(psStr('seq: extra operand ') + ' + $fx_nums[3]') +
+      ' }',
+    'else {',
+    "  $fx_a = [string]$(if ($fx_nums.Count -ge 2) { $fx_nums[0] } else { '1' })",
+    "  $fx_b = [string]$(if ($fx_nums.Count -eq 3) { $fx_nums[1] } else { '1' })",
+    '  $fx_c = [string]$(if ($fx_nums.Count -eq 3) { $fx_nums[2] } else { $fx_nums[$fx_nums.Count - 1] })',
     '$fx_first = fx-tod $fx_a',
     '$fx_inc = fx-tod $fx_b',
     '$fx_last = fx-tod $fx_c',
@@ -1121,6 +1118,7 @@ const seq: Handler = (args, ctx) => {
     '  }',
     '  if ($fx_strs.Count -eq 0) { }',
     '  else { fx-write (($fx_strs -join (' + sepExpr + ')) + [string][char]10) $fx_term }',
+    '  }',
     '}',
   ].join('\n');
 };
@@ -1225,8 +1223,6 @@ const xargs: Handler = (args) => {
     return psErrExpr(psStr(XARGS_BUILTIN_MSG));
   }
 
-  const cmdExpr = exprOfWord(target[0]);
-  const baseArgs = psArray(target.slice(1), exprOfWord);
   const n = chunkN !== null && Number.isFinite(chunkN) && chunkN > 0 ? chunkN : 0;
   const replExpr = repl !== null ? psStr(repl) : null;
 
@@ -1294,8 +1290,8 @@ const xargs: Handler = (args) => {
   return [
     PS_SPLITLINES_FN,
     STDIN_INLINES,
-    '$fx_cmd = ' + cmdExpr,
-    '$fx_base = ' + baseArgs,
+    '$fx_tg = ' + argListExpr(target, exprOfWord),
+    "if ($fx_tg.Count -eq 0) { $fx_cmd = ''; $fx_base = @() } else { $fx_cmd = [string]$fx_tg[0]; $fx_base = $(if ($fx_tg.Count -gt 1) { @($fx_tg[1..($fx_tg.Count - 1)]) } else { @() }) }",
     "$fx_args = @($fx_in | Where-Object { $_ -ne '' })",
     ...dispatch,
   ].join('\n');

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -241,7 +241,11 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     const end = input.indexOf('}', j);
     if (end === -1) throw new FauxnixParseError('fauxnix: unclosed ${');
     const name = input.slice(j + 1, end);
-    if (!isNameStart(name[0]) || !name.split('').every(isNameChar)) {
+    const sub = name.match(/^([A-Za-z_][A-Za-z0-9_]*)\[([0-9]+|@|\*)\]$/);
+    if (sub) {
+      return { part: { kind: 'Var', name: sub[1], index: sub[2] }, next: end + 1 };
+    }
+    if (!name || !isNameStart(name[0]) || !name.split('').every(isNameChar)) {
       // ${VAR:-default} etc. — unsupported, kept as raw text
       return { part: { kind: 'Text', text: input.slice(i, end + 1) }, next: end + 1 };
     }

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -16,7 +16,13 @@ import { PipelineCtx, lookup, psStr } from './registry.js';
 /* ------------------------------------------------------------------ */
 
 /** Map a bash $VAR name to a PowerShell expression (usable inside $(...)). */
-export function varExpr(name: string): string {
+export function varExpr(name: string, index?: string): string {
+  // Indexed reads always go through fx-subget → fx-arrload → fx-scalar0 so
+  // ${PWD[0]} keeps the special mapping and ${bash_rematch[0]} stays
+  // case-exact (a `$env:name` fallback would alias BASH_REMATCH on Windows).
+  if (index !== undefined) {
+    return '(fx-subget ' + psStr(name) + ' ' + psStr(index) + ')';
+  }
   switch (name) {
     case 'HOME':
       return '$HOME';
@@ -111,7 +117,7 @@ export function exprOfWord(w: Word): string {
 
   // single bare variable → bare expression
   if (expanded.length === 1 && expanded[0].kind === 'Var') {
-    return varExpr(expanded[0].name);
+    return varExpr(expanded[0].name, expanded[0].index);
   }
 
   const literal = expanded.every((p) => p.kind === 'Text' || p.kind === 'SingleQuoted');
@@ -134,7 +140,7 @@ export function exprOfWord(w: Word): string {
         for (const q of p.parts) emitPart(q);
         break;
       case 'Var':
-        out += '$(' + varExpr(p.name) + ')';
+        out += '$(' + varExpr(p.name, p.index) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd) + ')';
@@ -162,6 +168,71 @@ export function operandExpr(w: Word): string {
   const lit = literalOfWord(w);
   if (lit !== null) return pathExpr(normalizeLiteralPath(lit));
   return exprOfWord(w);
+}
+
+/** Flatten quotes but remember whether a part sat inside `"..."`. */
+function wordPartsForSplat(w: Word): { part: WordPart; quoted: boolean }[] {
+  const out: { part: WordPart; quoted: boolean }[] = [];
+  const walk = (parts: WordPart[], quoted: boolean) => {
+    for (const p of parts) {
+      if (p.kind === 'DoubleQuoted') walk(p.parts, true);
+      else out.push({ part: p, quoted });
+    }
+  };
+  walk(w, false);
+  return out;
+}
+
+/**
+ * `${name[@]}` / `"pre${name[@]}post"` — one argv per element.
+ * Unquoted `${name[*]}` also splats (bash); quoted `"${name[*]}"` stays one join.
+ */
+export function splatSpec(w: Word): { name: string; prefix: string; suffix: string } | null {
+  const parts = wordPartsForSplat(w);
+  let name: string | null = null;
+  let prefix = '';
+  let suffix = '';
+  let seen = false;
+  for (const { part: p, quoted } of parts) {
+    const splat = p.kind === 'Var' && (p.index === '@' || (p.index === '*' && !quoted));
+    if (splat) {
+      if (seen) return null;
+      seen = true;
+      name = p.name;
+      continue;
+    }
+    if (p.kind !== 'Text' && p.kind !== 'SingleQuoted') return null;
+    if (seen) suffix += p.text;
+    else prefix += p.text;
+  }
+  return name ? { name, prefix, suffix } : null;
+}
+
+/** PS expression of a string[]: `@` words splat, others stay one element. */
+export function argListExpr(words: Word[], fn: (w: Word) => string = exprOfWord): string {
+  if (words.length === 0) return '@()';
+  return (
+    '(' +
+    words
+      .map((w) => {
+        const s = splatSpec(w);
+        if (!s) return '@(' + fn(w) + ')';
+        if (!s.prefix && !s.suffix) return '@(fx-arrload ' + psStr(s.name) + ')';
+        return (
+          '@($( $fx_sp = @(fx-arrload ' +
+          psStr(s.name) +
+          '); if ($fx_sp.Count -eq 0) { $fx_sp = @(' +
+          psStr(s.prefix + s.suffix) +
+          ') } else { $fx_sp[0] = ' +
+          psStr(s.prefix) +
+          ' + $fx_sp[0]; $fx_sp[$fx_sp.Count-1] = $fx_sp[$fx_sp.Count-1] + ' +
+          psStr(s.suffix) +
+          ' }; $fx_sp ))'
+        );
+      })
+      .join(' + ') +
+    ')'
+  );
 }
 
 /* ------------------------------------------------------------------ */
@@ -203,9 +274,26 @@ export function translateSimple(
   }
 
   const nameLit = literalOfWord(cmd.name);
+  const nameSplat = splatSpec(cmd.name);
 
   let body: string;
-  if (nameLit !== null) {
+  if (nameSplat) {
+    const invoke = '& $fx_cmd @fx_na';
+    body = [
+      '$fx_cw = @(fx-arrload ' + psStr(nameSplat.name) + ')',
+      'if ($fx_cw.Count -eq 0) { $fx_cw = @(' + psStr(nameSplat.prefix + nameSplat.suffix) + ') }',
+      'else { $fx_cw[0] = ' +
+        psStr(nameSplat.prefix) +
+        ' + $fx_cw[0]; $fx_cw[$fx_cw.Count-1] = $fx_cw[$fx_cw.Count-1] + ' +
+        psStr(nameSplat.suffix) +
+        ' }',
+      '$fx_cmd = [string]$fx_cw[0]',
+      '$fx_na = ' + argListExpr(cmd.args),
+      'if ($fx_cw.Count -gt 1) { $fx_na = @($fx_cw[1..($fx_cw.Count - 1)]) + $fx_na }',
+      (hasStdin ? '($input | ' + invoke + ')' : invoke) + ' | ForEach-Object { [string]$_ }',
+      'if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 }',
+    ].join('\n');
+  } else if (nameLit !== null) {
     const handler = lookup(nameLit);
     if (handler && !(nameLit === '[[' && !isUnquotedLiteral(cmd.name, '[['))) {
       body = handler(cmd.args, { position, hasStdin });
@@ -214,23 +302,21 @@ export function translateSimple(
       // invoked with the call operator and an argv-style argument array —
       // no string re-parsing of user text.
       const nameExpr = psStr(nameLit);
-      const argExprs = cmd.args.map((a) => exprOfWord(a));
-      const args = argExprs.length ? ' @(' + argExprs.join(', ') + ')' : '';
-      const call = '& ' + nameExpr + args;
+      const invoke = '& ' + nameExpr + ' @fx_na';
       body = [
+        '$fx_na = ' + argListExpr(cmd.args),
         // feed pipeline stdin into the native process when we are a non-first stage
-        (hasStdin ? '($input | ' + call + ')' : call) + ' | ForEach-Object { [string]$_ }',
+        (hasStdin ? '($input | ' + invoke + ')' : invoke) + ' | ForEach-Object { [string]$_ }',
         'if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 }',
       ].join('\n');
     }
   } else {
     // dynamic command name — evaluate it
     const nameExpr = exprOfWord(cmd.name);
-    const argExprs = cmd.args.map((a) => exprOfWord(a));
-    const args = argExprs.length ? ' @(' + argExprs.join(', ') + ')' : '';
-    const call = '& (' + nameExpr + ')' + args;
+    const invoke = '& (' + nameExpr + ') @fx_na';
     body = [
-      (hasStdin ? '($input | ' + call + ')' : call) + ' | ForEach-Object { [string]$_ }',
+      '$fx_na = ' + argListExpr(cmd.args),
+      (hasStdin ? '($input | ' + invoke + ')' : invoke) + ' | ForEach-Object { [string]$_ }',
       'if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 }',
     ].join('\n');
   }
@@ -312,12 +398,15 @@ export function wrapTempEnv(
     }
   }
   if (names.length === 0) return body;
+  const assigned = new Set(sets.map((s) => s.name));
 
   const id = tempEnvSeq++;
   const save = '$fx_es' + id;
+  const arrSave = '$fx_ar' + id;
   const keep = persistWords && persistWords.length > 0 ? '$fx_ek' + id : '';
   const lines: string[] = [
     save + ' = @{}',
+    arrSave + ' = @{}',
     '$fx_sv0' + id + ' = $env:FAUXNIX_SETVARS',
     '$fx_uv0' + id + ' = $env:FAUXNIX_UNSETVARS',
     '$fx_xv0' + id + ' = $env:FAUXNIX_SETVALS',
@@ -334,6 +423,7 @@ export function wrapTempEnv(
         p +
         ').Value } else { $null })',
     );
+    lines.push(arrSave + '[' + psStr(n) + '] = (fx-arrpackget ' + psStr(n) + ')');
   }
   const valVars: string[] = [];
   for (let i = 0; i < sets.length; i++) {
@@ -347,6 +437,7 @@ export function wrapTempEnv(
     lines.push(
       '  Remove-Item -LiteralPath ' + psStr('Env:\\' + u) + ' -ErrorAction SilentlyContinue',
     );
+    lines.push('  fx-arrdrop ' + psStr(u));
     // `env -u NAME` must hide NAME from fx-envget / fx-isset for the
     // wrapped body. Removing Env:\NAME is not enough: an earlier
     // `export NAME=x` still lives in SETVARS/SETVALS, and special
@@ -373,6 +464,7 @@ export function wrapTempEnv(
     const n = sets[i].name;
     const nq = n.replace(/'/g, "''");
     lines.push('  $env:' + n + ' = ' + valVars[i]);
+    lines.push('  fx-arrdrop ' + psStr(n));
     lines.push(
       "  $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne '" +
         nq +
@@ -459,8 +551,13 @@ export function wrapTempEnv(
           '] }',
       );
     }
+    const restoreArr = 'fx-arrpackset ' + psStr(n) + ' ' + arrSave + '[' + psStr(n) + ']';
+    if (keep) {
+      lines.push('  if (-not $fx_skip) { ' + restoreArr + ' }');
+    } else {
+      lines.push('  ' + restoreArr);
+    }
   }
-  const assigned = new Set(sets.map((s) => s.name));
   for (const n of persistNames) {
     const nq = n.replace(/'/g, "''");
     const ep = psStr('Env:\\' + n);
@@ -649,6 +746,133 @@ export function wrapScript(body: string): string {
     "  if ($parts.Count -eq 1 -and $parts[0] -eq '') { return @() }",
     "  if ($parts[$parts.Count - 1] -eq '') { $parts = $parts[0..($parts.Count - 2)] }",
     '  return $parts',
+    '}',
+    'function fx-svenc($s) {',
+    '  return ([string]$s).Replace([string][char]92, ([string][char]92 + [string][char]92)).Replace([string][char]13, ([string][char]92 + [char]114)).Replace([string][char]10, ([string][char]92 + [char]110))',
+    '}',
+    'function fx-svdec($s) {',
+    '  $s = [string]$s',
+    '  $sb = New-Object System.Text.StringBuilder',
+    '  $i = 0',
+    '  while ($i -lt $s.Length) {',
+    '    $c = $s[$i]',
+    '    if ($c -eq [char]92 -and ($i + 1) -lt $s.Length) {',
+    '      $n2 = $s[$i + 1]',
+    '      if ($n2 -eq [char]110) { [void]$sb.Append([char]10); $i += 2; continue }',
+    '      if ($n2 -eq [char]114) { [void]$sb.Append([char]13); $i += 2; continue }',
+    '      if ($n2 -eq [char]92) { [void]$sb.Append([char]92); $i += 2; continue }',
+    '    }',
+    '    [void]$sb.Append($c)',
+    '    $i++',
+    '  }',
+    '  return [string]$sb',
+    '}',
+    'function fx-arrload($n) {',
+    '  $n = [string]$n',
+    '  foreach ($fx_pair in @($env:FAUXNIX_ARRS -split [string][char]10)) {',
+    '    $fx_eq = $fx_pair.IndexOf([char]61)',
+    '    if ($fx_eq -lt 1) { continue }',
+    '    if ($fx_pair.Substring(0, $fx_eq) -cne $n) { continue }',
+    '    $out = @()',
+    '    foreach ($el in @($fx_pair.Substring($fx_eq + 1) -split [string][char]30)) { $out += ,(fx-svdec $el) }',
+    '    return $out',
+    '  }',
+    '  $s0 = fx-scalar0 $n',
+    '  if ($null -eq $s0) { return @() }',
+    '  return @([string]$s0)',
+    '}',
+    'function fx-scalar0($n) {',
+    '  $n = [string]$n',
+    "  if (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ceq $n }).Count -gt 0) { return $null }",
+    '  foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) {',
+    '    $fx_eq = $fx_pair.IndexOf([char]61)',
+    '    if ($fx_eq -lt 1) { continue }',
+    '    if ($fx_pair.Substring(0, $fx_eq) -ceq $n) { return (fx-svdec $fx_pair.Substring($fx_eq + 1)) }',
+    '  }',
+    "  if ($n -ceq 'HOME') { return [string]$HOME }",
+    "  if ($n -ceq 'PWD') { return [string]$PWD.Path }",
+    "  if ($n -ceq 'USER' -or $n -ceq 'LOGNAME') { return [string]$env:USERNAME }",
+    "  if ($n -ceq 'PATH') { return [string]$env:PATH }",
+    "  if ($n -ceq 'SHELL') { return 'powershell' }",
+    "  if ($n -ceq 'TERM') { return 'xterm-256color' }",
+    "  if ($n -ceq 'OLDPWD') { return $(if ($env:FAUXNIX_OLDPWD) { [string]$env:FAUXNIX_OLDPWD } else { $null }) }",
+    "  if ($n -ceq 'HOSTNAME') { return [string]$env:COMPUTERNAME }",
+    '  $ev = Get-ChildItem Env: | Where-Object { $_.Name -ceq $n } | Select-Object -First 1',
+    '  if ($ev) { return [string]$ev.Value }',
+    '  return $null',
+    '}',
+    'function fx-ifs1 {',
+    "  $s = fx-scalar0 'IFS'",
+    "  if ($null -eq $s) { return ' ' }",
+    "  if ([string]$s -eq '') { return '' }",
+    '  return [string]$s[0]',
+    '}',
+    'function fx-arrdrop($n) {',
+    '  $n = [string]$n',
+    '  $fx_sm = @()',
+    '  foreach ($fx_pair in @($env:FAUXNIX_ARRS -split [string][char]10)) {',
+    '    $fx_eq = $fx_pair.IndexOf([char]61)',
+    '    if ($fx_eq -lt 1) { continue }',
+    '    if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sm += $fx_pair }',
+    '  }',
+    '  $env:FAUXNIX_ARRS = ($fx_sm -join [string][char]10)',
+    '}',
+    'function fx-arrhas($n) {',
+    '  $n = [string]$n',
+    '  foreach ($fx_pair in @($env:FAUXNIX_ARRS -split [string][char]10)) {',
+    '    $fx_eq = $fx_pair.IndexOf([char]61)',
+    '    if ($fx_eq -lt 1) { continue }',
+    '    if ($fx_pair.Substring(0, $fx_eq) -ceq $n) { return $true }',
+    '  }',
+    '  return $false',
+    '}',
+    'function fx-arrpackget($n) {',
+    '  $n = [string]$n',
+    '  foreach ($fx_pair in @($env:FAUXNIX_ARRS -split [string][char]10)) {',
+    '    $fx_eq = $fx_pair.IndexOf([char]61)',
+    '    if ($fx_eq -lt 1) { continue }',
+    '    if ($fx_pair.Substring(0, $fx_eq) -ceq $n) { return $fx_pair.Substring($fx_eq + 1) }',
+    '  }',
+    '  return $null',
+    '}',
+    'function fx-arrpackset($n, $pay) {',
+    '  fx-arrdrop $n',
+    '  if ($null -eq $pay) { return }',
+    "  $env:FAUXNIX_ARRS = ((@($env:FAUXNIX_ARRS -split [string][char]10 | Where-Object { $_ -ne '' }) + ([string]$n + [string][char]61 + [string]$pay)) -join [string][char]10)",
+    '}',
+    'function fx-arrput($n, $vals) {',
+    '  $n = [string]$n',
+    '  $vals = @($vals)',
+    '  fx-arrdrop $n',
+    '  if ($vals.Count -eq 0) { } else {',
+    '    $encs = @(); foreach ($v in $vals) { $encs += (fx-svenc $v) }',
+    "    $env:FAUXNIX_ARRS = ((@($env:FAUXNIX_ARRS -split [string][char]10 | Where-Object { $_ -ne '' }) + ($n + [string][char]61 + ($encs -join [string][char]30))) -join [string][char]10)",
+    '  }',
+    "  $fx_0 = $(if ($vals.Count -gt 0) { [string]$vals[0] } else { '' })",
+    '  Set-Item -LiteralPath (\'Env:\\\' + $n) -Value $fx_0',
+    "  $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",
+    "  $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
+    '  $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sv += $fx_pair } }',
+    "  $fx_sv += ($n + [string][char]61 + (fx-svenc $fx_0)); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
+    '}',
+    'function fx-arrclr($n) {',
+    '  $n = [string]$n',
+    '  fx-arrdrop $n',
+    "  Remove-Item -LiteralPath ('Env:\\' + $n) -ErrorAction SilentlyContinue",
+    "  $env:FAUXNIX_SETVARS = (@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
+    "  $env:FAUXNIX_UNSETVARS = ((@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",
+    '  $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sv += $fx_pair } }; $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)',
+    '}',
+    'function fx-subget($n, $ix) {',
+    '  $arr = @(fx-arrload $n)',
+    '  $ix = [string]$ix',
+    // argv-level `@` is expanded by argListExpr; this is the scalar/quoted-* join.
+    "  if ($ix -eq '*') { return ($arr -join (fx-ifs1)) }",
+    "  if ($ix -eq '@') { return ($arr -join (fx-ifs1)) }",
+    '  $i = 0',
+    '  if (-not [int]::TryParse($ix, [ref]$i)) { return \'\' }',
+    "  if ($i -lt 0 -or $i -ge $arr.Count) { return '' }",
+    '  return [string]$arr[$i]',
     '}',
     'try {',
     ...body.split('\n').map((l) => '  ' + l),

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -17,7 +17,7 @@ const hasPs =
   onWindows &&
   spawnSync('powershell.exe', ['-NoProfile', '-Command', 'exit 0'], { shell: false }).status === 0;
 
-describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
+describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () => {
   let dir: string;
   let session: FauxnixSession;
 
@@ -357,6 +357,46 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
     expect((await run("[[ 'a>b' =~ (a>b) ]]")).exitCode).toBe(0);
     expect((await run("[[ 'a&&b' =~ (a&&b) ]]")).exitCode).toBe(0);
     expect((await run('[[ abc =~ b ]]; echo "$BASH_REMATCH"')).stdout.trim()).toBe('b');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${BASH_REMATCH[0]}')).stdout.trim()).toBe('abc');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${BASH_REMATCH[1]}')).stdout.trim()).toBe('b');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${BASH_REMATCH[@]}')).stdout.trim()).toBe('abc b');
+    expect((await run("[[ abc =~ ^a(.)c$ ]]; printf '<%s>\\n' \"${BASH_REMATCH[@]}\"")).stdout).toBe(
+      '<abc>\n<b>\n',
+    );
+    expect((await run("[[ abc =~ ^a(.)c$ ]]; printf '<%s>\\n' \"${BASH_REMATCH[*]}\"")).stdout).toBe(
+      '<abc b>\n',
+    );
+    expect(
+      (await run('[[ abc =~ ^a(.)c$ ]]; unset BASH_REMATCH; echo ${BASH_REMATCH[0]}')).stdout.trim(),
+    ).toBe('');
+    expect(
+      (await run('[[ abc =~ ^a(.)c$ ]]; BASH_REMATCH=x; echo ${BASH_REMATCH[0]}; echo ${BASH_REMATCH[1]}')).stdout.trim(),
+    ).toBe('x');
+    expect((await run('[[ abc =~ z ]]; echo ${BASH_REMATCH[1]}')).stdout.trim()).toBe('');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; [[ -v BASH_REMATCH[1] ]]')).exitCode).toBe(0);
+    expect((await run('[[ x =~ ^ ]]; printf "<%s>\\n" "${BASH_REMATCH[@]}"')).stdout).toBe('<>\n');
+    expect(
+      (await run('[[ abc =~ ^a(.)c$ ]]; BASH_REMATCH=x true; echo ${BASH_REMATCH[1]}')).stdout.trim(),
+    ).toBe('b');
+    expect(
+      (await run("[[ abc =~ ^a(.)c$ ]]; printf '<%s>\\n' \"pre${BASH_REMATCH[@]}post\"")).stdout,
+    ).toBe('<preabc>\n<bpost>\n');
+    expect(
+      (await run('[[ abc =~ ^a(.)c$ ]]; bash_rematch=x; echo ${BASH_REMATCH[1]}; unset bash_rematch')).stdout.trim(),
+    ).toBe('b');
+    expect((await run('unset X; printf "<%s>\\n" "pre${X[@]}post"')).stdout).toBe('<prepost>\n');
+    expect((await run('echo ${PWD[0]}')).stdout.trim()).toBe(
+      (await run('echo $PWD')).stdout.trim(),
+    );
+    expect(
+      (await run('unset bash_rematch; [[ abc =~ ^a(.)c$ ]]; echo ${bash_rematch[0]}')).stdout.trim(),
+    ).toBe('');
+    expect(
+      (await run("IFS=','; [[ abc =~ ^a(.)c$ ]]; echo \"${BASH_REMATCH[*]}\"; unset IFS")).stdout.trim(),
+    ).toBe('abc,b');
+    expect(
+      (await run("[[ abc =~ ^a(.)c$ ]]; printf '<%s>\\n' pre\"${BASH_REMATCH[@]}\"post")).stdout,
+    ).toBe('<preabc>\n<bpost>\n');
     expect(
       (await run('export BASH_REMATCH=old; [[ abc =~ b ]]; [[ $BASH_REMATCH == b ]]; echo $?; unset BASH_REMATCH')).stdout.trim(),
     ).toBe('0');
@@ -412,6 +452,28 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
     ).toBe(0);
   }, 180000);
 
+  it('array subscripts splat across commands and persist correctly', async () => {
+    expect(
+      (
+        await run(
+          '[[ abc =~ ^a(.)c$ ]]; X=y export BASH_REMATCH=z; echo ${BASH_REMATCH[0]}; echo x${BASH_REMATCH[1]}x; unset BASH_REMATCH; unset X',
+        )
+      ).stdout.trim(),
+    ).toBe('z\nxx');
+    expect((await run('[[ echo =~ ^echo$ ]]; "${BASH_REMATCH[@]}" hi')).stdout.trim()).toBe('hi');
+    expect(
+      (await run("[[ abc =~ ^a(.)c$ ]]; printf '<%s>\\n' ${BASH_REMATCH[*]}")).stdout,
+    ).toBe('<abc>\n<b>\n');
+    expect(
+      (await run("IFS=; [[ abc =~ ^a(.)c$ ]]; echo \"${BASH_REMATCH[*]}\"; unset IFS")).stdout.trim(),
+    ).toBe('abcb');
+    expect((await run('[[ 3 =~ ^3$ ]]; seq "${BASH_REMATCH[@]}"')).stdout.trim()).toBe('1\n2\n3');
+    writeFileSync(join(dir, 'abc'), 'X', 'utf8');
+    writeFileSync(join(dir, 'b'), 'Y', 'utf8');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; cat "${BASH_REMATCH[@]}"')).stdout.trim()).toBe('X\nY');
+    await run('unset BASH_REMATCH');
+  }, 60000);
+
   it('&& and || short-circuit like bash', async () => {
     expect((await run('cat missing.txt || echo FELLBACK')).stdout).toContain('FELLBACK');
     const r = await run('cat missing.txt && echo NOPE ; echo END');
@@ -465,7 +527,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', () => {
       (await run('SA_Z=out; SA_Z=in [[ $SA_Z == in ]] && echo YES || echo NO')).stdout.trim(),
     ).toBe('YES');
     await run('unset SA_V SA_N SA_E SA_Z');
-  });
+  }, 20000);
 
   it('session cwd persists across calls', async () => {
     await run('cd sub');

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -5,6 +5,7 @@ import {
   exprOfWord,
   normalizeLiteralPath,
   pathExpr,
+  splatSpec,
   translateCommandList,
   varExpr,
   wrapScript,
@@ -67,6 +68,34 @@ describe('parser', () => {
     const cmd = parse('echo $(date +%Y)').segments[0].pipeline.commands[0];
     const parts = cmd.args[0];
     expect(parts.some((p) => p.kind === 'CmdSub' && p.cmd === 'date +%Y')).toBe(true);
+  });
+
+  it('parses ${name[index]} subscripts', () => {
+    const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
+    expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);
+    expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'PATH', index: '0' }]);
+    expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'x', index: '@' }]);
+  });
+
+  it('detects [@] splat through surrounding quotes', () => {
+    const cmd = parse('printf x pre"${a[@]}"post').segments[0].pipeline.commands[0];
+    expect(splatSpec(cmd.args[1])).toEqual({ name: 'a', prefix: 'pre', suffix: 'post' });
+  });
+
+  it('does not splat quoted ${name[*]}', () => {
+    const cmd = parse('printf x "${a[*]}"').segments[0].pipeline.commands[0];
+    expect(splatSpec(cmd.args[1])).toBeNull();
+  });
+
+  it('splats unquoted ${name[*]}', () => {
+    const cmd = parse('printf x ${a[*]}').segments[0].pipeline.commands[0];
+    expect(splatSpec(cmd.args[1])).toEqual({ name: 'a', prefix: '', suffix: '' });
+  });
+
+  it('indexes ${name[0]} through fx-subget, not $env:', () => {
+    expect(varExpr('bash_rematch', '0')).toContain('fx-subget');
+    expect(varExpr('bash_rematch', '0')).not.toMatch(/\$env:bash_rematch/i);
+    expect(varExpr('PWD', '0')).toContain('fx-subget');
   });
 
   it('rejects heredocs with a helpful message', () => {


### PR DESCRIPTION
Closes #84.
Supersedes #89 (same change, one commit).

## Why

`=~` already captured .NET `Groups`, but `$BASH_REMATCH` was scalar-only. Scripts that need `${BASH_REMATCH[1]}` had no expander for `${name[n]}`.

## What

- Parser accepts `${name[0]}`, `${name[1]}`, `${name[@]}`, `${name[*]}`
- Case-exact array sidecar `FAUXNIX_ARRS` (Windows env is case-insensitive)
- `fx-subget` / `fx-arrput` / `fx-arrload` so `echo` and `[[` both see groups
- Successful `=~` stores every capture group; a miss clears the array
- `${name[@]}` and unquoted `${name[*]}` splat to argv (prefix/suffix, empty affix)
- Quoted `${name[*]}` joins with the first `IFS` character
- Scalar assign / unset / `env` prefix restore the sidecar per name
- `${PWD[0]}` keeps the special mapping; `${bash_rematch[0]}` does not alias `BASH_REMATCH`

## Verification

- 110/110 tests, including real PowerShell integration