### PR TITLE
feat: translate if/then/else/fi as a compound command

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `source`, `eval`, `alias`, heredocs, shell control flow (`if`/`for`/`while`)
+- `tail -f`, `source`, `eval`, `alias`, heredocs, `for`/`while` (if/then/fi is supported)
   and background `&` are rejected with actionable error messages instead of misbehaving.
 - `chmod` maps only the read-only bit; exec bits are no-ops on Windows. `chown` is a silent no-op
   (as in Git Bash).

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `source`, `eval`, `alias`, heredocs, backticks, shell control flow (`if`/`for`/`while`)
+- `tail -f`, `source`, `eval`, `alias`, heredocs, shell control flow (`if`/`for`/`while`)
   and background `&` are rejected with actionable error messages instead of misbehaving.
 - `chmod` maps only the read-only bit; exec bits are no-ops on Windows. `chown` is a silent no-op
   (as in Git Bash).

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -7,11 +7,11 @@
  *   - redirections:         > >> 2> 2>> &> 2>&1 1>&2 <
  *   - quoting:              'literal'  "interp $VAR $(cmd)"
  *   - variables:            $VAR ${VAR} ${VAR[n]} plus special cases ($HOME $USER $PATH ...)
- *   - command substitution: $(...) (recursively translated)
+ *   - command substitution: $(...) and `...` (recursively translated)
  *   - env assignment prefix: VAR=value cmd
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
- *   heredocs, backticks, subshells (...), background &, control flow
+ *   heredocs, subshells (...), background &, control flow
  *   (if/for/while), globs inside quotes, process substitution <(...).
  */
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -11,8 +11,8 @@
  *   - env assignment prefix: VAR=value cmd
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
- *   heredocs, subshells (...), background &, control flow
- *   (if/for/while), globs inside quotes, process substitution <(...).
+ *   heredocs, subshells (...), background &,
+ *   while/until/case, globs inside quotes, process substitution <(...).
  */
 
 export interface CommandList {
@@ -27,9 +27,19 @@ export interface ListSegment {
   op: ';' | '&&' | '||';
 }
 
+export type ShellCommand = SimpleCommand | IfCommand;
+
 export interface Pipeline {
   kind: 'Pipeline';
-  commands: SimpleCommand[];
+  commands: ShellCommand[];
+}
+
+export interface IfCommand {
+  kind: 'If';
+  test: CommandList;
+  then: CommandList;
+  else?: CommandList;
+  redirects: Redirect[];
 }
 
 export interface SimpleCommand {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, backticks, control flow (if/for/while), background jobs.
+Not supported: heredocs, control flow (if/for/while), background jobs.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — but prefer COMBINING related commands in one call with ; or && (e.g. 'cd src && ls | wc -l'); each call is a fresh translation+process, so batching is faster than many tiny calls.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, control flow (if/for/while), background jobs.
+Not supported: heredocs, for/while, background jobs. \`if/then/else/fi\` is supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — but prefer COMBINING related commands in one call with ; or && (e.g. 'cd src && ls | wc -l'); each call is a fresh translation+process, so batching is faster than many tiny calls.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -163,6 +163,16 @@ export function tokenize(input: string): Token[] {
             continue;
           }
         }
+        if (c === '`') {
+          const v = readBacktick(input, i);
+          if (buf) {
+            parts.push({ kind: 'Text', text: buf });
+            buf = '';
+          }
+          parts.push(v.part);
+          i = v.next;
+          continue;
+        }
         buf += c;
         i++;
       }
@@ -189,9 +199,11 @@ export function tokenize(input: string): Token[] {
     }
 
     if (ch === '`') {
-      throw new FauxnixParseError(
-        'fauxnix: backticks are not supported. Use $(...) command substitution instead.',
-      );
+      const v = readBacktick(input, i);
+      beginWordPart();
+      cur.push(v.part);
+      i = v.next;
+      continue;
     }
 
     // escape outside quotes — keep the escape so [[ =~ ]] / == can
