### PR TITLE
ci: raise integration beforeAll hook timeout to 60s

### DIFF
--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -31,7 +31,9 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     session = new FauxnixSession();
     // seed the session cwd like a real shell login directory
     await session.run(translateCommandList(parseCommand('cd "' + dir + '"')));
-  });
+    // cold runner disks can take >10s (default hookTimeout) to spawn the first
+    // PowerShell session — seen as a false red on CI twice
+  }, 60000);
 
   afterAll(async () => {
     await session.dispose();


### PR DESCRIPTION
Cold GitHub Windows runners have twice (PR #96 first run) failed the integration suite in its `beforeAll` with 'Hook timed out in 10000ms' — 47 tests skipped, suite red before any test ran, unrelated to the diff, green on rerun. The describe-level `timeout: 30000` covers test cases, not hooks; this passes an explicit 60000 to the hook.