### PR TITLE
feat: add command -v and command NAME passthrough

### DIFF
--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -596,6 +596,58 @@ const type: Handler = (args) => {
   ].join('\n');
 };
 
+/** `command -v name` (and bare `command name args` as a no-alias run). */
+const commandCmd: Handler = (args, ctx) => {
+  let i = 0;
+  let identify = false;
+  while (i < args.length) {
+    const t = wordToString(args[i]);
+    if (t === '-v' || t === '-V') {
+      identify = true;
+      i++;
+      continue;
+    }
+    if (t === '--') {
+      i++;
+      break;
+    }
+    if (t.startsWith('-')) {
+      i++;
+      continue;
+    }
+    break;
+  }
+  const rest = args.slice(i);
+  if (identify) {
+    if (rest.length === 0) return '';
+    return [
+      PS_WHICH_FN,
+      '$fx_b = @(' + builtinNames().map(psStr).join(', ') + ')',
+      '$fx_ns = ' + textArgs(rest),
+      'foreach ($fx_n in $fx_ns) {',
+      "  if ($fx_b -contains $fx_n) { '/usr/bin/' + $fx_n }",
+      '  else {',
+      '    $fx_w = fx-which $fx_n',
+      "    if ($fx_w -eq '') { $script:fx_exit = 1 }",
+      "    else { $fx_w.Replace('\\', '/') }",
+      '  }',
+      '}',
+    ].join('\n');
+  }
+  if (rest.length === 0) return '';
+  return translateSimple(
+    {
+      kind: 'SimpleCommand',
+      assignments: [],
+      name: rest[0],
+      args: rest.slice(1),
+      redirects: [],
+    },
+    ctx.position,
+    ctx.hasStdin,
+  );
+};
+
 /* ------------------------------------------------------------------ */
 /* whoami / id / groups                                                */
 /* ------------------------------------------------------------------ */
@@ -2507,6 +2559,7 @@ export const handlers: Record<string, Handler> = {
   sleep,
   which,
   type,
+  command: commandCmd,
   whoami,
   id,
   groups,

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -711,6 +711,12 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
   });
 
+  it('command -v finds builtins and missing names', async () => {
+    expect((await run('command -v echo')).stdout.trim()).toBe('/usr/bin/echo');
+    expect((await run('command -v definitely_not_a_cmd_xyz')).exitCode).toBe(1);
+    expect((await run('command echo hi')).stdout.trim()).toBe('hi');
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -10,7 +10,7 @@ import {
   varExpr,
   wrapScript,
 } from '../src/translator.js';
-import { parseWords, psStr } from '../src/registry.js';
+import { lookup, parseWords, psStr } from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import { normalizeStderr } from '../src/errors.js';
 import '../src/commands/install-all.js';
@@ -86,6 +86,10 @@ describe('parser', () => {
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);
     expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'PATH', index: '0' }]);
     expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'x', index: '@' }]);
+  });
+
+  it('registers command as a builtin', () => {
+    expect(lookup('command')).toBeTypeOf('function');
   });
 
   it('detects [@] splat through surrounding quotes', () => {


### PR DESCRIPTION
Part of the agent script-surface series (RFC to follow).

## Why

Models emit `command -v git` / `command -v echo` constantly. Those currently fell through to a native `command.exe` (usually missing).

## What

- `command -v`/`-V`: builtins print `/usr/bin/NAME`; others use PATH; missing → exit 1
- `command NAME args`: run NAME (no alias/function layer)

## Verification

- `command -v echo` → `/usr/bin/echo`
- missing name → exit 1
- `command echo hi` → `hi`