### PR TITLE
docs: add Glama score badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![npm version](https://img.shields.io/npm/v/fauxnix-cli.svg)](https://www.npmjs.com/package/fauxnix-cli)
 [![npm downloads](https://img.shields.io/npm/dt/fauxnix-cli.svg)](https://www.npmjs.com/package/fauxnix-cli)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![20000419/fauxnix MCP server](https://glama.ai/mcp/servers/20000419/fauxnix/badges/score.svg)](https://glama.ai/mcp/servers/20000419/fauxnix)
 
 **Run Linux-style commands on Windows — natively, deterministically, with no VM and no WSL.**
 

--- a/docs/promotion/targets.md
+++ b/docs/promotion/targets.md
@@ -52,9 +52,11 @@ fauxnix = `bash` MCP tool, keeps their model choice free.
   2026-08-30. (A first attempt was aborted on their permission gate before any
   PR landed — no cleanup needed.)
 - **Smithery** (smithery.ai) — `npx @smithery/cli register` flow
-- **Glama** — approved & listed (see above); pending: claim + Dockerfile checks.
-  Score page gaps: no Glama release yet (blocks tool-quality scoring), profile
-  25%, no recent usage.
+- **Glama** — ✅ **fully evaluated 2026-08-18**: Server Coherence A, Tool
+  Definition Quality A (bash 4.6/5.0, session 4.3, translate 4.2), Maintenance
+  A, profile 100%, active usage recorded. Score + card badges render. Docker
+  checks pass (Debian build via mcp-proxy; bash tool answers with the honest
+  platform error there — execution is Windows-only by design).
 - **PulseMCP**, **mcp.so** — web submit forms
 
 ## Tier 2 — community hubs (announce once, answer questions)


### PR DESCRIPTION
Glama finished evaluating fauxnix — all A grades (Coherence A, Tool Definition Quality A with bash at 4.6/5.0, Maintenance A), profile 100%. Adds the score badge to the README badge row and records the result in docs/promotion/targets.md.