### PR TITLE
fix + release v0.4.0: repair #90×#91 typecheck break, bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Fauxnix — run Linux-style commands on Windows via deterministic PowerShell translation. No VM, no WSL. MCP server + CLI for AI agents.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ export async function runCli(argv: string[]): Promise<void> {
   const [verb, ...rest] = argv;
 
   if (verb === '--version' || verb === '-v') {
-    console.log('fauxnix 0.3.0');
+    console.log('fauxnix 0.4.0');
     return;
   }
 

--- a/src/commands/net.ts
+++ b/src/commands/net.ts
@@ -218,7 +218,7 @@ function mapWgetArgs(args: Word[]): WgetMap {
 }
 
 const wget: Handler = (args) => {
-  const orig = args.map(exprOfWord);
+  const orig = args.map((w) => exprOfWord(w));
   const mapped = mapWgetArgs(args);
   return [
     PS_NETGUARD_FNS,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -23,7 +23,7 @@ Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command n
 
 export async function startMcpServer(): Promise<void> {
   const server = new McpServer(
-    { name: 'fauxnix', version: '0.3.0' },
+    { name: 'fauxnix', version: '0.4.0' },
     { capabilities: { tools: {} } },
   );
   const session = new FauxnixSession();


### PR DESCRIPTION
## Hotfix
main CI is red at 3fd7fe1: #90 added `args.map(exprOfWord)` (net.ts) while #91 added an `opts` second parameter to `exprOfWord` — each PR green on its own tree, the merged combination broke typecheck (`Array.map` index misread as opts). Neither branch saw the other's change despite GitHub reporting MERGEABLE. This wraps the callback: `args.map((w) => exprOfWord(w))`.

## Release v0.4.0
Ships the RFC #81 'Next' roadmap: #90 (subscript expansion + BASH_REMATCH arrays, closes #84), #91 (cmdsub newline contract, closes #83). 111/111, differential vs real bash 52/53.

This PR doubles as the integration gate CONTRIBUTING.md mandates — and this time it caught a real combined-tree break within minutes of it reaching main.