@@ -227,6 +239,23 @@ function isNameStart(c: string): boolean {
 }
 function isNameChar(c: string): boolean {
   return /[A-Za-z0-9_]/.test(c);
+}
+
+/** Parse `cmd` as command substitution (same AST as $(cmd)). */
+function readBacktick(input: string, i: number): { part: WordPart; next: number } {
+  if (input[i] !== '`') throw new FauxnixParseError('fauxnix: expected backtick');
+  let k = i + 1;
+  while (k < input.length) {
+    if (input[k] === '\\' && k + 1 < input.length) {
+      k += 2;
+      continue;
+    }
+    if (input[k] === '`') {
+      return { part: { kind: 'CmdSub', cmd: input.slice(i + 1, k) }, next: k + 1 };
+    }
+    k++;
+  }
+  throw new FauxnixParseError('fauxnix: unclosed backtick');
 }
 
 /** Parse $VAR, ${VAR}, $(cmd substitution). Returns null when not a valid dollar construct. */

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7,6 +7,8 @@ import {
   Redirect,
   RedirectOp,
   SimpleCommand,
+  IfCommand,
+  ShellCommand,
   Word,
   WordPart,
   isUnquotedLiteral,
@@ -569,9 +571,17 @@ export function parseCommand(input: string): CommandList {
   };
 
   const parsePipeline = (): Pipeline => {
-    const commands: SimpleCommand[] = [];
+    const commands: ShellCommand[] = [];
     for (;;) {
-      commands.push(parseSimple());
+      const kw = peekKw();
+      if (kw === 'if') {
+        if (commands.length > 0) {
+          throw new FauxnixParseError('fauxnix: if in a pipeline is not supported');
+        }
+        commands.push(parseIf());
+      } else {
+        commands.push(parseSimple());
+      }
       const t = peek();
       if (t.type === 'OP' && t.op === '|') {
         next();
@@ -580,6 +590,78 @@ export function parseCommand(input: string): CommandList {
       break;
     }
     return { kind: 'Pipeline', commands };
+  };
+
+  const peekKw = (): string | null => {
+    const t = peek();
+    if (t.type !== 'WORD' || !t.parts) return null;
+    const s = wordToString(t.parts);
+    if (!isUnquotedLiteral(t.parts, s)) return null;
+    if (
+      s === 'if' ||
+      s === 'then' ||
+      s === 'else' ||
+      s === 'elif' ||
+      s === 'fi' ||
+      s === 'for' ||
+      s === 'in' ||
+      s === 'do' ||
+      s === 'done' ||
+      s === 'while'
+    ) {
+      return s;
+    }
+    return null;
+  };
+
+  const expectKw = (k: string): void => {
+    if (peekKw() !== k) {
+      throw new FauxnixParseError('fauxnix: expected `' + k + "'");
+    }
+    next();
+  };
+
+  const parseListUntil = (stops: string[]): CommandList => {
+    const stop = new Set(stops);
+    const segments: ListSegment[] = [];
+    let op: ';' | '&&' | '||' = ';';
+    const isListSep = (o?: string) => o === ';' || o === '\n';
+    while (peek().type === 'OP' && isListSep(peek().op)) next();
+    while (peek().type !== 'EOF') {
+      const kw = peekKw();
+      if (kw && stop.has(kw)) break;
+      const pipeline = parsePipeline();
+      segments.push({ pipeline, op });
+      const t = peek();
+      if (t.type === 'OP' && (t.op === '&&' || t.op === '||' || isListSep(t.op))) {
+        op = t.op === '\n' ? ';' : (t.op as '&&' | '||' | ';');
+        next();
+        while (peek().type === 'OP' && isListSep(peek().op)) next();
+      } else {
+        break;
+      }
+    }
+    if (segments.length === 0) {
+      throw new FauxnixParseError('fauxnix: empty command');
+    }
+    return { kind: 'CommandList', segments };
+  };
+
+  const parseIf = (): IfCommand => {
+    expectKw('if');
+    const test = parseListUntil(['then']);
+    expectKw('then');
+    const thenL = parseListUntil(['else', 'elif', 'fi']);
+    let elseL: CommandList | undefined;
+    if (peekKw() === 'elif') {
+      throw new FauxnixParseError('fauxnix: elif is not supported yet; use else + if');
+    }
+    if (peekKw() === 'else') {
+      next();
+      elseL = parseListUntil(['fi']);
+    }
+    expectKw('fi');
+    return { kind: 'If', test, then: thenL, else: elseL, redirects: [] };
   };
 
   const parseSimple = (): SimpleCommand => {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -4,6 +4,7 @@ import {
   FauxnixParseError,
   Redirect,
   SimpleCommand,
+  IfCommand,
   Word,
   WordPart,
   isUnquotedLiteral,
@@ -698,13 +699,46 @@ export interface PipelineParts {
  * multi-command pipelines become generated functions chained with `|`
  * (PS 5.1 forbids parenthesized expressions as non-first pipeline elements).
  */
-export function translatePipelineBody(p: { commands: SimpleCommand[] }): PipelineParts {
+function translateListInline(list: CommandList): string {
+  const chunks: string[] = [];
+  for (const seg of list.segments) {
+    const { defs, call } = translatePipelineBody(seg.pipeline);
+    const body = (defs ? defs + '\n' : '') + call;
+    if (seg.op === '&&') {
+      chunks.push('if ($script:fx_exit -eq 0) {\n' + body + '\n}');
+    } else if (seg.op === '||') {
+      chunks.push('if ($script:fx_exit -ne 0) {\n' + body + '\n}');
+    } else {
+      chunks.push(body);
+    }
+  }
+  return chunks.join('\n');
+}
+
+function translateIf(cmd: IfCommand): string {
+  const lines = [translateListInline(cmd.test), 'if ($script:fx_exit -eq 0) {'];
+  for (const l of translateListInline(cmd.then).split('\n')) lines.push(l ? '  ' + l : l);
+  if (cmd.else) {
+    lines.push('} else {');
+    for (const l of translateListInline(cmd.else).split('\n')) lines.push(l ? '  ' + l : l);
+    lines.push('}');
+  } else {
+    lines.push('}');
+  }
+  return lines.join('\n');
+}
+
+export function translatePipelineBody(p: {
+  commands: Array<SimpleCommand | IfCommand>;
+}): PipelineParts {
   const bodies: string[] = [];
   for (let i = 0; i < p.commands.length; i++) {
-    const hasStdin = i > 0 || p.commands[i].redirects.some((r) => r.op === '<');
+    const c = p.commands[i];
+    const hasStdin = i > 0 || c.redirects.some((r) => r.op === '<');
     const position: PipelineCtx['position'] =
       i === 0 ? 'first' : i === p.commands.length - 1 ? 'last' : 'middle';
-    bodies.push(translateSimple(p.commands[i], position, hasStdin));
+    if (c.kind === 'If') bodies.push(translateIf(c));
+    else bodies.push(translateSimple(c, position, hasStdin));
   }
 
   if (bodies.length === 1) {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -721,6 +721,14 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('command echo hi')).stdout.trim()).toBe('hi');
   });
 
+  it('if/then/else/fi follows the test exit code', async () => {
+    expect((await run('if true; then echo YES; fi')).stdout.trim()).toBe('YES');
+    expect((await run('if false; then echo YES; else echo NO; fi')).stdout.trim()).toBe('NO');
+    expect((await run('if true; then echo A; else echo B; fi')).stdout.trim()).toBe('A');
+    expect((await run('if false; then echo YES; fi')).stdout.trim()).toBe('');
+  });
+
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -494,6 +494,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
   it('variables and command substitution', async () => {
     expect((await run('export GREET=hi; echo $GREET/there')).stdout.trim()).toBe('hi/there');
     expect((await run('echo $(echo nested)')).stdout.trim()).toBe('nested');
+    expect((await run('echo `echo nested`')).stdout.trim()).toBe('nested');
     expect((await run("echo \"[$(printf 'a\\nb')]\"")).stdout).toBe('[a\nb]\n');
     expect((await run("[[ \"$(printf 'a\\nb')\" == \"a\nb\" ]]")).exitCode).toBe(0);
     expect((await run("X=$(printf 'a\\nb'); echo \"[$X]\"")).stdout).toBe('[a\nb]\n');

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -127,8 +127,9 @@ describe('parser', () => {
     expect(() => parse('cat <<EOF')).toThrow(/heredoc/);
   });
 
-  it('rejects backticks', () => {
-    expect(() => parse('echo `date`')).toThrow(/backtick/);
+  it('parses backticks as command substitution', () => {
+    const cmd = parse('echo `date +%Y`').segments[0].pipeline.commands[0];
+    expect(cmd.args[0].some((p) => p.kind === 'CmdSub' && p.cmd === 'date +%Y')).toBe(true);
   });
 
   it('rejects tokens after the closing ]]', () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -81,6 +81,16 @@ describe('parser', () => {
     expect(exprOfWord(a.assignments[0].value, { preserveCmdSub: true })).not.toContain("-join ' '");
   });
 
+  it('parses if/then/else/fi as one compound command', () => {
+    const list = parse('if true; then echo x; else echo y; fi');
+    expect(list.segments).toHaveLength(1);
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('If');
+    if (c.kind !== 'If') return;
+    expect(c.then.segments).toHaveLength(1);
+    expect(c.else?.segments).toHaveLength(1);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);


### PR DESCRIPTION
Part of the agent script-surface series (RFC to follow).

## Why

MCP docs said `if` is unsupported, but `if true; then echo x; fi` was parsed as three native commands (`if`, `then`, `fi`) — 127s, not a parse error. Agents emit this constantly.

## What

- Parser treats `if/then/else/fi` as one compound command (one session segment)
- Test list / then list / optional else list; `&&` `||` `;` inside each list
- `elif` fails loudly (use `else` + nested `if`)
- `if` in a `|` pipeline is rejected

## Verification

- `if true; then echo YES; fi` → YES
- `if false; then echo YES; else echo NO; fi` → NO
- `if false; then echo YES; fi` → empty
