### PR TITLE
feat: accept backtick command substitution as dollar-parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `source`, `eval`, `alias`, heredocs, backticks, shell control flow (`if`/`for`/`while`)
+- `tail -f`, `source`, `eval`, `alias`, heredocs, shell control flow (`if`/`for`/`while`)
   and background `&` are rejected with actionable error messages instead of misbehaving.
 - `chmod` maps only the read-only bit; exec bits are no-ops on Windows. `chown` is a silent no-op
   (as in Git Bash).

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -7,11 +7,11 @@
  *   - redirections:         > >> 2> 2>> &> 2>&1 1>&2 <
  *   - quoting:              'literal'  "interp $VAR $(cmd)"
  *   - variables:            $VAR ${VAR} ${VAR[n]} plus special cases ($HOME $USER $PATH ...)
- *   - command substitution: $(...) (recursively translated)
+ *   - command substitution: $(...) and `...` (recursively translated)
  *   - env assignment prefix: VAR=value cmd
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
- *   heredocs, backticks, subshells (...), background &, control flow
+ *   heredocs, subshells (...), background &, control flow
  *   (if/for/while), globs inside quotes, process substitution <(...).
  */
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, backticks, control flow (if/for/while), background jobs.
+Not supported: heredocs, control flow (if/for/while), background jobs.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — but prefer COMBINING related commands in one call with ; or && (e.g. 'cd src && ls | wc -l'); each call is a fresh translation+process, so batching is faster than many tiny calls.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -163,6 +163,16 @@ export function tokenize(input: string): Token[] {
             continue;
           }
         }
+        if (c === '`') {
+          const v = readBacktick(input, i);
+          if (buf) {
+            parts.push({ kind: 'Text', text: buf });
+            buf = '';
+          }
+          parts.push(v.part);
+          i = v.next;
+          continue;
+        }
         buf += c;
         i++;
       }
@@ -189,9 +199,11 @@ export function tokenize(input: string): Token[] {
     }
 
     if (ch === '`') {
-      throw new FauxnixParseError(
-        'fauxnix: backticks are not supported. Use $(...) command substitution instead.',
-      );
+      const v = readBacktick(input, i);
+      beginWordPart();
+      cur.push(v.part);
+      i = v.next;
+      continue;
     }
 
     // escape outside quotes — keep the escape so [[ =~ ]] / == can
@@ -227,6 +239,23 @@ function isNameStart(c: string): boolean {
 }
 function isNameChar(c: string): boolean {
   return /[A-Za-z0-9_]/.test(c);
+}
+
+/** Parse `cmd` as command substitution (same AST as $(cmd)). */
+function readBacktick(input: string, i: number): { part: WordPart; next: number } {
+  if (input[i] !== '`') throw new FauxnixParseError('fauxnix: expected backtick');
+  let k = i + 1;
+  while (k < input.length) {
+    if (input[k] === '\\' && k + 1 < input.length) {
+      k += 2;
+      continue;
+    }
+    if (input[k] === '`') {
+      return { part: { kind: 'CmdSub', cmd: input.slice(i + 1, k) }, next: k + 1 };
+    }
+    k++;
+  }
+  throw new FauxnixParseError('fauxnix: unclosed backtick');
 }
 
 /** Parse $VAR, ${VAR}, $(cmd substitution). Returns null when not a valid dollar construct. */

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -494,6 +494,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
   it('variables and command substitution', async () => {
     expect((await run('export GREET=hi; echo $GREET/there')).stdout.trim()).toBe('hi/there');
     expect((await run('echo $(echo nested)')).stdout.trim()).toBe('nested');
+    expect((await run('echo `echo nested`')).stdout.trim()).toBe('nested');
     expect((await run("echo \"[$(printf 'a\\nb')]\"")).stdout).toBe('[a\nb]\n');
     expect((await run("[[ \"$(printf 'a\\nb')\" == \"a\nb\" ]]")).exitCode).toBe(0);
     expect((await run("X=$(printf 'a\\nb'); echo \"[$X]\"")).stdout).toBe('[a\nb]\n');

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -127,8 +127,9 @@ describe('parser', () => {
     expect(() => parse('cat <<EOF')).toThrow(/heredoc/);
   });
 
-  it('rejects backticks', () => {
-    expect(() => parse('echo `date`')).toThrow(/backtick/);
+  it('parses backticks as command substitution', () => {
+    const cmd = parse('echo `date +%Y`').segments[0].pipeline.commands[0];
+    expect(cmd.args[0].some((p) => p.kind === 'CmdSub' && p.cmd === 'date +%Y')).toBe(true);
   });
 
   it('rejects tokens after the closing ]]', () => {


### PR DESCRIPTION
Part of the agent script-surface series (RFC to follow).

## Why

Models still emit `` `cmd` ``. The parser threw; the MCP description told them to rewrite. Accept backticks as the same AST as `$(cmd)`.

## What

- Unquoted and double-quoted backticks become `CmdSub`
- Same newline/IFS contract as `$(...)`
- Docs/MCP "not supported" list updated

## Verification

- Parser unit test
- `echo \`echo nested\`` → nested
