### PR TITLE
fix: refuse set -e/-u/-x instead of silently ignoring them

### DIFF
--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -2489,7 +2489,35 @@ const alias: Handler = (args) => {
   return "[Console]::Error.WriteLine('fauxnix: alias is not supported'); $script:fx_exit = 1";
 };
 
-const set: Handler = () => ''; // silently ignore (`set -e`, `set --` ... no-op)
+const set: Handler = (args) => {
+  const raw = args.map(wordToString);
+  const unsupported = raw.filter(
+    (t) =>
+      t === '-e' ||
+      t === '-u' ||
+      t === '-x' ||
+      t === '-o' ||
+      t === '+e' ||
+      t === '+u' ||
+      t === '+x' ||
+      t.startsWith('-o') ||
+      t.startsWith('+o') ||
+      t === '-eu' ||
+      t === '-ue' ||
+      t === '-eux' ||
+      /^-.*[eux]/.test(t),
+  );
+  if (unsupported.length > 0) {
+    return (
+      '[Console]::Error.WriteLine(' +
+      psStr(
+        'fauxnix: set -e/-u/-x is not supported (would silently lie); use explicit || exit',
+      ) +
+      '); $script:fx_exit = 2'
+    );
+  }
+  return '';
+};
 
 /* ------------------------------------------------------------------ */
 

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -711,6 +711,13 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
   });
 
+  it('set -e fails loudly instead of no-op', async () => {
+    const r = await run('set -e');
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/set -e\/-u\/-x is not supported/);
+    expect((await run('set --')).exitCode).toBe(0);
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -81,6 +81,12 @@ describe('parser', () => {
     expect(exprOfWord(a.assignments[0].value, { preserveCmdSub: true })).not.toContain("-join ' '");
   });
 
+  it('set -e is a loud usage error, not a silent no-op', () => {
+    const script = translateCommandList(parse('set -e'))[0].script;
+    expect(script).toMatch(/set -e\/-u\/-x is not supported/);
+    expect(script).toContain('$script:fx_exit = 2');
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);


### PR DESCRIPTION
Part of the agent script-surface series (RFC to follow).

## Why

fauxnix's charter is fail-loudly. `set -e` was a silent no-op, so agents believed errexit was enabled.

## What

- `set -e`/`-u`/`-x` (and clustered `-eu`) → stderr + exit 2
- Bare `set` and `set --` remain no-ops

## Verification

- `set -e` exit 2 and mentions the unsupported flags
- `set --` exit 0