### PR TITLE
docs(blog): fix alt-title error count to match benchmark table

### DIFF
--- a/docs/promotion/blog-benchmark-en.md
+++ b/docs/promotion/blog-benchmark-en.md
@@ -4,7 +4,7 @@
 
 **HN title:** Show HN: Fauxnix – bash for AI agents on Windows, no WSL (measured the PS tax first)
 
-**Alt title:** We benchmarked DeepSeek-V4-Pro writing PowerShell: 2.5× slower, 24 error events
+**Alt title:** We benchmarked DeepSeek-V4-Pro writing PowerShell: 2.5× slower, 14 error events (vs 0 in bash mode)
 
 ---
 


### PR DESCRIPTION
Codex Review on #94 caught a real misattribution: the EN draft's alt headline said "24 error events" for DeepSeek-V4-Pro, but per the table in the same draft that count belongs to kimi-k2-thinking (26 / 24 / 302s); deepseek-v4-pro is 15 calls / 14 errors / 174s.

Alt headline now reads `2.5× slower, 14 error events (vs 0 in bash mode)` — the 2.5× figure was already correct (174s vs 70s).

ZH draft checked: no equivalent issue.