### PR TITLE
feat: expand #name string length and #name[@] count

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -64,7 +64,13 @@ export type WordPart =
   | { kind: 'Text'; text: string; escaped?: boolean }
   | { kind: 'SingleQuoted'; text: string }
   | { kind: 'DoubleQuoted'; parts: WordPart[] }
-  | { kind: 'Var'; name: string; index?: string }
+  | {
+      kind: 'Var';
+      name: string;
+      index?: string;
+      /** `${name:-word}` / `${name:+word}` / `${name:?word}` (and non-colon). */
+      param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string };
+    }
   | { kind: 'CmdSub'; cmd: string };
 
 export function wordToString(w: Word): string {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -70,6 +70,8 @@ export type WordPart =
       index?: string;
       /** `${name:-word}` / `${name:+word}` / `${name:?word}` (and non-colon). */
       param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string };
+      /** `${#name}` / `${#name[@]}` */
+      length?: boolean;
     }
   | { kind: 'CmdSub'; cmd: string };
 

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -11,6 +11,7 @@ import {
   translateCmdSub,
   normalizeLiteralPath,
   pathExpr,
+  paramExpr,
 } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
@@ -1487,6 +1488,9 @@ function kshExprOfWord(w: Word): string {
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
+    if (expanded[0].param) {
+      return paramExpr(expanded[0].name, expanded[0].param.op, expanded[0].param.word);
+    }
     if (expanded[0].index !== undefined) {
       return '(fx-subget ' + psStr(expanded[0].name) + ' ' + psStr(expanded[0].index) + ')';
     }
@@ -1511,7 +1515,9 @@ function kshExprOfWord(w: Word): string {
         break;
       case 'Var':
         out +=
-          p.index !== undefined
+          p.param
+            ? '$(' + paramExpr(p.name, p.param.op, p.param.word) + ')'
+            : p.index !== undefined
             ? '$(fx-subget ' + psStr(p.name) + ' ' + psStr(p.index) + ')'
             : '$(fx-envget ' + psStr(p.name) + ')';
         break;

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -12,6 +12,7 @@ import {
   normalizeLiteralPath,
   pathExpr,
   paramExpr,
+  varExpr,
 } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
@@ -1488,6 +1489,9 @@ function kshExprOfWord(w: Word): string {
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
+    if (expanded[0].length) {
+      return varExpr(expanded[0].name, expanded[0].index, undefined, true);
+    }
     if (expanded[0].param) {
       return paramExpr(expanded[0].name, expanded[0].param.op, expanded[0].param.word);
     }
@@ -1515,7 +1519,9 @@ function kshExprOfWord(w: Word): string {
         break;
       case 'Var':
         out +=
-          p.param
+          p.length
+            ? '$(' + varExpr(p.name, p.index, undefined, true) + ')'
+            : p.param
             ? '$(' + paramExpr(p.name, p.param.op, p.param.word) + ')'
             : p.index !== undefined
             ? '$(fx-subget ' + psStr(p.name) + ' ' + psStr(p.index) + ')'

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -245,6 +245,13 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     if (sub) {
       return { part: { kind: 'Var', name: sub[1], index: sub[2] }, next: end + 1 };
     }
+    const hash = name.match(/^#([A-Za-z_][A-Za-z0-9_]*)(\[([0-9]+|@|\*)\])?$/);
+    if (hash) {
+      return {
+        part: { kind: 'Var', name: hash[1], index: hash[3], length: true },
+        next: end + 1,
+      };
+    }
     const pm = name.match(/^([A-Za-z_][A-Za-z0-9_]*)(:?[-+?])(.*)$/);
     if (pm) {
       const op = pm[2] as ':-' | ':+' | ':?' | '-' | '+' | '?';

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -245,8 +245,16 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     if (sub) {
       return { part: { kind: 'Var', name: sub[1], index: sub[2] }, next: end + 1 };
     }
+    const pm = name.match(/^([A-Za-z_][A-Za-z0-9_]*)(:?[-+?])(.*)$/);
+    if (pm) {
+      const op = pm[2] as ':-' | ':+' | ':?' | '-' | '+' | '?';
+      return {
+        part: { kind: 'Var', name: pm[1], param: { op, word: pm[3] } },
+        next: end + 1,
+      };
+    }
     if (!name || !isNameStart(name[0]) || !name.split('').every(isNameChar)) {
-      // ${VAR:-default} etc. — unsupported, kept as raw text
+      // ${VAR:=default} etc. still raw text
       return { part: { kind: 'Text', text: input.slice(i, end + 1) }, next: end + 1 };
     }
     return { part: { kind: 'Var', name }, next: end + 1 };

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -62,7 +62,21 @@ export function varExpr(
   name: string,
   index?: string,
   param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string },
+  length = false,
 ): string {
+  if (length) {
+    if (index === '@' || index === '*') {
+      return '@(fx-arrload ' + psStr(name) + ').Count';
+    }
+    if (index !== undefined) {
+      return '([string](fx-subget ' + psStr(name) + ' ' + psStr(index) + ')).Length';
+    }
+    return (
+      '([string]$(if ($null -eq ($fx_pv = fx-scalar0 ' +
+      psStr(name) +
+      ')) { \'\' } else { $fx_pv })).Length'
+    );
+  }
   if (param) return paramExpr(name, param.op, param.word);
   // Indexed reads always go through fx-subget → fx-arrload → fx-scalar0 so
   // ${PWD[0]} keeps the special mapping and ${bash_rematch[0]} stays
@@ -164,7 +178,12 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
 
   // single bare variable → bare expression
   if (expanded.length === 1 && expanded[0].kind === 'Var') {
-    return varExpr(expanded[0].name, expanded[0].index, expanded[0].param);
+    return varExpr(
+      expanded[0].name,
+      expanded[0].index,
+      expanded[0].param,
+      expanded[0].length === true,
+    );
   }
   // Bare `$(...)` must not sit inside a PS expandable string: the
   // substitution body contains `"` / `$_` that would break interpolation.
@@ -192,7 +211,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
         for (const q of p.parts) emitPart(q, true);
         break;
       case 'Var':
-        out += '$(' + varExpr(p.name, p.index, p.param) + ')';
+        out += '$(' + varExpr(p.name, p.index, p.param, p.length === true) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd, quoted || opts?.preserveCmdSub === true) + ')';
@@ -246,7 +265,10 @@ export function splatSpec(w: Word): { name: string; prefix: string; suffix: stri
   let suffix = '';
   let seen = false;
   for (const { part: p, quoted } of parts) {
-    const splat = p.kind === 'Var' && (p.index === '@' || (p.index === '*' && !quoted));
+    const splat =
+      p.kind === 'Var' &&
+      !p.length &&
+      (p.index === '@' || (p.index === '*' && !quoted));
     if (splat) {
       if (seen) return null;
       seen = true;

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -15,8 +15,55 @@ import { PipelineCtx, lookup, psStr } from './registry.js';
 /* Variable mapping                                                    */
 /* ------------------------------------------------------------------ */
 
+function paramWordExpr(word: string): string {
+  if (word.startsWith('$') && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(word)) {
+    return varExpr(word.slice(1));
+  }
+  return psStr(word);
+}
+
+/** `${name:-word}` and friends using case-exact fx-scalar0. */
+export function paramExpr(
+  name: string,
+  op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?',
+  word: string,
+): string {
+  const alt = paramWordExpr(word);
+  const get = '(fx-scalar0 ' + psStr(name) + ')';
+  const empty = '($null -eq $fx_pv -or [string]$fx_pv -eq \'\')';
+  const unset = '($null -eq $fx_pv)';
+  if (op === ':-') {
+    return '$( $fx_pv = ' + get + '; if (' + empty + ') { ' + alt + ' } else { $fx_pv } )';
+  }
+  if (op === '-') {
+    return '$( $fx_pv = ' + get + '; if (' + unset + ') { ' + alt + ' } else { $fx_pv } )';
+  }
+  if (op === ':+') {
+    return '$( $fx_pv = ' + get + '; if (' + empty + ') { \'\' } else { ' + alt + ' } )';
+  }
+  if (op === '+') {
+    return '$( $fx_pv = ' + get + '; if (' + unset + ') { \'\' } else { ' + alt + ' } )';
+  }
+  const msg = word === '' ? name + ': parameter null or not set' : name + ': ' + word;
+  const cond = op === ':?' ? empty : unset;
+  return (
+    '$( $fx_pv = ' +
+    get +
+    '; if (' +
+    cond +
+    ') { [Console]::Error.WriteLine(' +
+    psStr('bash: ' + msg) +
+    '); $script:fx_exit = 1; \'\' } else { $fx_pv } )'
+  );
+}
+
 /** Map a bash $VAR name to a PowerShell expression (usable inside $(...)). */
-export function varExpr(name: string, index?: string): string {
+export function varExpr(
+  name: string,
+  index?: string,
+  param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string },
+): string {
+  if (param) return paramExpr(name, param.op, param.word);
   // Indexed reads always go through fx-subget → fx-arrload → fx-scalar0 so
   // ${PWD[0]} keeps the special mapping and ${bash_rematch[0]} stays
   // case-exact (a `$env:name` fallback would alias BASH_REMATCH on Windows).
@@ -117,7 +164,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
 
   // single bare variable → bare expression
   if (expanded.length === 1 && expanded[0].kind === 'Var') {
-    return varExpr(expanded[0].name, expanded[0].index);
+    return varExpr(expanded[0].name, expanded[0].index, expanded[0].param);
   }
   // Bare `$(...)` must not sit inside a PS expandable string: the
   // substitution body contains `"` / `$_` that would break interpolation.
@@ -145,7 +192,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
         for (const q of p.parts) emitPart(q, true);
         break;
       case 'Var':
-        out += '$(' + varExpr(p.name, p.index) + ')';
+        out += '$(' + varExpr(p.name, p.index, p.param) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd, quoted || opts?.preserveCmdSub === true) + ')';

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -720,6 +720,17 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('command echo hi')).stdout.trim()).toBe('hi');
   });
 
+  it('${name:-word} and ${name:+word} follow bash empty/unset rules', async () => {
+    expect((await run('unset X; echo ${X:-def}')).stdout.trim()).toBe('def');
+    expect((await run('X=; echo ${X:-def}; unset X')).stdout.trim()).toBe('def');
+    expect((await run('X=hi; echo ${X:-def}; unset X')).stdout.trim()).toBe('hi');
+    expect((await run('X=hi; echo ${X:+on}; unset X')).stdout.trim()).toBe('on');
+    expect((await run('unset X; echo [${X:+on}]')).stdout.trim()).toBe('[]');
+    const miss = await run('unset X; echo ${X:?missing}');
+    expect(miss.exitCode).toBe(1);
+    expect(miss.stderr).toMatch(/X: missing/);
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -731,6 +731,13 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(miss.stderr).toMatch(/X: missing/);
   });
 
+  it('${#name} is string length and ${#name[@]} is element count', async () => {
+    expect((await run('X=abcd; echo ${#X}; unset X')).stdout.trim()).toBe('4');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${#BASH_REMATCH[@]}')).stdout.trim()).toBe('2');
+    expect((await run('unset Z; echo ${#Z}')).stdout.trim()).toBe('0');
+  });
+
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -88,6 +88,12 @@ describe('parser', () => {
     expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'Z', param: { op: ':?', word: 'err' } }]);
   });
 
+  it('parses ${#name} and ${#name[@]}', () => {
+    const cmd = parse('echo ${#X} ${#Y[@]}').segments[0].pipeline.commands[0];
+    expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'X', length: true }]);
+    expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'Y', index: '@', length: true }]);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -81,6 +81,13 @@ describe('parser', () => {
     expect(exprOfWord(a.assignments[0].value, { preserveCmdSub: true })).not.toContain("-join ' '");
   });
 
+  it('parses ${name:-word} parameter defaults', () => {
+    const cmd = parse('echo ${X:-def} ${Y:+on} ${Z:?err}').segments[0].pipeline.commands[0];
+    expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'X', param: { op: ':-', word: 'def' } }]);
+    expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'Y', param: { op: ':+', word: 'on' } }]);
+    expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'Z', param: { op: ':?', word: 'err' } }]);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);


### PR DESCRIPTION
Part of the agent script-surface series (RFC to follow).

## Why

Agents use `${#var}` and `${#arr[@]}` for counts. These were raw text.

## What

- `${#name}` → string length of the scalar (fx-scalar0)
- `${#name[@]}` / `${#name[*]}` → element count (fx-arrload)
- `${#name[@]}` is not an argv splat

## Verification

- `X=abcd; echo ${#X}` → 4
- after `[[ abc =~ ^a(.)c$ ]]`, `${#BASH_REMATCH[@]}` → 2
- unset → 0
