### PR TITLE
release: v0.5.0 — wave 2 agent script surface (integrates #103-#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.5.0 — 2026-08-18
+
+Wave 2 "agent script surface" (RFC #111, by r3wretrhy; integration merge):
+
+- `if/then/else/fi` and `for x in words; do ...; done` as compound commands,
+  one PowerShell process per segment; `elif`/C-style `for`/`while` fail loudly
+- Parameter expansions: `${name:-word}` `:+` `:?` (and non-colon forms),
+  `${#name}` / `${#name[@]}` counts
+- Backtick command substitution `` `cmd` `` (same pipeline as `$(...)`)
+- `command -v` (+ bare `command NAME` no-alias run), `read`/`read -r` from
+  pipelines into session vars, dotenv-style `source` (NAME=VALUE files)
+- `set -e/-u/-x` now refuses loudly (exit 2) instead of silently ignoring
+- `${arr[@]}` in command position with an empty array promotes the next word
+  (bash parity)
+- Docs: README known-deviations updated for the new supported surface
+  (+ `command -v` builtin-path deviation noted)
+
 ## v0.4.2 — 2026-08-18
 
 - Glama/Linux-host readiness (audit follow-up):

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `source`, `eval`, `alias`, heredocs, backticks, shell control flow (`if`/`for`/`while`)
+- `tail -f`, `source`, `eval`, `alias`, heredocs, backticks, `for`/`while` (if/then/fi is supported)
   and background `&` are rejected with actionable error messages instead of misbehaving.
 - `chmod` maps only the read-only bit; exec bits are no-ops on Windows. `chown` is a silent no-op
   (as in Git Bash).

--- a/README.md
+++ b/README.md
@@ -193,8 +193,12 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `source`, `eval`, `alias`, heredocs, shell control flow (`if`/`for`/`while`)
+- `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`
   and background `&` are rejected with actionable error messages instead of misbehaving.
+  (`if/then/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
+  and dotenv-style `source` are supported.)
+- `command -v <builtin>` prints `/usr/bin/<name>` where bash prints the bare builtin name;
+  exit codes and empty-result semantics match.
 - `chmod` maps only the read-only bit; exec bits are no-ops on Windows. `chown` is a silent no-op
   (as in Git Bash).
 - `ps aux` columns are approximations (no per-process CPU% accounting, USER shows `?`).

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `source`, `eval`, `alias`, heredocs, backticks, shell control flow (`if`/`for`/`while`)
+- `tail -f`, `source`, `eval`, `alias`, heredocs, backticks, `if`/`while` (`for x in ...; do ...; done` is supported)
   and background `&` are rejected with actionable error messages instead of misbehaving.
 - `chmod` maps only the read-only bit; exec bits are no-ops on Windows. `chown` is a silent no-op
   (as in Git Bash).

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `source`, `eval`, `alias`, heredocs, backticks, shell control flow (`if`/`for`/`while`)
+- `tail -f`, `source`, `eval`, `alias`, heredocs, shell control flow (`if`/`for`/`while`)
   and background `&` are rejected with actionable error messages instead of misbehaving.
 - `chmod` maps only the read-only bit; exec bits are no-ops on Windows. `chown` is a silent no-op
   (as in Git Bash).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fauxnix-cli",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Fauxnix — run Linux-style commands on Windows via deterministic PowerShell translation. No VM, no WSL. MCP server + CLI for AI agents.",
   "type": "module",
   "bin": {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -64,6 +64,7 @@ export type WordPart =
   | { kind: 'Text'; text: string; escaped?: boolean }
   | { kind: 'SingleQuoted'; text: string }
   | { kind: 'DoubleQuoted'; parts: WordPart[] }
+<<<<<<< HEAD
   | {
       kind: 'Var';
       name: string;
@@ -71,6 +72,9 @@ export type WordPart =
       /** `${name:-word}` / `${name:+word}` / `${name:?word}` (and non-colon). */
       param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string };
     }
+=======
+  | { kind: 'Var'; name: string; index?: string; length?: boolean }
+>>>>>>> pr/107
   | { kind: 'CmdSub'; cmd: string };
 
 export function wordToString(w: Word): string {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -64,7 +64,13 @@ export type WordPart =
   | { kind: 'Text'; text: string; escaped?: boolean }
   | { kind: 'SingleQuoted'; text: string }
   | { kind: 'DoubleQuoted'; parts: WordPart[] }
-  | { kind: 'Var'; name: string; index?: string }
+  | {
+      kind: 'Var';
+      name: string;
+      index?: string;
+      /** `${name:-word}` / `${name:+word}` / `${name:?word}` (and non-colon). */
+      param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string };
+    }
   | { kind: 'CmdSub'; cmd: string };
 
 export function wordToString(w: Word): string {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -11,8 +11,8 @@
  *   - env assignment prefix: VAR=value cmd
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
- *   heredocs, subshells (...), background &, control flow
- *   (if/for/while), globs inside quotes, process substitution <(...).
+ *   heredocs, subshells (...), background &, while/until/case,
+ *   globs inside quotes, process substitution <(...).
  */
 
 export interface CommandList {
@@ -27,9 +27,19 @@ export interface ListSegment {
   op: ';' | '&&' | '||';
 }
 
+export type ShellCommand = SimpleCommand | IfCommand;
+
 export interface Pipeline {
   kind: 'Pipeline';
-  commands: SimpleCommand[];
+  commands: ShellCommand[];
+}
+
+export interface IfCommand {
+  kind: 'If';
+  test: CommandList;
+  then: CommandList;
+  else?: CommandList;
+  redirects: Redirect[];
 }
 
 export interface SimpleCommand {
@@ -64,17 +74,15 @@ export type WordPart =
   | { kind: 'Text'; text: string; escaped?: boolean }
   | { kind: 'SingleQuoted'; text: string }
   | { kind: 'DoubleQuoted'; parts: WordPart[] }
-<<<<<<< HEAD
   | {
       kind: 'Var';
       name: string;
       index?: string;
       /** `${name:-word}` / `${name:+word}` / `${name:?word}` (and non-colon). */
       param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string };
+      /** `${#name}` / `${#name[@]}` — string/array length expansion. */
+      length?: boolean;
     }
-=======
-  | { kind: 'Var'; name: string; index?: string; length?: boolean }
->>>>>>> pr/107
   | { kind: 'CmdSub'; cmd: string };
 
 export function wordToString(w: Word): string {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -11,8 +11,9 @@
  *   - env assignment prefix: VAR=value cmd
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
- *   heredocs, backticks, subshells (...), background &, control flow
- *   (if/for/while), globs inside quotes, process substitution <(...).
+ *   heredocs, backticks, subshells (...), background &,
+ *   if/while/case (for/in/do/done is supported), globs inside quotes,
+ *   process substitution <(...).
  */
 
 export interface CommandList {
@@ -27,9 +28,19 @@ export interface ListSegment {
   op: ';' | '&&' | '||';
 }
 
+export type ShellCommand = SimpleCommand | ForCommand;
+
 export interface Pipeline {
   kind: 'Pipeline';
-  commands: SimpleCommand[];
+  commands: ShellCommand[];
+}
+
+export interface ForCommand {
+  kind: 'For';
+  name: string;
+  words: Word[];
+  body: CommandList;
+  redirects: Redirect[];
 }
 
 export interface SimpleCommand {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -64,7 +64,7 @@ export type WordPart =
   | { kind: 'Text'; text: string; escaped?: boolean }
   | { kind: 'SingleQuoted'; text: string }
   | { kind: 'DoubleQuoted'; parts: WordPart[] }
-  | { kind: 'Var'; name: string; index?: string }
+  | { kind: 'Var'; name: string; index?: string; length?: boolean }
   | { kind: 'CmdSub'; cmd: string };
 
 export function wordToString(w: Word): string {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -27,7 +27,7 @@ export interface ListSegment {
   op: ';' | '&&' | '||';
 }
 
-export type ShellCommand = SimpleCommand | IfCommand;
+export type ShellCommand = SimpleCommand | IfCommand | ForCommand;
 
 export interface Pipeline {
   kind: 'Pipeline';
@@ -39,6 +39,14 @@ export interface IfCommand {
   test: CommandList;
   then: CommandList;
   else?: CommandList;
+  redirects: Redirect[];
+}
+
+export interface ForCommand {
+  kind: 'For';
+  name: string;
+  words: Word[];
+  body: CommandList;
   redirects: Redirect[];
 }
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -7,11 +7,11 @@
  *   - redirections:         > >> 2> 2>> &> 2>&1 1>&2 <
  *   - quoting:              'literal'  "interp $VAR $(cmd)"
  *   - variables:            $VAR ${VAR} ${VAR[n]} plus special cases ($HOME $USER $PATH ...)
- *   - command substitution: $(...) (recursively translated)
+ *   - command substitution: $(...) and `...` (recursively translated)
  *   - env assignment prefix: VAR=value cmd
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
- *   heredocs, backticks, subshells (...), background &, control flow
+ *   heredocs, subshells (...), background &, control flow
  *   (if/for/while), globs inside quotes, process substitution <(...).
  */
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -11,8 +11,8 @@
  *   - env assignment prefix: VAR=value cmd
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
- *   heredocs, backticks, subshells (...), background &, control flow
- *   (if/for/while), globs inside quotes, process substitution <(...).
+ *   heredocs, backticks, subshells (...), background &,
+ *   while/until/case, globs inside quotes, process substitution <(...).
  */
 
 export interface CommandList {
@@ -27,9 +27,19 @@ export interface ListSegment {
   op: ';' | '&&' | '||';
 }
 
+export type ShellCommand = SimpleCommand | IfCommand;
+
 export interface Pipeline {
   kind: 'Pipeline';
-  commands: SimpleCommand[];
+  commands: ShellCommand[];
+}
+
+export interface IfCommand {
+  kind: 'If';
+  test: CommandList;
+  then: CommandList;
+  else?: CommandList;
+  redirects: Redirect[];
 }
 
 export interface SimpleCommand {

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -11,11 +11,8 @@ import {
   translateCmdSub,
   normalizeLiteralPath,
   pathExpr,
-<<<<<<< HEAD
   paramExpr,
-=======
   varExpr,
->>>>>>> pr/107
 } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
@@ -1492,13 +1489,11 @@ function kshExprOfWord(w: Word): string {
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
-<<<<<<< HEAD
     if (expanded[0].param) {
       return paramExpr(expanded[0].name, expanded[0].param.op, expanded[0].param.word);
-=======
+    }
     if (expanded[0].length) {
-      return varExpr(expanded[0].name, expanded[0].index, true);
->>>>>>> pr/107
+      return varExpr(expanded[0].name, expanded[0].index, undefined, true);
     }
     if (expanded[0].index !== undefined) {
       return '(fx-subget ' + psStr(expanded[0].name) + ' ' + psStr(expanded[0].index) + ')';

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -2489,6 +2489,59 @@ const less: Handler = (args, ctx) => {
 };
 
 /* ------------------------------------------------------------------ */
+/* read                                                                */
+/* ------------------------------------------------------------------ */
+
+const readCmd: Handler = (args, ctx) => {
+  const names: string[] = [];
+  for (const w of args) {
+    const t = wordToString(w);
+    if (t === '-r' || t === '-a' || t.startsWith('-')) continue;
+    if (!NAME_RE.test(t)) {
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr('bash: read: `' + t + "': not a valid identifier") +
+        '); $script:fx_exit = 2'
+      );
+    }
+    names.push(t);
+  }
+  if (names.length === 0) names.push('REPLY');
+  const first = names[0];
+  return [
+    ctx.hasStdin
+      ? "$fx_line = [string]((@($input) | Select-Object -First 1))"
+      : "$fx_line = ''",
+    ctx.hasStdin ? '' : '$script:fx_exit = 1',
+    names.length === 1
+      ? [
+          "Set-Item -LiteralPath ('Env:\\' + " + psStr(first) + ') -Value $fx_line',
+          " $n = " + psStr(first),
+          " $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",
+          " $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
+          ' fx-arrdrop $n',
+          ' $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sv += $fx_pair } }',
+          ' $fx_sv += ($n + [string][char]61 + (fx-svenc $fx_line)); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)',
+        ].join('\n')
+      : [
+          "$fx_fs = @($fx_line -split '\\s+', " + names.length + ')',
+          'foreach ($fx_i in 0..' + (names.length - 1) + ') {',
+          '  $n = @(' + names.map(psStr).join(',') + ')[$fx_i]',
+          "  $fx_v = $(if ($fx_i -lt $fx_fs.Count) { [string]$fx_fs[$fx_i] } else { '' })",
+          "  Set-Item -LiteralPath ('Env:\\' + $n) -Value $fx_v",
+          "  $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",
+          "  $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
+          '  fx-arrdrop $n',
+          '  $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sv += $fx_pair } }',
+          '  $fx_sv += ($n + [string][char]61 + (fx-svenc $fx_v)); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)',
+          '}',
+        ].join('\n'),
+  ]
+    .filter((l) => l !== '')
+    .join('\n');
+};
+
+/* ------------------------------------------------------------------ */
 /* source / . / eval / exit / alias / set                              */
 /* ------------------------------------------------------------------ */
 
@@ -2627,6 +2680,7 @@ export const handlers: Record<string, Handler> = {
   history,
   less,
   more: less,
+  read: readCmd,
   source,
   '.': source,
   eval: evalCmd,

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -11,6 +11,7 @@ import {
   translateCmdSub,
   normalizeLiteralPath,
   pathExpr,
+  paramExpr,
 } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
@@ -1435,6 +1436,9 @@ function kshExprOfWord(w: Word): string {
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
+    if (expanded[0].param) {
+      return paramExpr(expanded[0].name, expanded[0].param.op, expanded[0].param.word);
+    }
     if (expanded[0].index !== undefined) {
       return '(fx-subget ' + psStr(expanded[0].name) + ' ' + psStr(expanded[0].index) + ')';
     }
@@ -1459,7 +1463,9 @@ function kshExprOfWord(w: Word): string {
         break;
       case 'Var':
         out +=
-          p.index !== undefined
+          p.param
+            ? '$(' + paramExpr(p.name, p.param.op, p.param.word) + ')'
+            : p.index !== undefined
             ? '$(fx-subget ' + psStr(p.name) + ' ' + psStr(p.index) + ')'
             : '$(fx-envget ' + psStr(p.name) + ')';
         break;

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -2636,7 +2636,35 @@ const alias: Handler = (args) => {
   return "[Console]::Error.WriteLine('fauxnix: alias is not supported'); $script:fx_exit = 1";
 };
 
-const set: Handler = () => ''; // silently ignore (`set -e`, `set --` ... no-op)
+const set: Handler = (args) => {
+  const raw = args.map(wordToString);
+  const unsupported = raw.filter(
+    (t) =>
+      t === '-e' ||
+      t === '-u' ||
+      t === '-x' ||
+      t === '-o' ||
+      t === '+e' ||
+      t === '+u' ||
+      t === '+x' ||
+      t.startsWith('-o') ||
+      t.startsWith('+o') ||
+      t === '-eu' ||
+      t === '-ue' ||
+      t === '-eux' ||
+      /^-.*[eux]/.test(t),
+  );
+  if (unsupported.length > 0) {
+    return (
+      '[Console]::Error.WriteLine(' +
+      psStr(
+        'fauxnix: set -e/-u/-x is not supported (would silently lie); use explicit || exit',
+      ) +
+      '); $script:fx_exit = 2'
+    );
+  }
+  return '';
+};
 
 /* ------------------------------------------------------------------ */
 

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -596,6 +596,58 @@ const type: Handler = (args) => {
   ].join('\n');
 };
 
+/** `command -v name` (and bare `command name args` as a no-alias run). */
+const commandCmd: Handler = (args, ctx) => {
+  let i = 0;
+  let identify = false;
+  while (i < args.length) {
+    const t = wordToString(args[i]);
+    if (t === '-v' || t === '-V') {
+      identify = true;
+      i++;
+      continue;
+    }
+    if (t === '--') {
+      i++;
+      break;
+    }
+    if (t.startsWith('-')) {
+      i++;
+      continue;
+    }
+    break;
+  }
+  const rest = args.slice(i);
+  if (identify) {
+    if (rest.length === 0) return '';
+    return [
+      PS_WHICH_FN,
+      '$fx_b = @(' + builtinNames().map(psStr).join(', ') + ')',
+      '$fx_ns = ' + textArgs(rest),
+      'foreach ($fx_n in $fx_ns) {',
+      "  if ($fx_b -contains $fx_n) { '/usr/bin/' + $fx_n }",
+      '  else {',
+      '    $fx_w = fx-which $fx_n',
+      "    if ($fx_w -eq '') { $script:fx_exit = 1 }",
+      "    else { $fx_w.Replace('\\', '/') }",
+      '  }',
+      '}',
+    ].join('\n');
+  }
+  if (rest.length === 0) return '';
+  return translateSimple(
+    {
+      kind: 'SimpleCommand',
+      assignments: [],
+      name: rest[0],
+      args: rest.slice(1),
+      redirects: [],
+    },
+    ctx.position,
+    ctx.hasStdin,
+  );
+};
+
 /* ------------------------------------------------------------------ */
 /* whoami / id / groups                                                */
 /* ------------------------------------------------------------------ */
@@ -2535,6 +2587,7 @@ export const handlers: Record<string, Handler> = {
   sleep,
   which,
   type,
+  command: commandCmd,
   whoami,
   id,
   groups,

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -2489,7 +2489,35 @@ const alias: Handler = (args) => {
   return "[Console]::Error.WriteLine('fauxnix: alias is not supported'); $script:fx_exit = 1";
 };
 
-const set: Handler = () => ''; // silently ignore (`set -e`, `set --` ... no-op)
+const set: Handler = (args) => {
+  const raw = args.map(wordToString);
+  const unsupported = raw.filter(
+    (t) =>
+      t === '-e' ||
+      t === '-u' ||
+      t === '-x' ||
+      t === '-o' ||
+      t === '+e' ||
+      t === '+u' ||
+      t === '+x' ||
+      t.startsWith('-o') ||
+      t.startsWith('+o') ||
+      t === '-eu' ||
+      t === '-ue' ||
+      t === '-eux' ||
+      /^-.*[eux]/.test(t),
+  );
+  if (unsupported.length > 0) {
+    return (
+      '[Console]::Error.WriteLine(' +
+      psStr(
+        'fauxnix: set -e/-u/-x is not supported (would silently lie); use explicit || exit',
+      ) +
+      '); $script:fx_exit = 2'
+    );
+  }
+  return '';
+};
 
 /* ------------------------------------------------------------------ */
 

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -11,7 +11,11 @@ import {
   translateCmdSub,
   normalizeLiteralPath,
   pathExpr,
+<<<<<<< HEAD
   paramExpr,
+=======
+  varExpr,
+>>>>>>> pr/107
 } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
@@ -1488,8 +1492,13 @@ function kshExprOfWord(w: Word): string {
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
+<<<<<<< HEAD
     if (expanded[0].param) {
       return paramExpr(expanded[0].name, expanded[0].param.op, expanded[0].param.word);
+=======
+    if (expanded[0].length) {
+      return varExpr(expanded[0].name, expanded[0].index, true);
+>>>>>>> pr/107
     }
     if (expanded[0].index !== undefined) {
       return '(fx-subget ' + psStr(expanded[0].name) + ' ' + psStr(expanded[0].index) + ')';

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -11,6 +11,7 @@ import {
   translateCmdSub,
   normalizeLiteralPath,
   pathExpr,
+  paramExpr,
 } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
@@ -1487,6 +1488,9 @@ function kshExprOfWord(w: Word): string {
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
+    if (expanded[0].param) {
+      return paramExpr(expanded[0].name, expanded[0].param.op, expanded[0].param.word);
+    }
     if (expanded[0].index !== undefined) {
       return '(fx-subget ' + psStr(expanded[0].name) + ' ' + psStr(expanded[0].index) + ')';
     }
@@ -1511,7 +1515,9 @@ function kshExprOfWord(w: Word): string {
         break;
       case 'Var':
         out +=
-          p.index !== undefined
+          p.param
+            ? '$(' + paramExpr(p.name, p.param.op, p.param.word) + ')'
+            : p.index !== undefined
             ? '$(fx-subget ' + psStr(p.name) + ' ' + psStr(p.index) + ')'
             : '$(fx-envget ' + psStr(p.name) + ')';
         break;

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -11,6 +11,7 @@ import {
   translateCmdSub,
   normalizeLiteralPath,
   pathExpr,
+  varExpr,
 } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
@@ -1435,6 +1436,9 @@ function kshExprOfWord(w: Word): string {
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
+    if (expanded[0].length) {
+      return varExpr(expanded[0].name, expanded[0].index, true);
+    }
     if (expanded[0].index !== undefined) {
       return '(fx-subget ' + psStr(expanded[0].name) + ' ' + psStr(expanded[0].index) + ')';
     }

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -596,6 +596,58 @@ const type: Handler = (args) => {
   ].join('\n');
 };
 
+/** `command -v name` (and bare `command name args` as a no-alias run). */
+const commandCmd: Handler = (args, ctx) => {
+  let i = 0;
+  let identify = false;
+  while (i < args.length) {
+    const t = wordToString(args[i]);
+    if (t === '-v' || t === '-V') {
+      identify = true;
+      i++;
+      continue;
+    }
+    if (t === '--') {
+      i++;
+      break;
+    }
+    if (t.startsWith('-')) {
+      i++;
+      continue;
+    }
+    break;
+  }
+  const rest = args.slice(i);
+  if (identify) {
+    if (rest.length === 0) return '';
+    return [
+      PS_WHICH_FN,
+      '$fx_b = @(' + builtinNames().map(psStr).join(', ') + ')',
+      '$fx_ns = ' + textArgs(rest),
+      'foreach ($fx_n in $fx_ns) {',
+      "  if ($fx_b -contains $fx_n) { '/usr/bin/' + $fx_n }",
+      '  else {',
+      '    $fx_w = fx-which $fx_n',
+      "    if ($fx_w -eq '') { $script:fx_exit = 1 }",
+      "    else { $fx_w.Replace('\\', '/') }",
+      '  }',
+      '}',
+    ].join('\n');
+  }
+  if (rest.length === 0) return '';
+  return translateSimple(
+    {
+      kind: 'SimpleCommand',
+      assignments: [],
+      name: rest[0],
+      args: rest.slice(1),
+      redirects: [],
+    },
+    ctx.position,
+    ctx.hasStdin,
+  );
+};
+
 /* ------------------------------------------------------------------ */
 /* whoami / id / groups                                                */
 /* ------------------------------------------------------------------ */
@@ -2560,6 +2612,7 @@ export const handlers: Record<string, Handler> = {
   sleep,
   which,
   type,
+  command: commandCmd,
   whoami,
   id,
   groups,

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -2437,6 +2437,59 @@ const less: Handler = (args, ctx) => {
 };
 
 /* ------------------------------------------------------------------ */
+/* read                                                                */
+/* ------------------------------------------------------------------ */
+
+const readCmd: Handler = (args, ctx) => {
+  const names: string[] = [];
+  for (const w of args) {
+    const t = wordToString(w);
+    if (t === '-r' || t === '-a' || t.startsWith('-')) continue;
+    if (!NAME_RE.test(t)) {
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr('bash: read: `' + t + "': not a valid identifier") +
+        '); $script:fx_exit = 2'
+      );
+    }
+    names.push(t);
+  }
+  if (names.length === 0) names.push('REPLY');
+  const first = names[0];
+  return [
+    ctx.hasStdin
+      ? "$fx_line = [string]((@($input) | Select-Object -First 1))"
+      : "$fx_line = ''",
+    ctx.hasStdin ? '' : '$script:fx_exit = 1',
+    names.length === 1
+      ? [
+          "Set-Item -LiteralPath ('Env:\\' + " + psStr(first) + ') -Value $fx_line',
+          " $n = " + psStr(first),
+          " $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",
+          " $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
+          ' fx-arrdrop $n',
+          ' $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sv += $fx_pair } }',
+          ' $fx_sv += ($n + [string][char]61 + (fx-svenc $fx_line)); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)',
+        ].join('\n')
+      : [
+          "$fx_fs = @($fx_line -split '\\s+', " + names.length + ')',
+          'foreach ($fx_i in 0..' + (names.length - 1) + ') {',
+          '  $n = @(' + names.map(psStr).join(',') + ')[$fx_i]',
+          "  $fx_v = $(if ($fx_i -lt $fx_fs.Count) { [string]$fx_fs[$fx_i] } else { '' })",
+          "  Set-Item -LiteralPath ('Env:\\' + $n) -Value $fx_v",
+          "  $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) + $n) -join ';')",
+          "  $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne $n }) -join ';')",
+          '  fx-arrdrop $n',
+          '  $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne $n) { $fx_sv += $fx_pair } }',
+          '  $fx_sv += ($n + [string][char]61 + (fx-svenc $fx_v)); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)',
+          '}',
+        ].join('\n'),
+  ]
+    .filter((l) => l !== '')
+    .join('\n');
+};
+
+/* ------------------------------------------------------------------ */
 /* source / . / eval / exit / alias / set                              */
 /* ------------------------------------------------------------------ */
 
@@ -2532,6 +2585,7 @@ export const handlers: Record<string, Handler> = {
   history,
   less,
   more: less,
+  read: readCmd,
   source,
   '.': source,
   eval: evalCmd,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, backticks, control flow (if/for/while), background jobs.
+Not supported: heredocs, backticks, for/while, background jobs. `if/then/else/fi` is supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — but prefer COMBINING related commands in one call with ; or && (e.g. 'cd src && ls | wc -l'); each call is a fresh translation+process, so batching is faster than many tiny calls.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, for/while, background jobs. if/then/else/fi conditionals are supported.
+Not supported: heredocs, while/until/case, background jobs. if/then/else/fi and for-in loops are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — but prefer COMBINING related commands in one call with ; or && (e.g. 'cd src && ls | wc -l'); each call is a fresh translation+process, so batching is faster than many tiny calls.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, backticks, control flow (if/for/while), background jobs.
+Not supported: heredocs, control flow (if/for/while), background jobs.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — but prefer COMBINING related commands in one call with ; or && (e.g. 'cd src && ls | wc -l'); each call is a fresh translation+process, so batching is faster than many tiny calls.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, backticks, control flow (if/for/while), background jobs.
+Not supported: heredocs, backticks, if/while, background jobs. `for x in words; do ...; done` is supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — but prefer COMBINING related commands in one call with ; or && (e.g. 'cd src && ls | wc -l'); each call is a fresh translation+process, so batching is faster than many tiny calls.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, control flow (if/for/while), background jobs.
+Not supported: heredocs, for/while, background jobs. if/then/else/fi conditionals are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — but prefer COMBINING related commands in one call with ; or && (e.g. 'cd src && ls | wc -l'); each call is a fresh translation+process, so batching is faster than many tiny calls.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7,6 +7,8 @@ import {
   Redirect,
   RedirectOp,
   SimpleCommand,
+  IfCommand,
+  ShellCommand,
   Word,
   WordPart,
   isUnquotedLiteral,
@@ -540,9 +542,17 @@ export function parseCommand(input: string): CommandList {
   };
 
   const parsePipeline = (): Pipeline => {
-    const commands: SimpleCommand[] = [];
+    const commands: ShellCommand[] = [];
     for (;;) {
-      commands.push(parseSimple());
+      const kw = peekKw();
+      if (kw === 'if') {
+        if (commands.length > 0) {
+          throw new FauxnixParseError('fauxnix: if in a pipeline is not supported');
+        }
+        commands.push(parseIf());
+      } else {
+        commands.push(parseSimple());
+      }
       const t = peek();
       if (t.type === 'OP' && t.op === '|') {
         next();
@@ -551,6 +561,78 @@ export function parseCommand(input: string): CommandList {
       break;
     }
     return { kind: 'Pipeline', commands };
+  };
+
+  const peekKw = (): string | null => {
+    const t = peek();
+    if (t.type !== 'WORD' || !t.parts) return null;
+    const s = wordToString(t.parts);
+    if (!isUnquotedLiteral(t.parts, s)) return null;
+    if (
+      s === 'if' ||
+      s === 'then' ||
+      s === 'else' ||
+      s === 'elif' ||
+      s === 'fi' ||
+      s === 'for' ||
+      s === 'in' ||
+      s === 'do' ||
+      s === 'done' ||
+      s === 'while'
+    ) {
+      return s;
+    }
+    return null;
+  };
+
+  const expectKw = (k: string): void => {
+    if (peekKw() !== k) {
+      throw new FauxnixParseError('fauxnix: expected `' + k + "'");
+    }
+    next();
+  };
+
+  const parseListUntil = (stops: string[]): CommandList => {
+    const stop = new Set(stops);
+    const segments: ListSegment[] = [];
+    let op: ';' | '&&' | '||' = ';';
+    const isListSep = (o?: string) => o === ';' || o === '\n';
+    while (peek().type === 'OP' && isListSep(peek().op)) next();
+    while (peek().type !== 'EOF') {
+      const kw = peekKw();
+      if (kw && stop.has(kw)) break;
+      const pipeline = parsePipeline();
+      segments.push({ pipeline, op });
+      const t = peek();
+      if (t.type === 'OP' && (t.op === '&&' || t.op === '||' || isListSep(t.op))) {
+        op = t.op === '\n' ? ';' : (t.op as '&&' | '||' | ';');
+        next();
+        while (peek().type === 'OP' && isListSep(peek().op)) next();
+      } else {
+        break;
+      }
+    }
+    if (segments.length === 0) {
+      throw new FauxnixParseError('fauxnix: empty command');
+    }
+    return { kind: 'CommandList', segments };
+  };
+
+  const parseIf = (): IfCommand => {
+    expectKw('if');
+    const test = parseListUntil(['then']);
+    expectKw('then');
+    const thenL = parseListUntil(['else', 'elif', 'fi']);
+    let elseL: CommandList | undefined;
+    if (peekKw() === 'elif') {
+      throw new FauxnixParseError('fauxnix: elif is not supported yet; use else + if');
+    }
+    if (peekKw() === 'else') {
+      next();
+      elseL = parseListUntil(['fi']);
+    }
+    expectKw('fi');
+    return { kind: 'If', test, then: thenL, else: elseL, redirects: [] };
   };
 
   const parseSimple = (): SimpleCommand => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -163,6 +163,16 @@ export function tokenize(input: string): Token[] {
             continue;
           }
         }
+        if (c === '`') {
+          const v = readBacktick(input, i);
+          if (buf) {
+            parts.push({ kind: 'Text', text: buf });
+            buf = '';
+          }
+          parts.push(v.part);
+          i = v.next;
+          continue;
+        }
         buf += c;
         i++;
       }
@@ -189,9 +199,11 @@ export function tokenize(input: string): Token[] {
     }
 
     if (ch === '`') {
-      throw new FauxnixParseError(
-        'fauxnix: backticks are not supported. Use $(...) command substitution instead.',
-      );
+      const v = readBacktick(input, i);
+      beginWordPart();
+      cur.push(v.part);
+      i = v.next;
+      continue;
     }
 
     // escape outside quotes — keep the escape so [[ =~ ]] / == can
@@ -227,6 +239,23 @@ function isNameStart(c: string): boolean {
 }
 function isNameChar(c: string): boolean {
   return /[A-Za-z0-9_]/.test(c);
+}
+
+/** Parse `cmd` as command substitution (same AST as $(cmd)). */
+function readBacktick(input: string, i: number): { part: WordPart; next: number } {
+  if (input[i] !== '`') throw new FauxnixParseError('fauxnix: expected backtick');
+  let k = i + 1;
+  while (k < input.length) {
+    if (input[k] === '\\' && k + 1 < input.length) {
+      k += 2;
+      continue;
+    }
+    if (input[k] === '`') {
+      return { part: { kind: 'CmdSub', cmd: input.slice(i + 1, k) }, next: k + 1 };
+    }
+    k++;
+  }
+  throw new FauxnixParseError('fauxnix: unclosed backtick');
 }
 
 /** Parse $VAR, ${VAR}, $(cmd substitution). Returns null when not a valid dollar construct. */

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8,6 +8,7 @@ import {
   RedirectOp,
   SimpleCommand,
   IfCommand,
+  ForCommand,
   ShellCommand,
   Word,
   WordPart,
@@ -594,6 +595,11 @@ export function parseCommand(input: string): CommandList {
           throw new FauxnixParseError('fauxnix: if in a pipeline is not supported');
         }
         commands.push(parseIf());
+      } else if (kw === 'for') {
+        if (commands.length > 0) {
+          throw new FauxnixParseError('fauxnix: for in a pipeline is not supported');
+        }
+        commands.push(parseFor());
       } else {
         commands.push(parseSimple());
       }
@@ -677,6 +683,35 @@ export function parseCommand(input: string): CommandList {
     }
     expectKw('fi');
     return { kind: 'If', test, then: thenL, else: elseL, redirects: [] };
+  };
+
+  const parseFor = (): ForCommand => {
+    expectKw('for');
+    const nt = peek();
+    if (nt.type !== 'WORD' || !nt.parts) {
+      throw new FauxnixParseError('fauxnix: `for` expected a name');
+    }
+    const name = wordToString(nt.parts);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name) || !isUnquotedLiteral(nt.parts, name)) {
+      throw new FauxnixParseError('fauxnix: `for` name must be an identifier');
+    }
+    next();
+    expectKw('in');
+    const words: Word[] = [];
+    for (;;) {
+      while (peek().type === 'OP' && (peek().op === ';' || peek().op === '\n')) next();
+      if (peekKw() === 'do') break;
+      const t = peek();
+      if (t.type !== 'WORD' || !t.parts) {
+        throw new FauxnixParseError("fauxnix: `for` expected `do`");
+      }
+      words.push(t.parts);
+      next();
+    }
+    expectKw('do');
+    const body = parseListUntil(['done']);
+    expectKw('done');
+    return { kind: 'For', name, words, body, redirects: [] };
   };
 
   const parseSimple = (): SimpleCommand => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -245,6 +245,13 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     if (sub) {
       return { part: { kind: 'Var', name: sub[1], index: sub[2] }, next: end + 1 };
     }
+    const hash = name.match(/^#([A-Za-z_][A-Za-z0-9_]*)(\[([0-9]+|@|\*)\])?$/);
+    if (hash) {
+      return {
+        part: { kind: 'Var', name: hash[1], index: hash[3], length: true },
+        next: end + 1,
+      };
+    }
     if (!name || !isNameStart(name[0]) || !name.split('').every(isNameChar)) {
       // ${VAR:-default} etc. — unsupported, kept as raw text
       return { part: { kind: 'Text', text: input.slice(i, end + 1) }, next: end + 1 };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -245,11 +245,18 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     if (sub) {
       return { part: { kind: 'Var', name: sub[1], index: sub[2] }, next: end + 1 };
     }
+<<<<<<< HEAD
     const pm = name.match(/^([A-Za-z_][A-Za-z0-9_]*)(:?[-+?])(.*)$/);
     if (pm) {
       const op = pm[2] as ':-' | ':+' | ':?' | '-' | '+' | '?';
       return {
         part: { kind: 'Var', name: pm[1], param: { op, word: pm[3] } },
+=======
+    const hash = name.match(/^#([A-Za-z_][A-Za-z0-9_]*)(\[([0-9]+|@|\*)\])?$/);
+    if (hash) {
+      return {
+        part: { kind: 'Var', name: hash[1], index: hash[3], length: true },
+>>>>>>> pr/107
         next: end + 1,
       };
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7,6 +7,8 @@ import {
   Redirect,
   RedirectOp,
   SimpleCommand,
+  ForCommand,
+  ShellCommand,
   Word,
   WordPart,
   isUnquotedLiteral,
@@ -540,9 +542,17 @@ export function parseCommand(input: string): CommandList {
   };
 
   const parsePipeline = (): Pipeline => {
-    const commands: SimpleCommand[] = [];
+    const commands: ShellCommand[] = [];
     for (;;) {
-      commands.push(parseSimple());
+      const kw = peekKw();
+      if (kw === 'for') {
+        if (commands.length > 0) {
+          throw new FauxnixParseError('fauxnix: for in a pipeline is not supported');
+        }
+        commands.push(parseFor());
+      } else {
+        commands.push(parseSimple());
+      }
       const t = peek();
       if (t.type === 'OP' && t.op === '|') {
         next();
@@ -551,6 +561,89 @@ export function parseCommand(input: string): CommandList {
       break;
     }
     return { kind: 'Pipeline', commands };
+  };
+
+  const peekKw = (): string | null => {
+    const t = peek();
+    if (t.type !== 'WORD' || !t.parts) return null;
+    const s = wordToString(t.parts);
+    if (!isUnquotedLiteral(t.parts, s)) return null;
+    if (
+      s === 'if' ||
+      s === 'then' ||
+      s === 'else' ||
+      s === 'fi' ||
+      s === 'for' ||
+      s === 'in' ||
+      s === 'do' ||
+      s === 'done' ||
+      s === 'while'
+    ) {
+      return s;
+    }
+    return null;
+  };
+
+  const expectKw = (k: string): void => {
+    if (peekKw() !== k) {
+      throw new FauxnixParseError('fauxnix: expected `' + k + "'");
+    }
+    next();
+  };
+
+  const parseListUntil = (stops: string[]): CommandList => {
+    const stop = new Set(stops);
+    const segments: ListSegment[] = [];
+    let op: ';' | '&&' | '||' = ';';
+    const isListSep = (o?: string) => o === ';' || o === '\n';
+    while (peek().type === 'OP' && isListSep(peek().op)) next();
+    while (peek().type !== 'EOF') {
+      const kw = peekKw();
+      if (kw && stop.has(kw)) break;
+      const pipeline = parsePipeline();
+      segments.push({ pipeline, op });
+      const t = peek();
+      if (t.type === 'OP' && (t.op === '&&' || t.op === '||' || isListSep(t.op))) {
+        op = t.op === '\n' ? ';' : (t.op as '&&' | '||' | ';');
+        next();
+        while (peek().type === 'OP' && isListSep(peek().op)) next();
+      } else {
+        break;
+      }
+    }
+    if (segments.length === 0) {
+      throw new FauxnixParseError('fauxnix: empty command');
+    }
+    return { kind: 'CommandList', segments };
+  };
+
+  const parseFor = (): ForCommand => {
+    expectKw('for');
+    const nt = peek();
+    if (nt.type !== 'WORD' || !nt.parts) {
+      throw new FauxnixParseError('fauxnix: `for` expected a name');
+    }
+    const name = wordToString(nt.parts);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name) || !isUnquotedLiteral(nt.parts, name)) {
+      throw new FauxnixParseError('fauxnix: `for` name must be an identifier');
+    }
+    next();
+    expectKw('in');
+    const words: Word[] = [];
+    for (;;) {
+      while (peek().type === 'OP' && (peek().op === ';' || peek().op === '\n')) next();
+      if (peekKw() === 'do') break;
+      const t = peek();
+      if (t.type !== 'WORD' || !t.parts) {
+        throw new FauxnixParseError("fauxnix: `for` expected `do`");
+      }
+      words.push(t.parts);
+      next();
+    }
+    expectKw('do');
+    const body = parseListUntil(['done']);
+    expectKw('done');
+    return { kind: 'For', name, words, body, redirects: [] };
   };
 
   const parseSimple = (): SimpleCommand => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -245,8 +245,16 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     if (sub) {
       return { part: { kind: 'Var', name: sub[1], index: sub[2] }, next: end + 1 };
     }
+    const pm = name.match(/^([A-Za-z_][A-Za-z0-9_]*)(:?[-+?])(.*)$/);
+    if (pm) {
+      const op = pm[2] as ':-' | ':+' | ':?' | '-' | '+' | '?';
+      return {
+        part: { kind: 'Var', name: pm[1], param: { op, word: pm[3] } },
+        next: end + 1,
+      };
+    }
     if (!name || !isNameStart(name[0]) || !name.split('').every(isNameChar)) {
-      // ${VAR:-default} etc. — unsupported, kept as raw text
+      // ${VAR:=default} etc. still raw text
       return { part: { kind: 'Text', text: input.slice(i, end + 1) }, next: end + 1 };
     }
     return { part: { kind: 'Var', name }, next: end + 1 };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7,6 +7,8 @@ import {
   Redirect,
   RedirectOp,
   SimpleCommand,
+  IfCommand,
+  ShellCommand,
   Word,
   WordPart,
   isUnquotedLiteral,
@@ -274,18 +276,18 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     if (sub) {
       return { part: { kind: 'Var', name: sub[1], index: sub[2] }, next: end + 1 };
     }
-<<<<<<< HEAD
     const pm = name.match(/^([A-Za-z_][A-Za-z0-9_]*)(:?[-+?])(.*)$/);
     if (pm) {
       const op = pm[2] as ':-' | ':+' | ':?' | '-' | '+' | '?';
       return {
         part: { kind: 'Var', name: pm[1], param: { op, word: pm[3] } },
-=======
+        next: end + 1,
+      };
+    }
     const hash = name.match(/^#([A-Za-z_][A-Za-z0-9_]*)(\[([0-9]+|@|\*)\])?$/);
     if (hash) {
       return {
         part: { kind: 'Var', name: hash[1], index: hash[3], length: true },
->>>>>>> pr/107
         next: end + 1,
       };
     }
@@ -584,9 +586,17 @@ export function parseCommand(input: string): CommandList {
   };
 
   const parsePipeline = (): Pipeline => {
-    const commands: SimpleCommand[] = [];
+    const commands: ShellCommand[] = [];
     for (;;) {
-      commands.push(parseSimple());
+      const kw = peekKw();
+      if (kw === 'if') {
+        if (commands.length > 0) {
+          throw new FauxnixParseError('fauxnix: if in a pipeline is not supported');
+        }
+        commands.push(parseIf());
+      } else {
+        commands.push(parseSimple());
+      }
       const t = peek();
       if (t.type === 'OP' && t.op === '|') {
         next();
@@ -595,6 +605,78 @@ export function parseCommand(input: string): CommandList {
       break;
     }
     return { kind: 'Pipeline', commands };
+  };
+
+  const peekKw = (): string | null => {
+    const t = peek();
+    if (t.type !== 'WORD' || !t.parts) return null;
+    const s = wordToString(t.parts);
+    if (!isUnquotedLiteral(t.parts, s)) return null;
+    if (
+      s === 'if' ||
+      s === 'then' ||
+      s === 'else' ||
+      s === 'elif' ||
+      s === 'fi' ||
+      s === 'for' ||
+      s === 'in' ||
+      s === 'do' ||
+      s === 'done' ||
+      s === 'while'
+    ) {
+      return s;
+    }
+    return null;
+  };
+
+  const expectKw = (k: string): void => {
+    if (peekKw() !== k) {
+      throw new FauxnixParseError('fauxnix: expected `' + k + "'");
+    }
+    next();
+  };
+
+  const parseListUntil = (stops: string[]): CommandList => {
+    const stop = new Set(stops);
+    const segments: ListSegment[] = [];
+    let op: ';' | '&&' | '||' = ';';
+    const isListSep = (o?: string) => o === ';' || o === '\n';
+    while (peek().type === 'OP' && isListSep(peek().op)) next();
+    while (peek().type !== 'EOF') {
+      const kw = peekKw();
+      if (kw && stop.has(kw)) break;
+      const pipeline = parsePipeline();
+      segments.push({ pipeline, op });
+      const t = peek();
+      if (t.type === 'OP' && (t.op === '&&' || t.op === '||' || isListSep(t.op))) {
+        op = t.op === '\n' ? ';' : (t.op as '&&' | '||' | ';');
+        next();
+        while (peek().type === 'OP' && isListSep(peek().op)) next();
+      } else {
+        break;
+      }
+    }
+    if (segments.length === 0) {
+      throw new FauxnixParseError('fauxnix: empty command');
+    }
+    return { kind: 'CommandList', segments };
+  };
+
+  const parseIf = (): IfCommand => {
+    expectKw('if');
+    const test = parseListUntil(['then']);
+    expectKw('then');
+    const thenL = parseListUntil(['else', 'elif', 'fi']);
+    let elseL: CommandList | undefined;
+    if (peekKw() === 'elif') {
+      throw new FauxnixParseError('fauxnix: elif is not supported yet; use else + if');
+    }
+    if (peekKw() === 'else') {
+      next();
+      elseL = parseListUntil(['fi']);
+    }
+    expectKw('fi');
+    return { kind: 'If', test, then: thenL, else: elseL, redirects: [] };
   };
 
   const parseSimple = (): SimpleCommand => {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -4,6 +4,8 @@ import {
   FauxnixParseError,
   Redirect,
   SimpleCommand,
+  IfCommand,
+  CommandList,
   Word,
   WordPart,
   isUnquotedLiteral,
@@ -660,13 +662,46 @@ export interface PipelineParts {
  * multi-command pipelines become generated functions chained with `|`
  * (PS 5.1 forbids parenthesized expressions as non-first pipeline elements).
  */
-export function translatePipelineBody(p: { commands: SimpleCommand[] }): PipelineParts {
+function translateListInline(list: CommandList): string {
+  const chunks: string[] = [];
+  for (const seg of list.segments) {
+    const { defs, call } = translatePipelineBody(seg.pipeline);
+    const body = (defs ? defs + '\n' : '') + call;
+    if (seg.op === '&&') {
+      chunks.push('if ($script:fx_exit -eq 0) {\n' + body + '\n}');
+    } else if (seg.op === '||') {
+      chunks.push('if ($script:fx_exit -ne 0) {\n' + body + '\n}');
+    } else {
+      chunks.push(body);
+    }
+  }
+  return chunks.join('\n');
+}
+
+function translateIf(cmd: IfCommand): string {
+  const lines = [translateListInline(cmd.test), 'if ($script:fx_exit -eq 0) {'];
+  for (const l of translateListInline(cmd.then).split('\n')) lines.push(l ? '  ' + l : l);
+  if (cmd.else) {
+    lines.push('} else {');
+    for (const l of translateListInline(cmd.else).split('\n')) lines.push(l ? '  ' + l : l);
+    lines.push('}');
+  } else {
+    lines.push('}');
+  }
+  return lines.join('\n');
+}
+
+export function translatePipelineBody(p: {
+  commands: Array<SimpleCommand | IfCommand>;
+}): PipelineParts {
   const bodies: string[] = [];
   for (let i = 0; i < p.commands.length; i++) {
-    const hasStdin = i > 0 || p.commands[i].redirects.some((r) => r.op === '<');
+    const c = p.commands[i];
+    const hasStdin = i > 0 || c.redirects.some((r) => r.op === '<');
     const position: PipelineCtx['position'] =
       i === 0 ? 'first' : i === p.commands.length - 1 ? 'last' : 'middle';
-    bodies.push(translateSimple(p.commands[i], position, hasStdin));
+    if (c.kind === 'If') bodies.push(translateIf(c));
+    else bodies.push(translateSimple(c, position, hasStdin));
   }
 
   if (bodies.length === 1) {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -15,8 +15,55 @@ import { PipelineCtx, lookup, psStr } from './registry.js';
 /* Variable mapping                                                    */
 /* ------------------------------------------------------------------ */
 
+function paramWordExpr(word: string): string {
+  if (word.startsWith('$') && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(word)) {
+    return varExpr(word.slice(1));
+  }
+  return psStr(word);
+}
+
+/** `${name:-word}` and friends using case-exact fx-scalar0. */
+export function paramExpr(
+  name: string,
+  op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?',
+  word: string,
+): string {
+  const alt = paramWordExpr(word);
+  const get = '(fx-scalar0 ' + psStr(name) + ')';
+  const empty = '($null -eq $fx_pv -or [string]$fx_pv -eq \'\')';
+  const unset = '($null -eq $fx_pv)';
+  if (op === ':-') {
+    return '$( $fx_pv = ' + get + '; if (' + empty + ') { ' + alt + ' } else { $fx_pv } )';
+  }
+  if (op === '-') {
+    return '$( $fx_pv = ' + get + '; if (' + unset + ') { ' + alt + ' } else { $fx_pv } )';
+  }
+  if (op === ':+') {
+    return '$( $fx_pv = ' + get + '; if (' + empty + ') { \'\' } else { ' + alt + ' } )';
+  }
+  if (op === '+') {
+    return '$( $fx_pv = ' + get + '; if (' + unset + ') { \'\' } else { ' + alt + ' } )';
+  }
+  const msg = word === '' ? name + ': parameter null or not set' : name + ': ' + word;
+  const cond = op === ':?' ? empty : unset;
+  return (
+    '$( $fx_pv = ' +
+    get +
+    '; if (' +
+    cond +
+    ') { [Console]::Error.WriteLine(' +
+    psStr('bash: ' + msg) +
+    '); $script:fx_exit = 1; \'\' } else { $fx_pv } )'
+  );
+}
+
 /** Map a bash $VAR name to a PowerShell expression (usable inside $(...)). */
-export function varExpr(name: string, index?: string): string {
+export function varExpr(
+  name: string,
+  index?: string,
+  param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string },
+): string {
+  if (param) return paramExpr(name, param.op, param.word);
   // Indexed reads always go through fx-subget → fx-arrload → fx-scalar0 so
   // ${PWD[0]} keeps the special mapping and ${bash_rematch[0]} stays
   // case-exact (a `$env:name` fallback would alias BASH_REMATCH on Windows).
@@ -117,7 +164,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
 
   // single bare variable → bare expression
   if (expanded.length === 1 && expanded[0].kind === 'Var') {
-    return varExpr(expanded[0].name, expanded[0].index);
+    return varExpr(expanded[0].name, expanded[0].index, expanded[0].param);
   }
   // Bare `$(...)` must not sit inside a PS expandable string: the
   // substitution body contains `"` / `$_` that would break interpolation.
@@ -145,7 +192,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
         for (const q of p.parts) emitPart(q, true);
         break;
       case 'Var':
-        out += '$(' + varExpr(p.name, p.index) + ')';
+        out += '$(' + varExpr(p.name, p.index, p.param) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd, quoted || opts?.preserveCmdSub === true) + ')';

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -5,6 +5,7 @@ import {
   Redirect,
   SimpleCommand,
   IfCommand,
+  ForCommand,
   Word,
   WordPart,
   isUnquotedLiteral,
@@ -781,20 +782,48 @@ function translateListInline(list: CommandList): string {
 }
 
 function translateIf(cmd: IfCommand): string {
-  const lines = [translateListInline(cmd.test), 'if ($script:fx_exit -eq 0) {'];
+  // Branch bodies reset fx_exit first: the compound's exit status must come
+  // from the taken branch's last command (bash semantics), not leak the test's
+  // failure — `if false; then A; else B; fi` exits 0 in bash.
+  const lines = [translateListInline(cmd.test), 'if ($script:fx_exit -eq 0) {', '  $script:fx_exit = 0'];
   for (const l of translateListInline(cmd.then).split('\n')) lines.push(l ? '  ' + l : l);
+  lines.push('} else {', '  $script:fx_exit = 0');
   if (cmd.else) {
-    lines.push('} else {');
     for (const l of translateListInline(cmd.else).split('\n')) lines.push(l ? '  ' + l : l);
-    lines.push('}');
-  } else {
-    lines.push('}');
   }
+  lines.push('}');
+  return lines.join('\n');
+}
+
+function translateFor(cmd: ForCommand): string {
+  const n = cmd.name.replace(/'/g, "''");
+  const lines = [
+    '$fx_for = ' + argListExpr(cmd.words),
+    'foreach ($fx_it in @($fx_for)) {',
+    "  Set-Item -LiteralPath ('Env:\\' + '" + n + "') -Value ([string]$fx_it)",
+    "  $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne '" +
+      n +
+      "' }) + '" +
+      n +
+      "') -join ';')",
+    "  $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne '" +
+      n +
+      "' }) -join ';')",
+    '  fx-arrdrop ' + psStr(cmd.name),
+    "  $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne '" +
+      n +
+      "') { $fx_sv += $fx_pair } }",
+    "  $fx_sv += ('" +
+      n +
+      "' + [string][char]61 + (fx-svenc ([string]$fx_it))); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
+  ];
+  for (const l of translateListInline(cmd.body).split('\n')) lines.push(l ? '  ' + l : l);
+  lines.push('}');
   return lines.join('\n');
 }
 
 export function translatePipelineBody(p: {
-  commands: Array<SimpleCommand | IfCommand>;
+  commands: Array<SimpleCommand | IfCommand | ForCommand>;
 }): PipelineParts {
   const bodies: string[] = [];
   for (let i = 0; i < p.commands.length; i++) {
@@ -803,6 +832,7 @@ export function translatePipelineBody(p: {
     const position: PipelineCtx['position'] =
       i === 0 ? 'first' : i === p.commands.length - 1 ? 'last' : 'middle';
     if (c.kind === 'If') bodies.push(translateIf(c));
+    else if (c.kind === 'For') bodies.push(translateFor(c));
     else bodies.push(translateSimple(c, position, hasStdin));
   }
 

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -4,6 +4,8 @@ import {
   FauxnixParseError,
   Redirect,
   SimpleCommand,
+  ForCommand,
+  CommandList,
   Word,
   WordPart,
   isUnquotedLiteral,
@@ -660,13 +662,60 @@ export interface PipelineParts {
  * multi-command pipelines become generated functions chained with `|`
  * (PS 5.1 forbids parenthesized expressions as non-first pipeline elements).
  */
-export function translatePipelineBody(p: { commands: SimpleCommand[] }): PipelineParts {
+function translateListInline(list: CommandList): string {
+  const chunks: string[] = [];
+  for (const seg of list.segments) {
+    const { defs, call } = translatePipelineBody(seg.pipeline);
+    const body = (defs ? defs + '\n' : '') + call;
+    if (seg.op === '&&') {
+      chunks.push('if ($script:fx_exit -eq 0) {\n' + body + '\n}');
+    } else if (seg.op === '||') {
+      chunks.push('if ($script:fx_exit -ne 0) {\n' + body + '\n}');
+    } else {
+      chunks.push(body);
+    }
+  }
+  return chunks.join('\n');
+}
+
+function translateFor(cmd: ForCommand): string {
+  const n = cmd.name.replace(/'/g, "''");
+  const lines = [
+    '$fx_for = ' + argListExpr(cmd.words),
+    'foreach ($fx_it in @($fx_for)) {',
+    "  Set-Item -LiteralPath ('Env:\\' + '" + n + "') -Value ([string]$fx_it)",
+    "  $env:FAUXNIX_SETVARS = ((@($env:FAUXNIX_SETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne '" +
+      n +
+      "' }) + '" +
+      n +
+      "') -join ';')",
+    "  $env:FAUXNIX_UNSETVARS = (@($env:FAUXNIX_UNSETVARS -split ';' | Where-Object { $_ -ne '' -and $_ -cne '" +
+      n +
+      "' }) -join ';')",
+    '  fx-arrdrop ' + psStr(cmd.name),
+    "  $fx_sv = @(); foreach ($fx_pair in @($env:FAUXNIX_SETVALS -split [string][char]10)) { $fx_eq = $fx_pair.IndexOf([char]61); if ($fx_eq -lt 1) { continue }; if ($fx_pair.Substring(0, $fx_eq) -cne '" +
+      n +
+      "') { $fx_sv += $fx_pair } }",
+    "  $fx_sv += ('" +
+      n +
+      "' + [string][char]61 + (fx-svenc ([string]$fx_it))); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
+  ];
+  for (const l of translateListInline(cmd.body).split('\n')) lines.push(l ? '  ' + l : l);
+  lines.push('}');
+  return lines.join('\n');
+}
+
+export function translatePipelineBody(p: {
+  commands: Array<SimpleCommand | ForCommand>;
+}): PipelineParts {
   const bodies: string[] = [];
   for (let i = 0; i < p.commands.length; i++) {
-    const hasStdin = i > 0 || p.commands[i].redirects.some((r) => r.op === '<');
+    const c = p.commands[i];
+    const hasStdin = i > 0 || c.redirects.some((r) => r.op === '<');
     const position: PipelineCtx['position'] =
       i === 0 ? 'first' : i === p.commands.length - 1 ? 'last' : 'middle';
-    bodies.push(translateSimple(p.commands[i], position, hasStdin));
+    if (c.kind === 'For') bodies.push(translateFor(c));
+    else bodies.push(translateSimple(c, position, hasStdin));
   }
 
   if (bodies.length === 1) {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -16,7 +16,20 @@ import { PipelineCtx, lookup, psStr } from './registry.js';
 /* ------------------------------------------------------------------ */
 
 /** Map a bash $VAR name to a PowerShell expression (usable inside $(...)). */
-export function varExpr(name: string, index?: string): string {
+export function varExpr(name: string, index?: string, length = false): string {
+  if (length) {
+    if (index === '@' || index === '*') {
+      return '@(fx-arrload ' + psStr(name) + ').Count';
+    }
+    if (index !== undefined) {
+      return '([string](fx-subget ' + psStr(name) + ' ' + psStr(index) + ')).Length';
+    }
+    return (
+      '([string]$(if ($null -eq ($fx_pv = fx-scalar0 ' +
+      psStr(name) +
+      ')) { \'\' } else { $fx_pv })).Length'
+    );
+  }
   // Indexed reads always go through fx-subget → fx-arrload → fx-scalar0 so
   // ${PWD[0]} keeps the special mapping and ${bash_rematch[0]} stays
   // case-exact (a `$env:name` fallback would alias BASH_REMATCH on Windows).
@@ -117,7 +130,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
 
   // single bare variable → bare expression
   if (expanded.length === 1 && expanded[0].kind === 'Var') {
-    return varExpr(expanded[0].name, expanded[0].index);
+    return varExpr(expanded[0].name, expanded[0].index, expanded[0].length === true);
   }
   // Bare `$(...)` must not sit inside a PS expandable string: the
   // substitution body contains `"` / `$_` that would break interpolation.
@@ -145,7 +158,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
         for (const q of p.parts) emitPart(q, true);
         break;
       case 'Var':
-        out += '$(' + varExpr(p.name, p.index) + ')';
+        out += '$(' + varExpr(p.name, p.index, p.length === true) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd, quoted || opts?.preserveCmdSub === true) + ')';
@@ -199,7 +212,10 @@ export function splatSpec(w: Word): { name: string; prefix: string; suffix: stri
   let suffix = '';
   let seen = false;
   for (const { part: p, quoted } of parts) {
-    const splat = p.kind === 'Var' && (p.index === '@' || (p.index === '*' && !quoted));
+    const splat =
+      p.kind === 'Var' &&
+      !p.length &&
+      (p.index === '@' || (p.index === '*' && !quoted));
     if (splat) {
       if (seen) return null;
       seen = true;

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -4,6 +4,7 @@ import {
   FauxnixParseError,
   Redirect,
   SimpleCommand,
+  IfCommand,
   Word,
   WordPart,
   isUnquotedLiteral,
@@ -58,15 +59,13 @@ export function paramExpr(
 }
 
 /** Map a bash $VAR name to a PowerShell expression (usable inside $(...)). */
-<<<<<<< HEAD
 export function varExpr(
   name: string,
   index?: string,
   param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string },
+  length = false,
 ): string {
   if (param) return paramExpr(name, param.op, param.word);
-=======
-export function varExpr(name: string, index?: string, length = false): string {
   if (length) {
     if (index === '@' || index === '*') {
       return '@(fx-arrload ' + psStr(name) + ').Count';
@@ -80,7 +79,6 @@ export function varExpr(name: string, index?: string, length = false): string {
       ')) { \'\' } else { $fx_pv })).Length'
     );
   }
->>>>>>> pr/107
   // Indexed reads always go through fx-subget → fx-arrload → fx-scalar0 so
   // ${PWD[0]} keeps the special mapping and ${bash_rematch[0]} stays
   // case-exact (a `$env:name` fallback would alias BASH_REMATCH on Windows).
@@ -181,11 +179,8 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
 
   // single bare variable → bare expression
   if (expanded.length === 1 && expanded[0].kind === 'Var') {
-<<<<<<< HEAD
-    return varExpr(expanded[0].name, expanded[0].index, expanded[0].param);
-=======
-    return varExpr(expanded[0].name, expanded[0].index, expanded[0].length === true);
->>>>>>> pr/107
+    const v = expanded[0];
+    return varExpr(v.name, v.index, v.param, v.length === true);
   }
   // Bare `$(...)` must not sit inside a PS expandable string: the
   // substitution body contains `"` / `$_` that would break interpolation.
@@ -213,11 +208,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
         for (const q of p.parts) emitPart(q, true);
         break;
       case 'Var':
-<<<<<<< HEAD
-        out += '$(' + varExpr(p.name, p.index, p.param) + ')';
-=======
-        out += '$(' + varExpr(p.name, p.index, p.length === true) + ')';
->>>>>>> pr/107
+        out += '$(' + varExpr(p.name, p.index, p.param, p.length === true) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd, quoted || opts?.preserveCmdSub === true) + ')';
@@ -773,13 +764,46 @@ export interface PipelineParts {
  * multi-command pipelines become generated functions chained with `|`
  * (PS 5.1 forbids parenthesized expressions as non-first pipeline elements).
  */
-export function translatePipelineBody(p: { commands: SimpleCommand[] }): PipelineParts {
+function translateListInline(list: CommandList): string {
+  const chunks: string[] = [];
+  for (const seg of list.segments) {
+    const { defs, call } = translatePipelineBody(seg.pipeline);
+    const body = (defs ? defs + '\n' : '') + call;
+    if (seg.op === '&&') {
+      chunks.push('if ($script:fx_exit -eq 0) {\n' + body + '\n}');
+    } else if (seg.op === '||') {
+      chunks.push('if ($script:fx_exit -ne 0) {\n' + body + '\n}');
+    } else {
+      chunks.push(body);
+    }
+  }
+  return chunks.join('\n');
+}
+
+function translateIf(cmd: IfCommand): string {
+  const lines = [translateListInline(cmd.test), 'if ($script:fx_exit -eq 0) {'];
+  for (const l of translateListInline(cmd.then).split('\n')) lines.push(l ? '  ' + l : l);
+  if (cmd.else) {
+    lines.push('} else {');
+    for (const l of translateListInline(cmd.else).split('\n')) lines.push(l ? '  ' + l : l);
+    lines.push('}');
+  } else {
+    lines.push('}');
+  }
+  return lines.join('\n');
+}
+
+export function translatePipelineBody(p: {
+  commands: Array<SimpleCommand | IfCommand>;
+}): PipelineParts {
   const bodies: string[] = [];
   for (let i = 0; i < p.commands.length; i++) {
-    const hasStdin = i > 0 || p.commands[i].redirects.some((r) => r.op === '<');
+    const c = p.commands[i];
+    const hasStdin = i > 0 || c.redirects.some((r) => r.op === '<');
     const position: PipelineCtx['position'] =
       i === 0 ? 'first' : i === p.commands.length - 1 ? 'last' : 'middle';
-    bodies.push(translateSimple(p.commands[i], position, hasStdin));
+    if (c.kind === 'If') bodies.push(translateIf(c));
+    else bodies.push(translateSimple(c, position, hasStdin));
   }
 
   if (bodies.length === 1) {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -58,12 +58,29 @@ export function paramExpr(
 }
 
 /** Map a bash $VAR name to a PowerShell expression (usable inside $(...)). */
+<<<<<<< HEAD
 export function varExpr(
   name: string,
   index?: string,
   param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string },
 ): string {
   if (param) return paramExpr(name, param.op, param.word);
+=======
+export function varExpr(name: string, index?: string, length = false): string {
+  if (length) {
+    if (index === '@' || index === '*') {
+      return '@(fx-arrload ' + psStr(name) + ').Count';
+    }
+    if (index !== undefined) {
+      return '([string](fx-subget ' + psStr(name) + ' ' + psStr(index) + ')).Length';
+    }
+    return (
+      '([string]$(if ($null -eq ($fx_pv = fx-scalar0 ' +
+      psStr(name) +
+      ')) { \'\' } else { $fx_pv })).Length'
+    );
+  }
+>>>>>>> pr/107
   // Indexed reads always go through fx-subget → fx-arrload → fx-scalar0 so
   // ${PWD[0]} keeps the special mapping and ${bash_rematch[0]} stays
   // case-exact (a `$env:name` fallback would alias BASH_REMATCH on Windows).
@@ -164,7 +181,11 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
 
   // single bare variable → bare expression
   if (expanded.length === 1 && expanded[0].kind === 'Var') {
+<<<<<<< HEAD
     return varExpr(expanded[0].name, expanded[0].index, expanded[0].param);
+=======
+    return varExpr(expanded[0].name, expanded[0].index, expanded[0].length === true);
+>>>>>>> pr/107
   }
   // Bare `$(...)` must not sit inside a PS expandable string: the
   // substitution body contains `"` / `$_` that would break interpolation.
@@ -192,7 +213,11 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
         for (const q of p.parts) emitPart(q, true);
         break;
       case 'Var':
+<<<<<<< HEAD
         out += '$(' + varExpr(p.name, p.index, p.param) + ')';
+=======
+        out += '$(' + varExpr(p.name, p.index, p.length === true) + ')';
+>>>>>>> pr/107
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd, quoted || opts?.preserveCmdSub === true) + ')';
@@ -246,7 +271,10 @@ export function splatSpec(w: Word): { name: string; prefix: string; suffix: stri
   let suffix = '';
   let seen = false;
   for (const { part: p, quoted } of parts) {
-    const splat = p.kind === 'Var' && (p.index === '@' || (p.index === '*' && !quoted));
+    const splat =
+      p.kind === 'Var' &&
+      !p.length &&
+      (p.index === '@' || (p.index === '*' && !quoted));
     if (splat) {
       if (seen) return null;
       seen = true;

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -273,6 +273,13 @@ export function translateCmdSub(cmdText: string, keepNl = false): string {
 /* Simple command translation                                          */
 /* ------------------------------------------------------------------ */
 
+function indentBlock(s: string): string {
+  return s
+    .split('\n')
+    .map((l) => (l ? '  ' + l : l))
+    .join('\n');
+}
+
 export function translateSimple(
   cmd: SimpleCommand,
   position: PipelineCtx['position'],
@@ -297,20 +304,51 @@ export function translateSimple(
   let body: string;
   if (nameSplat) {
     const invoke = '& $fx_cmd @fx_na';
-    body = [
+    const hasAffix = !!(nameSplat.prefix || nameSplat.suffix);
+    const promoted =
+      cmd.args.length === 0
+        ? ''
+        : translateSimple(
+            {
+              kind: 'SimpleCommand',
+              assignments: [],
+              name: cmd.args[0],
+              args: cmd.args.slice(1),
+              redirects: cmd.redirects,
+            },
+            position,
+            hasStdin,
+          );
+    const emptyCmdLines: string[] = [
       '$fx_cw = @(fx-arrload ' + psStr(nameSplat.name) + ')',
-      'if ($fx_cw.Count -eq 0) { $fx_cw = @(' + psStr(nameSplat.prefix + nameSplat.suffix) + ') }',
-      'else { $fx_cw[0] = ' +
-        psStr(nameSplat.prefix) +
-        ' + $fx_cw[0]; $fx_cw[$fx_cw.Count-1] = $fx_cw[$fx_cw.Count-1] + ' +
-        psStr(nameSplat.suffix) +
-        ' }',
-      '$fx_cmd = [string]$fx_cw[0]',
-      '$fx_na = ' + argListExpr(cmd.args),
-      'if ($fx_cw.Count -gt 1) { $fx_na = @($fx_cw[1..($fx_cw.Count - 1)]) + $fx_na }',
-      (hasStdin ? '($input | ' + invoke + ')' : invoke) + ' | ForEach-Object { [string]$_ }',
-      'if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 }',
-    ].join('\n');
+    ];
+    if (hasAffix) {
+      emptyCmdLines.push(
+        'if ($fx_cw.Count -eq 0) { $fx_cw = @(' +
+          psStr(nameSplat.prefix + nameSplat.suffix) +
+          ') } else { $fx_cw[0] = ' +
+          psStr(nameSplat.prefix) +
+          ' + $fx_cw[0]; $fx_cw[$fx_cw.Count-1] = $fx_cw[$fx_cw.Count-1] + ' +
+          psStr(nameSplat.suffix) +
+          ' }',
+      );
+    }
+    emptyCmdLines.push(
+      'if ($fx_cw.Count -eq 0) {',
+      // No words left → bash null command (exit 0). Remaining words are
+      // known at compile time, so reuse translateSimple (handlers, not `&`).
+      promoted ? indentBlock(promoted) : '  ',
+      '} else {',
+      '  $fx_na = [object[]]@(' + argListExpr(cmd.args) + ')',
+      '  $fx_cmd = [string]$fx_cw[0]',
+      '  if ($fx_cw.Count -gt 1) { $fx_na = @($fx_cw[1..($fx_cw.Count - 1)]) + $fx_na }',
+      '  ' +
+        (hasStdin ? '($input | ' + invoke + ')' : invoke) +
+        ' | ForEach-Object { [string]$_ }',
+      '  if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE } elseif ($LASTEXITCODE -lt 0) { $script:fx_exit = 1 }',
+      '}',
+    );
+    body = emptyCmdLines.join('\n');
   } else if (nameLit !== null) {
     const handler = lookup(nameLit);
     if (handler && !(nameLit === '[[' && !isUnquotedLiteral(cmd.name, '[['))) {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -711,6 +711,12 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
   });
 
+  it('read -r stores a line from a pipe into the session', async () => {
+    expect((await run("printf 'hello\\n' | read -r X; echo $X")).stdout.trim()).toBe('hello');
+    expect((await run("printf 'a b c\\n' | read A B; echo $A $B")).stdout.trim()).toBe('a b c');
+    await run('unset X A B');
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -474,6 +474,9 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     writeFileSync(join(dir, 'b'), 'Y', 'utf8');
     expect((await run('[[ abc =~ ^a(.)c$ ]]; cat "${BASH_REMATCH[@]}"')).stdout.trim()).toBe('X\nY');
     await run('unset BASH_REMATCH');
+    expect((await run('unset X; ${X[@]}')).exitCode).toBe(0);
+    expect((await run('unset X; ${X[@]} echo ok')).stdout.trim()).toBe('ok');
+    expect((await run('unset X; ${X[@]} printf %s hi')).stdout).toBe('hi');
   }, 60000);
 
   it('&& and || short-circuit like bash', async () => {
@@ -709,6 +712,12 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
 
   it('uname reports fauxnix kernel marker', async () => {
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
+  });
+
+  it('command -v finds builtins and missing names', async () => {
+    expect((await run('command -v echo')).stdout.trim()).toBe('/usr/bin/echo');
+    expect((await run('command -v definitely_not_a_cmd_xyz')).exitCode).toBe(1);
+    expect((await run('command echo hi')).stdout.trim()).toBe('hi');
   });
 
   it('read -r stores a line from a pipe into the session', async () => {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -714,6 +714,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
   });
 
+<<<<<<< HEAD
   it('command -v finds builtins and missing names', async () => {
     expect((await run('command -v echo')).stdout.trim()).toBe('/usr/bin/echo');
     expect((await run('command -v definitely_not_a_cmd_xyz')).exitCode).toBe(1);
@@ -748,6 +749,12 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     const miss = await run('unset X; echo ${X:?missing}');
     expect(miss.exitCode).toBe(1);
     expect(miss.stderr).toMatch(/X: missing/);
+=======
+  it('${#name} is string length and ${#name[@]} is element count', async () => {
+    expect((await run('X=abcd; echo ${#X}; unset X')).stdout.trim()).toBe('4');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${#BASH_REMATCH[@]}')).stdout.trim()).toBe('2');
+    expect((await run('unset Z; echo ${#Z}')).stdout.trim()).toBe('0');
+>>>>>>> pr/107
   });
 
   it('date format tokens', async () => {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -732,6 +732,13 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     await run('unset X A B');
   });
 
+  it('set -e fails loudly instead of no-op', async () => {
+    const r = await run('set -e');
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/set -e\/-u\/-x is not supported/);
+    expect((await run('set --')).exitCode).toBe(0);
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -711,6 +711,17 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
   });
 
+  it('${name:-word} and ${name:+word} follow bash empty/unset rules', async () => {
+    expect((await run('unset X; echo ${X:-def}')).stdout.trim()).toBe('def');
+    expect((await run('X=; echo ${X:-def}; unset X')).stdout.trim()).toBe('def');
+    expect((await run('X=hi; echo ${X:-def}; unset X')).stdout.trim()).toBe('hi');
+    expect((await run('X=hi; echo ${X:+on}; unset X')).stdout.trim()).toBe('on');
+    expect((await run('unset X; echo [${X:+on}]')).stdout.trim()).toBe('[]');
+    const miss = await run('unset X; echo ${X:?missing}');
+    expect(miss.exitCode).toBe(1);
+    expect(miss.stderr).toMatch(/X: missing/);
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -726,6 +726,12 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     await run('unset FOO BAZ QUOT');
   });
 
+  it('read -r stores a line from a pipe into the session', async () => {
+    expect((await run("printf 'hello\\n' | read -r X; echo $X")).stdout.trim()).toBe('hello');
+    expect((await run("printf 'a b c\\n' | read A B; echo $A $B")).stdout.trim()).toBe('a b c');
+    await run('unset X A B');
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -4,7 +4,7 @@
  */
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync, appendFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parseCommand } from '../src/parser.js';
@@ -41,7 +41,13 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
   });
 
   async function run(cmd: string) {
-    return session.run(translateCommandList(parseCommand(cmd)));
+    const t0 = Date.now();
+    const r = await session.run(translateCommandList(parseCommand(cmd)));
+    if (process.env.FX_TRACE) {
+      console.error(`[trace ${((Date.now() - t0) / 1000).toFixed(1)}s] ${cmd.slice(0, 70)} => ${r.exitCode}`);
+      appendFileSync(join(tmpdir(), 'fx-trace.log'), cmd + '\x1e');
+    }
+    return r;
   }
 
   it('cat reads files', async () => {
@@ -452,7 +458,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
         )
       ).exitCode
     ).toBe(0);
-  }, 180000);
+  }, 420000);
 
   it('array subscripts splat across commands and persist correctly', async () => {
     expect(
@@ -522,7 +528,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('echo $FX_P')).stdout.trim()).toBe('via');
     await run('unset FX_P FX_K FX_A FX_B FX_N');
     expect((await run('FX_P=bar true; echo x$FX_P')).stdout.trim()).toBe('x');
-  }, 20000);
+  }, 60000);
 
   it('standalone assignment segments persist and feed later commands (#82)', async () => {
     expect((await run('SA_V=hello; echo $SA_V')).stdout.trim()).toBe('hello');
@@ -762,6 +768,13 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('if false; then echo YES; else echo NO; fi')).stdout.trim()).toBe('NO');
     expect((await run('if true; then echo A; else echo B; fi')).stdout.trim()).toBe('A');
     expect((await run('if false; then echo YES; fi')).stdout.trim()).toBe('');
+  });
+
+  it('for x in words; do ...; done iterates in the same session', async () => {
+    expect((await run('for x in a b c; do echo $x; done')).stdout.trim()).toBe('a\nb\nc');
+    expect((await run('for x in 1 2; do echo n$x; done; echo z$x')).stdout.trim()).toBe(
+      'n1\nn2\nz2',
+    );
   });
 
   it('date format tokens', async () => {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -491,6 +491,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
   it('variables and command substitution', async () => {
     expect((await run('export GREET=hi; echo $GREET/there')).stdout.trim()).toBe('hi/there');
     expect((await run('echo $(echo nested)')).stdout.trim()).toBe('nested');
+    expect((await run('echo `echo nested`')).stdout.trim()).toBe('nested');
     expect((await run("echo \"[$(printf 'a\\nb')]\"")).stdout).toBe('[a\nb]\n');
     expect((await run("[[ \"$(printf 'a\\nb')\" == \"a\nb\" ]]")).exitCode).toBe(0);
     expect((await run("X=$(printf 'a\\nb'); echo \"[$X]\"")).stdout).toBe('[a\nb]\n');

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -711,6 +711,13 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
   });
 
+  it('if/then/else/fi follows the test exit code', async () => {
+    expect((await run('if true; then echo YES; fi')).stdout.trim()).toBe('YES');
+    expect((await run('if false; then echo YES; else echo NO; fi')).stdout.trim()).toBe('NO');
+    expect((await run('if true; then echo A; else echo B; fi')).stdout.trim()).toBe('A');
+    expect((await run('if false; then echo YES; fi')).stdout.trim()).toBe('');
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -711,6 +711,13 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
   });
 
+  it('set -e fails loudly instead of no-op', async () => {
+    const r = await run('set -e');
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/set -e\/-u\/-x is not supported/);
+    expect((await run('set --')).exitCode).toBe(0);
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -715,7 +715,6 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
   });
 
-<<<<<<< HEAD
   it('command -v finds builtins and missing names', async () => {
     expect((await run('command -v echo')).stdout.trim()).toBe('/usr/bin/echo');
     expect((await run('command -v definitely_not_a_cmd_xyz')).exitCode).toBe(1);
@@ -750,12 +749,19 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     const miss = await run('unset X; echo ${X:?missing}');
     expect(miss.exitCode).toBe(1);
     expect(miss.stderr).toMatch(/X: missing/);
-=======
+  });
+
   it('${#name} is string length and ${#name[@]} is element count', async () => {
     expect((await run('X=abcd; echo ${#X}; unset X')).stdout.trim()).toBe('4');
     expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${#BASH_REMATCH[@]}')).stdout.trim()).toBe('2');
     expect((await run('unset Z; echo ${#Z}')).stdout.trim()).toBe('0');
->>>>>>> pr/107
+  });
+
+  it('if/then/else/fi follows the test exit code', async () => {
+    expect((await run('if true; then echo YES; fi')).stdout.trim()).toBe('YES');
+    expect((await run('if false; then echo YES; else echo NO; fi')).stdout.trim()).toBe('NO');
+    expect((await run('if true; then echo A; else echo B; fi')).stdout.trim()).toBe('A');
+    expect((await run('if false; then echo YES; fi')).stdout.trim()).toBe('');
   });
 
   it('date format tokens', async () => {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -474,6 +474,9 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     writeFileSync(join(dir, 'b'), 'Y', 'utf8');
     expect((await run('[[ abc =~ ^a(.)c$ ]]; cat "${BASH_REMATCH[@]}"')).stdout.trim()).toBe('X\nY');
     await run('unset BASH_REMATCH');
+    expect((await run('unset X; ${X[@]}')).exitCode).toBe(0);
+    expect((await run('unset X; ${X[@]} echo ok')).stdout.trim()).toBe('ok');
+    expect((await run('unset X; ${X[@]} printf %s hi')).stdout).toBe('hi');
   }, 60000);
 
   it('&& and || short-circuit like bash', async () => {
@@ -709,6 +712,12 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
 
   it('uname reports fauxnix kernel marker', async () => {
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
+  });
+
+  it('command -v finds builtins and missing names', async () => {
+    expect((await run('command -v echo')).stdout.trim()).toBe('/usr/bin/echo');
+    expect((await run('command -v definitely_not_a_cmd_xyz')).exitCode).toBe(1);
+    expect((await run('command echo hi')).stdout.trim()).toBe('hi');
   });
 
   it('set -e fails loudly instead of no-op', async () => {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -494,6 +494,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
   it('variables and command substitution', async () => {
     expect((await run('export GREET=hi; echo $GREET/there')).stdout.trim()).toBe('hi/there');
     expect((await run('echo $(echo nested)')).stdout.trim()).toBe('nested');
+    expect((await run('echo `echo nested`')).stdout.trim()).toBe('nested');
     expect((await run("echo \"[$(printf 'a\\nb')]\"")).stdout).toBe('[a\nb]\n');
     expect((await run("[[ \"$(printf 'a\\nb')\" == \"a\nb\" ]]")).exitCode).toBe(0);
     expect((await run("X=$(printf 'a\\nb'); echo \"[$X]\"")).stdout).toBe('[a\nb]\n');

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -739,6 +739,17 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('set --')).exitCode).toBe(0);
   });
 
+  it('${name:-word} and ${name:+word} follow bash empty/unset rules', async () => {
+    expect((await run('unset X; echo ${X:-def}')).stdout.trim()).toBe('def');
+    expect((await run('X=; echo ${X:-def}; unset X')).stdout.trim()).toBe('def');
+    expect((await run('X=hi; echo ${X:-def}; unset X')).stdout.trim()).toBe('hi');
+    expect((await run('X=hi; echo ${X:+on}; unset X')).stdout.trim()).toBe('on');
+    expect((await run('unset X; echo [${X:+on}]')).stdout.trim()).toBe('[]');
+    const miss = await run('unset X; echo ${X:?missing}');
+    expect(miss.exitCode).toBe(1);
+    expect(miss.stderr).toMatch(/X: missing/);
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -711,6 +711,13 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
   });
 
+  it('for x in words; do ...; done iterates in the same session', async () => {
+    expect((await run('for x in a b c; do echo $x; done')).stdout.trim()).toBe('a\nb\nc');
+    expect((await run('for x in 1 2; do echo n$x; done; echo z$x')).stdout.trim()).toBe(
+      'n1\nn2\nz2',
+    );
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -711,6 +711,12 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
   });
 
+  it('${#name} is string length and ${#name[@]} is element count', async () => {
+    expect((await run('X=abcd; echo ${#X}; unset X')).stdout.trim()).toBe('4');
+    expect((await run('[[ abc =~ ^a(.)c$ ]]; echo ${#BASH_REMATCH[@]}')).stdout.trim()).toBe('2');
+    expect((await run('unset Z; echo ${#Z}')).stdout.trim()).toBe('0');
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -94,6 +94,12 @@ describe('parser', () => {
     expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'Z', param: { op: ':?', word: 'err' } }]);
   });
 
+  it('parses ${#name} and ${#name[@]}', () => {
+    const cmd = parse('echo ${#X} ${#Y[@]}').segments[0].pipeline.commands[0];
+    expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'X', length: true }]);
+    expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'Y', index: '@', length: true }]);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -81,6 +81,12 @@ describe('parser', () => {
     expect(exprOfWord(a.assignments[0].value, { preserveCmdSub: true })).not.toContain("-join ' '");
   });
 
+  it('parses ${#name} and ${#name[@]}', () => {
+    const cmd = parse('echo ${#X} ${#Y[@]}').segments[0].pipeline.commands[0];
+    expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'X', length: true }]);
+    expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'Y', index: '@', length: true }]);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -10,7 +10,7 @@ import {
   varExpr,
   wrapScript,
 } from '../src/translator.js';
-import { parseWords, psStr } from '../src/registry.js';
+import { lookup, parseWords, psStr } from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import { normalizeStderr } from '../src/errors.js';
 import '../src/commands/install-all.js';
@@ -94,6 +94,10 @@ describe('parser', () => {
     expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'x', index: '@' }]);
   });
 
+  it('registers command as a builtin', () => {
+    expect(lookup('command')).toBeTypeOf('function');
+  });
+
   it('detects [@] splat through surrounding quotes', () => {
     const cmd = parse('printf x pre"${a[@]}"post').segments[0].pipeline.commands[0];
     expect(splatSpec(cmd.args[1])).toEqual({ name: 'a', prefix: 'pre', suffix: 'post' });
@@ -102,6 +106,15 @@ describe('parser', () => {
   it('does not splat quoted ${name[*]}', () => {
     const cmd = parse('printf x "${a[*]}"').segments[0].pipeline.commands[0];
     expect(splatSpec(cmd.args[1])).toBeNull();
+  });
+
+  it('promotes the next word when a command-position [@] is empty', () => {
+    const empty = translateCommandList(parse('${X[@]}'))[0].script;
+    expect(empty).toContain('if ($fx_cw.Count -eq 0)');
+    expect(empty).not.toContain("bash: : command not found");
+    const one = translateCommandList(parse('${X[@]} printf %s hi'))[0].script;
+    expect(one).toContain('fx-printf');
+    expect(one).toContain('[object[]]');
   });
 
   it('splats unquoted ${name[*]}', () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -100,6 +100,16 @@ describe('parser', () => {
     expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'Y', index: '@', length: true }]);
   });
 
+  it('parses if/then/else/fi as one compound command', () => {
+    const list = parse('if true; then echo x; else echo y; fi');
+    expect(list.segments).toHaveLength(1);
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('If');
+    if (c.kind !== 'If') return;
+    expect(c.then.segments).toHaveLength(1);
+    expect(c.else?.segments).toHaveLength(1);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -114,8 +114,9 @@ describe('parser', () => {
     expect(() => parse('cat <<EOF')).toThrow(/heredoc/);
   });
 
-  it('rejects backticks', () => {
-    expect(() => parse('echo `date`')).toThrow(/backtick/);
+  it('parses backticks as command substitution', () => {
+    const cmd = parse('echo `date +%Y`').segments[0].pipeline.commands[0];
+    expect(cmd.args[0].some((p) => p.kind === 'CmdSub' && p.cmd === 'date +%Y')).toBe(true);
   });
 
   it('rejects tokens after the closing ]]', () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -81,6 +81,16 @@ describe('parser', () => {
     expect(exprOfWord(a.assignments[0].value, { preserveCmdSub: true })).not.toContain("-join ' '");
   });
 
+  it('parses if/then/else/fi as one compound command', () => {
+    const list = parse('if true; then echo x; else echo y; fi');
+    expect(list.segments).toHaveLength(1);
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('If');
+    if (c.kind !== 'If') return;
+    expect(c.then.segments).toHaveLength(1);
+    expect(c.else?.segments).toHaveLength(1);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -10,7 +10,7 @@ import {
   varExpr,
   wrapScript,
 } from '../src/translator.js';
-import { parseWords, psStr } from '../src/registry.js';
+import { lookup, parseWords, psStr } from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import { normalizeStderr } from '../src/errors.js';
 import '../src/commands/install-all.js';
@@ -88,6 +88,10 @@ describe('parser', () => {
     expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'x', index: '@' }]);
   });
 
+  it('registers command as a builtin', () => {
+    expect(lookup('command')).toBeTypeOf('function');
+  });
+
   it('detects [@] splat through surrounding quotes', () => {
     const cmd = parse('printf x pre"${a[@]}"post').segments[0].pipeline.commands[0];
     expect(splatSpec(cmd.args[1])).toEqual({ name: 'a', prefix: 'pre', suffix: 'post' });
@@ -96,6 +100,15 @@ describe('parser', () => {
   it('does not splat quoted ${name[*]}', () => {
     const cmd = parse('printf x "${a[*]}"').segments[0].pipeline.commands[0];
     expect(splatSpec(cmd.args[1])).toBeNull();
+  });
+
+  it('promotes the next word when a command-position [@] is empty', () => {
+    const empty = translateCommandList(parse('${X[@]}'))[0].script;
+    expect(empty).toContain('if ($fx_cw.Count -eq 0)');
+    expect(empty).not.toContain("bash: : command not found");
+    const one = translateCommandList(parse('${X[@]} printf %s hi'))[0].script;
+    expect(one).toContain('fx-printf');
+    expect(one).toContain('[object[]]');
   });
 
   it('splats unquoted ${name[*]}', () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -87,6 +87,13 @@ describe('parser', () => {
     expect(script).toContain('$script:fx_exit = 2');
   });
 
+  it('parses ${name:-word} parameter defaults', () => {
+    const cmd = parse('echo ${X:-def} ${Y:+on} ${Z:?err}').segments[0].pipeline.commands[0];
+    expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'X', param: { op: ':-', word: 'def' } }]);
+    expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'Y', param: { op: ':+', word: 'on' } }]);
+    expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'Z', param: { op: ':?', word: 'err' } }]);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -81,6 +81,13 @@ describe('parser', () => {
     expect(exprOfWord(a.assignments[0].value, { preserveCmdSub: true })).not.toContain("-join ' '");
   });
 
+  it('parses ${name:-word} parameter defaults', () => {
+    const cmd = parse('echo ${X:-def} ${Y:+on} ${Z:?err}').segments[0].pipeline.commands[0];
+    expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'X', param: { op: ':-', word: 'def' } }]);
+    expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'Y', param: { op: ':+', word: 'on' } }]);
+    expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'Z', param: { op: ':?', word: 'err' } }]);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -146,8 +146,9 @@ describe('parser', () => {
     expect(() => parse('cat <<EOF')).toThrow(/heredoc/);
   });
 
-  it('rejects backticks', () => {
-    expect(() => parse('echo `date`')).toThrow(/backtick/);
+  it('parses backticks as command substitution', () => {
+    const cmd = parse('echo `date +%Y`').segments[0].pipeline.commands[0];
+    expect(cmd.args[0].some((p) => p.kind === 'CmdSub' && p.cmd === 'date +%Y')).toBe(true);
   });
 
   it('rejects tokens after the closing ]]', () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -110,6 +110,15 @@ describe('parser', () => {
     expect(c.else?.segments).toHaveLength(1);
   });
 
+  it('parses for name in words; do ...; done', () => {
+    const list = parse('for x in a b c; do echo $x; done');
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('For');
+    if (c.kind !== 'For') return;
+    expect(c.name).toBe('x');
+    expect(c.words).toHaveLength(3);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -81,6 +81,15 @@ describe('parser', () => {
     expect(exprOfWord(a.assignments[0].value, { preserveCmdSub: true })).not.toContain("-join ' '");
   });
 
+  it('parses for name in words; do ...; done', () => {
+    const list = parse('for x in a b c; do echo $x; done');
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('For');
+    if (c.kind !== 'For') return;
+    expect(c.name).toBe('x');
+    expect(c.words).toHaveLength(3);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -81,6 +81,12 @@ describe('parser', () => {
     expect(exprOfWord(a.assignments[0].value, { preserveCmdSub: true })).not.toContain("-join ' '");
   });
 
+  it('set -e is a loud usage error, not a silent no-op', () => {
+    const script = translateCommandList(parse('set -e'))[0].script;
+    expect(script).toMatch(/set -e\/-u\/-x is not supported/);
+    expect(script).toContain('$script:fx_exit = 2');
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);


### PR DESCRIPTION
Maintainer-side integration of the remaining wave-2 PRs per the CONTRIBUTING integration-PR rule. Sequential GitHub merging stalled on repeated same-anchor conflicts, so this branch unions #103–#110 with semantic resolutions:

**Semantic resolutions** (the parts a naive merge would get wrong):
- `varExpr` unified to the 4-arg signature (`param` object + `length` flag coexist) — same resolution posted on #106 and adopted by the contributor's restack
- `Var` AST variant carries both `param` and `length`
- `translatePipelineBody` dispatches both `If` and `For` compound commands
- **if-branch exit semantics**: each branch resets `fx_exit` first, so `if false; then A; else B; fi` exits 0 (branch result) instead of leaking the test's failure — verified against bash behavior
- README known-deviations rewritten for the new supported surface; `command -v` builtin-path deviation noted

**Test budget fixes**: the `[[ ]]` mega-test (240 sequential PowerShell spawns) at 180s and the prefixes test at 20s were both legitimately exceeding budget after the generated scripts grew — raised to 420s/60s. No behavior change.

**Verification**: typecheck ✅ · build ✅ · full suite **126/126** ✅ (500s) · 12-behavior spot matrix ✅ · if/for semantics 7-case check vs bash ✅ · Git Bash differential on `command -v` (one documented deviation: builtins print `/usr/bin/name`)

Known pre-existing gap surfaced during verification (not a regression): word-level `$((x+1))` arithmetic expansion was never supported (only `[[ ]]\'s fx-arith) — flagged as a wave-3 candidate on RFC #111.

Closes #103, closes #104, closes #105, closes #106, closes #107, closes #108, closes #109, closes #110.