### PR TITLE
feat: expand name:-word name:+word name:?word

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -64,7 +64,13 @@ export type WordPart =
   | { kind: 'Text'; text: string; escaped?: boolean }
   | { kind: 'SingleQuoted'; text: string }
   | { kind: 'DoubleQuoted'; parts: WordPart[] }
-  | { kind: 'Var'; name: string; index?: string }
+  | {
+      kind: 'Var';
+      name: string;
+      index?: string;
+      /** `${name:-word}` / `${name:+word}` / `${name:?word}` (and non-colon). */
+      param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string };
+    }
   | { kind: 'CmdSub'; cmd: string };
 
 export function wordToString(w: Word): string {

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -11,6 +11,7 @@ import {
   translateCmdSub,
   normalizeLiteralPath,
   pathExpr,
+  paramExpr,
 } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
@@ -1487,6 +1488,9 @@ function kshExprOfWord(w: Word): string {
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
+    if (expanded[0].param) {
+      return paramExpr(expanded[0].name, expanded[0].param.op, expanded[0].param.word);
+    }
     if (expanded[0].index !== undefined) {
       return '(fx-subget ' + psStr(expanded[0].name) + ' ' + psStr(expanded[0].index) + ')';
     }
@@ -1511,7 +1515,9 @@ function kshExprOfWord(w: Word): string {
         break;
       case 'Var':
         out +=
-          p.index !== undefined
+          p.param
+            ? '$(' + paramExpr(p.name, p.param.op, p.param.word) + ')'
+            : p.index !== undefined
             ? '$(fx-subget ' + psStr(p.name) + ' ' + psStr(p.index) + ')'
             : '$(fx-envget ' + psStr(p.name) + ')';
         break;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -245,8 +245,16 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     if (sub) {
       return { part: { kind: 'Var', name: sub[1], index: sub[2] }, next: end + 1 };
     }
+    const pm = name.match(/^([A-Za-z_][A-Za-z0-9_]*)(:?[-+?])(.*)$/);
+    if (pm) {
+      const op = pm[2] as ':-' | ':+' | ':?' | '-' | '+' | '?';
+      return {
+        part: { kind: 'Var', name: pm[1], param: { op, word: pm[3] } },
+        next: end + 1,
+      };
+    }
     if (!name || !isNameStart(name[0]) || !name.split('').every(isNameChar)) {
-      // ${VAR:-default} etc. — unsupported, kept as raw text
+      // ${VAR:=default} etc. still raw text
       return { part: { kind: 'Text', text: input.slice(i, end + 1) }, next: end + 1 };
     }
     return { part: { kind: 'Var', name }, next: end + 1 };

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -15,8 +15,55 @@ import { PipelineCtx, lookup, psStr } from './registry.js';
 /* Variable mapping                                                    */
 /* ------------------------------------------------------------------ */
 
+function paramWordExpr(word: string): string {
+  if (word.startsWith('$') && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(word)) {
+    return varExpr(word.slice(1));
+  }
+  return psStr(word);
+}
+
+/** `${name:-word}` and friends using case-exact fx-scalar0. */
+export function paramExpr(
+  name: string,
+  op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?',
+  word: string,
+): string {
+  const alt = paramWordExpr(word);
+  const get = '(fx-scalar0 ' + psStr(name) + ')';
+  const empty = '($null -eq $fx_pv -or [string]$fx_pv -eq \'\')';
+  const unset = '($null -eq $fx_pv)';
+  if (op === ':-') {
+    return '$( $fx_pv = ' + get + '; if (' + empty + ') { ' + alt + ' } else { $fx_pv } )';
+  }
+  if (op === '-') {
+    return '$( $fx_pv = ' + get + '; if (' + unset + ') { ' + alt + ' } else { $fx_pv } )';
+  }
+  if (op === ':+') {
+    return '$( $fx_pv = ' + get + '; if (' + empty + ') { \'\' } else { ' + alt + ' } )';
+  }
+  if (op === '+') {
+    return '$( $fx_pv = ' + get + '; if (' + unset + ') { \'\' } else { ' + alt + ' } )';
+  }
+  const msg = word === '' ? name + ': parameter null or not set' : name + ': ' + word;
+  const cond = op === ':?' ? empty : unset;
+  return (
+    '$( $fx_pv = ' +
+    get +
+    '; if (' +
+    cond +
+    ') { [Console]::Error.WriteLine(' +
+    psStr('bash: ' + msg) +
+    '); $script:fx_exit = 1; \'\' } else { $fx_pv } )'
+  );
+}
+
 /** Map a bash $VAR name to a PowerShell expression (usable inside $(...)). */
-export function varExpr(name: string, index?: string): string {
+export function varExpr(
+  name: string,
+  index?: string,
+  param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string },
+): string {
+  if (param) return paramExpr(name, param.op, param.word);
   // Indexed reads always go through fx-subget → fx-arrload → fx-scalar0 so
   // ${PWD[0]} keeps the special mapping and ${bash_rematch[0]} stays
   // case-exact (a `$env:name` fallback would alias BASH_REMATCH on Windows).
@@ -117,7 +164,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
 
   // single bare variable → bare expression
   if (expanded.length === 1 && expanded[0].kind === 'Var') {
-    return varExpr(expanded[0].name, expanded[0].index);
+    return varExpr(expanded[0].name, expanded[0].index, expanded[0].param);
   }
   // Bare `$(...)` must not sit inside a PS expandable string: the
   // substitution body contains `"` / `$_` that would break interpolation.
@@ -145,7 +192,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
         for (const q of p.parts) emitPart(q, true);
         break;
       case 'Var':
-        out += '$(' + varExpr(p.name, p.index) + ')';
+        out += '$(' + varExpr(p.name, p.index, p.param) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd, quoted || opts?.preserveCmdSub === true) + ')';

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -720,6 +720,17 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('command echo hi')).stdout.trim()).toBe('hi');
   });
 
