### PR TITLE
fix: reject word-level $((...)) instead of a confusing empty command

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,8 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`
+- `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`, word-level
+  `$((...))` arithmetic expansion
   and background `&` are rejected with actionable error messages instead of misbehaving.
   (`if/then/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
   and dotenv-style `source` are supported.)

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -12,7 +12,8 @@
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
  *   heredocs, subshells (...), background &, while/until/case,
- *   globs inside quotes, process substitution <(...).
+ *   word-level $((...)) arithmetic expansion, globs inside quotes,
+ *   process substitution <(...).
  */
 
 export interface CommandList {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, while/until/case, background jobs. if/then/else/fi and for-in loops are supported.
+Not supported: heredocs, while/until/case, word-level \$((...)) arithmetic expansion, background jobs. if/then/else/fi and for-in loops are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — but prefer COMBINING related commands in one call with ; or && (e.g. 'cd src && ls | wc -l'); each call is a fresh translation+process, so batching is faster than many tiny calls.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -299,6 +299,15 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     return { part: { kind: 'Var', name }, next: end + 1 };
   }
 
+  // $((...)) is arithmetic expansion, not command substitution of a
+  // parenthesized body. Today it was parsed as $( (expr) ) and became an
+  // empty/confusing command. Reject loudly until word-level arith lands.
+  if (input[j] === '(' && j + 1 < n && input[j + 1] === '(') {
+    throw new FauxnixParseError(
+      'fauxnix: $((...)) arithmetic expansion is not supported; compute the value in the agent or compare with [[ $n -eq m ]]',
+    );
+  }
+
   // $(cmd substitution) — captured with balanced parens; the translator
   // recursively translates this text before embedding it.
   if (input[j] === '(') {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -165,6 +165,16 @@ describe('parser', () => {
     expect(() => parse('cat <<EOF')).toThrow(/heredoc/);
   });
 
+  it('rejects word-level $((...)) instead of treating it as $( (expr) )', () => {
+    expect(() => parse('echo $((1+1))')).toThrow(FauxnixParseError);
+    expect(() => parse('echo $((1+1))')).toThrow(/\$\(\(\.\.\.\)\) arithmetic expansion is not supported/);
+    expect(() => parse('X=$((x+1))')).toThrow(/arithmetic expansion/);
+    expect(() => parse('echo "$((1+1))"')).toThrow(/arithmetic expansion/);
+    expect(() => parse('echo ok; echo $((x+1))')).toThrow(/arithmetic expansion/);
+    // space after $( is command substitution of a subshell, not arith
+    expect(() => parse('echo $( (true) )')).not.toThrow(/arithmetic expansion/);
+  });
+
   it('parses backticks as command substitution', () => {
     const cmd = parse('echo `date +%Y`').segments[0].pipeline.commands[0];
     expect(cmd.args[0].some((p) => p.kind === 'CmdSub' && p.cmd === 'date +%Y')).toBe(true);


### PR DESCRIPTION
## Why

Wave-3 note from #111: word-level `$((x+1))` has never been supported (only `[[ ]]`-context `fx-arith`). Agents emit it constantly. Today `readDollar` treats `$((…))` as command substitution of `(x+1)`, which then becomes an empty/confusing command — silent-wrong.

## What

Parse-time loud reject, same shape as heredocs / `elif`:

```
fauxnix: $((...)) arithmetic expansion is not supported; compute the value in the agent or compare with [[ $n -eq m ]]
```

Detection is `$` immediately followed by `((`. A space after `$(` stays command substitution (`$( (true) )`).

Docs (README rejected-list, MCP tool description, ast header) updated to match.

## Tests

- Unit: `echo $((1+1))`, assignment, quoted, and `echo ok; echo $((x+1))` all throw before any segment runs.
- `npx vitest run test/unit.test.ts` — 72 passed.
- `npm run typecheck` clean.

Not implementing word-level arith in this PR — that is the later half of the wave-3 note.
