### PR TITLE
fix: promote the next word when command-position [@] is empty

### DIFF
--- a/src/translator.ts
+++ b/src/translator.ts
@@ -299,17 +299,35 @@ export function translateSimple(
     const invoke = '& $fx_cmd @fx_na';
     body = [
       '$fx_cw = @(fx-arrload ' + psStr(nameSplat.name) + ')',
-      'if ($fx_cw.Count -eq 0) { $fx_cw = @(' + psStr(nameSplat.prefix + nameSplat.suffix) + ') }',
-      'else { $fx_cw[0] = ' +
+      'if ($fx_cw.Count -eq 0) {',
+      // Empty ${X[@]} in command position is removed; bash promotes the
+      // next word. Only synthesize an empty command when an affix remains.
+      '  if (' +
+        (nameSplat.prefix || nameSplat.suffix ? '$true' : '$false') +
+        ') { $fx_cw = @(' +
+        psStr(nameSplat.prefix + nameSplat.suffix) +
+        ') }',
+      '} else { $fx_cw[0] = ' +
         psStr(nameSplat.prefix) +
         ' + $fx_cw[0]; $fx_cw[$fx_cw.Count-1] = $fx_cw[$fx_cw.Count-1] + ' +
         psStr(nameSplat.suffix) +
         ' }',
-      '$fx_cmd = [string]$fx_cw[0]',
       '$fx_na = ' + argListExpr(cmd.args),
-      'if ($fx_cw.Count -gt 1) { $fx_na = @($fx_cw[1..($fx_cw.Count - 1)]) + $fx_na }',
-      (hasStdin ? '($input | ' + invoke + ')' : invoke) + ' | ForEach-Object { [string]$_ }',
-      'if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 }',
+      'if ($fx_cw.Count -eq 0) {',
+      "  if ($fx_na.Count -eq 0) { [Console]::Error.WriteLine('bash: : command not found'); $script:fx_exit = 127 }",
+      '  else { $fx_cmd = [string]$fx_na[0]; if ($fx_na.Count -gt 1) { $fx_na = @($fx_na[1..($fx_na.Count - 1)]) } else { $fx_na = @() }',
+      '    ' +
+        (hasStdin ? '($input | & $fx_cmd @fx_na)' : '& $fx_cmd @fx_na') +
+        ' | ForEach-Object { [string]$_ }',
+      '    if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 } }',
+      '} else {',
+      '  $fx_cmd = [string]$fx_cw[0]',
+      '  if ($fx_cw.Count -gt 1) { $fx_na = @($fx_cw[1..($fx_cw.Count - 1)]) + $fx_na }',
+      '  ' +
+        (hasStdin ? '($input | ' + invoke + ')' : invoke) +
+        ' | ForEach-Object { [string]$_ }',
+      '  if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 }',
+      '}',
     ].join('\n');
   } else if (nameLit !== null) {
     const handler = lookup(nameLit);

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -273,6 +273,13 @@ export function translateCmdSub(cmdText: string, keepNl = false): string {
 /* Simple command translation                                          */
 /* ------------------------------------------------------------------ */
 
+function indentBlock(s: string): string {
+  return s
+    .split('\n')
+    .map((l) => (l ? '  ' + l : l))
+    .join('\n');
+}
+
 export function translateSimple(
   cmd: SimpleCommand,
   position: PipelineCtx['position'],
@@ -297,30 +304,42 @@ export function translateSimple(
   let body: string;
   if (nameSplat) {
     const invoke = '& $fx_cmd @fx_na';
-    body = [
+    const hasAffix = !!(nameSplat.prefix || nameSplat.suffix);
+    const promoted =
+      cmd.args.length === 0
+        ? ''
+        : translateSimple(
+            {
+              kind: 'SimpleCommand',
+              assignments: [],
+              name: cmd.args[0],
+              args: cmd.args.slice(1),
+              redirects: cmd.redirects,
+            },
+            position,
+            hasStdin,
+          );
+    const emptyCmdLines: string[] = [
       '$fx_cw = @(fx-arrload ' + psStr(nameSplat.name) + ')',
+    ];
+    if (hasAffix) {
+      emptyCmdLines.push(
+        'if ($fx_cw.Count -eq 0) { $fx_cw = @(' +
+          psStr(nameSplat.prefix + nameSplat.suffix) +
+          ') } else { $fx_cw[0] = ' +
+          psStr(nameSplat.prefix) +
+          ' + $fx_cw[0]; $fx_cw[$fx_cw.Count-1] = $fx_cw[$fx_cw.Count-1] + ' +
+          psStr(nameSplat.suffix) +
+          ' }',
+      );
+    }
+    emptyCmdLines.push(
       'if ($fx_cw.Count -eq 0) {',
-      // Empty ${X[@]} in command position is removed; bash promotes the
-      // next word. Only synthesize an empty command when an affix remains.
-      '  if (' +
-        (nameSplat.prefix || nameSplat.suffix ? '$true' : '$false') +
-        ') { $fx_cw = @(' +
-        psStr(nameSplat.prefix + nameSplat.suffix) +
-        ') }',
-      '} else { $fx_cw[0] = ' +
-        psStr(nameSplat.prefix) +
-        ' + $fx_cw[0]; $fx_cw[$fx_cw.Count-1] = $fx_cw[$fx_cw.Count-1] + ' +
-        psStr(nameSplat.suffix) +
-        ' }',
-      '$fx_na = ' + argListExpr(cmd.args),
-      'if ($fx_cw.Count -eq 0) {',
-      "  if ($fx_na.Count -eq 0) { [Console]::Error.WriteLine('bash: : command not found'); $script:fx_exit = 127 }",
-      '  else { $fx_cmd = [string]$fx_na[0]; if ($fx_na.Count -gt 1) { $fx_na = @($fx_na[1..($fx_na.Count - 1)]) } else { $fx_na = @() }',
-      '    ' +
-        (hasStdin ? '($input | & $fx_cmd @fx_na)' : '& $fx_cmd @fx_na') +
-        ' | ForEach-Object { [string]$_ }',
-      '    if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 } }',
+      // No words left → bash null command (exit 0). Remaining words are
+      // known at compile time, so reuse translateSimple (handlers, not `&`).
+      promoted ? indentBlock(promoted) : '  ',
       '} else {',
+      '  $fx_na = [object[]]@(' + argListExpr(cmd.args) + ')',
       '  $fx_cmd = [string]$fx_cw[0]',
       '  if ($fx_cw.Count -gt 1) { $fx_na = @($fx_cw[1..($fx_cw.Count - 1)]) + $fx_na }',
       '  ' +
@@ -328,7 +347,8 @@ export function translateSimple(
         ' | ForEach-Object { [string]$_ }',
       '  if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 }',
       '}',
-    ].join('\n');
+    );
+    body = emptyCmdLines.join('\n');
   } else if (nameLit !== null) {
     const handler = lookup(nameLit);
     if (handler && !(nameLit === '[[' && !isUnquotedLiteral(cmd.name, '[['))) {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -474,6 +474,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     writeFileSync(join(dir, 'b'), 'Y', 'utf8');
     expect((await run('[[ abc =~ ^a(.)c$ ]]; cat "${BASH_REMATCH[@]}"')).stdout.trim()).toBe('X\nY');
     await run('unset BASH_REMATCH');
+    expect((await run('unset X; ${X[@]} echo ok')).stdout.trim()).toBe('ok');
   }, 60000);
 
   it('&& and || short-circuit like bash', async () => {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -474,7 +474,9 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     writeFileSync(join(dir, 'b'), 'Y', 'utf8');
     expect((await run('[[ abc =~ ^a(.)c$ ]]; cat "${BASH_REMATCH[@]}"')).stdout.trim()).toBe('X\nY');
     await run('unset BASH_REMATCH');
+    expect((await run('unset X; ${X[@]}')).exitCode).toBe(0);
     expect((await run('unset X; ${X[@]} echo ok')).stdout.trim()).toBe('ok');
+    expect((await run('unset X; ${X[@]} printf %s hi')).stdout).toBe('hi');
   }, 60000);
 
   it('&& and || short-circuit like bash', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -98,6 +98,12 @@ describe('parser', () => {
     expect(splatSpec(cmd.args[1])).toBeNull();
   });
 
+  it('promotes the next word when a command-position [@] is empty', () => {
+    const script = translateCommandList(parse('${X[@]} echo ok'))[0].script;
+    expect(script).toContain('$fx_na.Count -eq 0');
+    expect(script).toContain('$fx_cmd = [string]$fx_na[0]');
+  });
+
   it('splats unquoted ${name[*]}', () => {
     const cmd = parse('printf x ${a[*]}').segments[0].pipeline.commands[0];
     expect(splatSpec(cmd.args[1])).toEqual({ name: 'a', prefix: '', suffix: '' });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -99,9 +99,12 @@ describe('parser', () => {
   });
 
   it('promotes the next word when a command-position [@] is empty', () => {
-    const script = translateCommandList(parse('${X[@]} echo ok'))[0].script;
-    expect(script).toContain('$fx_na.Count -eq 0');
-    expect(script).toContain('$fx_cmd = [string]$fx_na[0]');
+    const empty = translateCommandList(parse('${X[@]}'))[0].script;
+    expect(empty).toContain('if ($fx_cw.Count -eq 0)');
+    expect(empty).not.toContain("bash: : command not found");
+    const one = translateCommandList(parse('${X[@]} printf %s hi'))[0].script;
+    expect(one).toContain('fx-printf');
+    expect(one).toContain('[object[]]');
   });
 
   it('splats unquoted ${name[*]}', () => {


### PR DESCRIPTION
Part of the agent script-surface series (RFC to follow).

## Why

After `unset X`, bash runs `${X[@]} echo ok` as `echo ok`. fauxnix synthesized an empty command name and reported command-not-found.

## What

- Empty array in command position with no affix: promote argv[0]
- Nonempty prefix/suffix still becomes a single `pre+post` command word
- Zero remaining words: `bash: : command not found` (127)

## Verification

- Unit: generated script contains the promote branch
- Integration: `unset X; ${X[@]} echo ok` → `ok`