+  it('${name:-word} and ${name:+word} follow bash empty/unset rules', async () => {
+    expect((await run('unset X; echo ${X:-def}')).stdout.trim()).toBe('def');
+    expect((await run('X=; echo ${X:-def}; unset X')).stdout.trim()).toBe('def');
+    expect((await run('X=hi; echo ${X:-def}; unset X')).stdout.trim()).toBe('hi');
+    expect((await run('X=hi; echo ${X:+on}; unset X')).stdout.trim()).toBe('on');
+    expect((await run('unset X; echo [${X:+on}]')).stdout.trim()).toBe('[]');
+    const miss = await run('unset X; echo ${X:?missing}');
+    expect(miss.exitCode).toBe(1);
+    expect(miss.stderr).toMatch(/X: missing/);
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -81,6 +81,13 @@ describe('parser', () => {
     expect(exprOfWord(a.assignments[0].value, { preserveCmdSub: true })).not.toContain("-join ' '");
   });
 
+  it('parses ${name:-word} parameter defaults', () => {
+    const cmd = parse('echo ${X:-def} ${Y:+on} ${Z:?err}').segments[0].pipeline.commands[0];
+    expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'X', param: { op: ':-', word: 'def' } }]);
+    expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'Y', param: { op: ':+', word: 'on' } }]);
+    expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'Z', param: { op: ':?', word: 'err' } }]);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);


### PR DESCRIPTION
Part of the agent script-surface series (RFC to follow).

## Why

`${FOO:-bar}` was kept as literal text — a silent wrong answer. Agents use this constantly.

## What

- Parser: `:-` `:+` `:?` and non-colon `-` `+` `?`
- Runtime via case-exact `fx-scalar0`
- `:?` prints `bash: NAME: word` and exits 1
- `:=` still raw (not in this PR)

## Verification

- unset / empty / set cases for `:-` and `:+`
- `:?` on unset → exit 1
