### PR TITLE
perf: reuse one powershell.exe host per FauxnixSession

### DIFF
--- a/docs/rfc-persistent-powershell-host.md
+++ b/docs/rfc-persistent-powershell-host.md
@@ -1,0 +1,75 @@
+# RFC: Persistent PowerShell host per FauxnixSession
+
+Follow-up to [#111](https://github.com/20000419/fauxnix/issues/111) / [#114](https://github.com/20000419/fauxnix/pull/114).
+Not a request to implement word-level `$((…))` — that stays a loud reject until a later PR.
+
+## Why spawn is the latency root cause
+
+#114 slimmed `wrapScript` so `echo hi` no longer ships the full ~170-line `fx-*` catalog.
+Maintainer measurement on that branch:
+
+> **1.25s/cmd vs 1.26s on main** — wall time is unchanged because `powershell.exe` spawn + Node startup dominate, and parsing the old preamble was only milliseconds.
+
+Today every `SegmentPlan` is `spawn('powershell.exe', ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-EncodedCommand'|'-File'])`.
+`FauxnixSession` already persists cwd / env / `$?` across calls via temp files, but the process is thrown away each time.
+
+The architectural lever is one resident `powershell.exe` per session, with an RPC-style frame for each translated segment.
+
+## Proposal
+
+- One MCP / CLI `FauxnixSession` = one `powershell.exe` 5.1 host.
+- Node sends one JSON line per segment; the host captures stdout/stderr, returns one JSON line, and **does not `exit`**.
+- `Set-Location` + `[Environment]::CurrentDirectory` stay in that process so the next frame sees the same cwd.
+- `fauxnix_session reset` / `dispose()` kill the host.
+- `fauxnix translate` still prints a spawn-style script and never starts a host.
+
+## Protocol
+
+UTF-8 JSON lines on the process stdin/stdout pipes (raw `OpenStandardInput` / `OpenStandardOutput` + `UTF8Encoding($false)` so PS 5.1's default UTF-16LE pipe encoding does not own the channel).
+
+Host → Node, once at boot:
+
+```json
+{"ready":true}
+```
+
+Node → Host, per segment:
+
+```json
+{"id":"<uuid>","scriptB64":"<utf-8 script>","env":{"FAUXNIX_CWD":"...","FAUXNIX_PREV_EXIT":"0","FAUXNIX_STDIN_FILE":""}}
+```
+
+`env` values are strings. An empty string unsets that variable (so a missing `<` redirect cannot leak `FAUXNIX_STDIN_FILE`).
+
+Host → Node:
+
+```json
+{"id":"<uuid>","stdoutB64":"<bytes>","stderrB64":"<bytes>","exitCode":0}
+```
+
+Captured command streams are the UTF-8 bytes of `[Console]::Out` / `[Console]::Error` after redirecting those writers for the frame. Pipeline objects (`Write-Output` / `fx-write` line mode) are `WriteLine`d to the same `Console.Out` as they arrive so `echo -n` / `printf` exact writes still interleave correctly. Node runs the existing `decodeOutput` + `normalizeHostNewlines` path on those bytes.
+
+The per-frame script is `wrapScript(body, { mode: 'host' })`: same cwd/env persist files and try/catch as spawn mode, **no `exit`**, **no helper re-emit** (the bootstrap already defined every `fx-*`).
+
+## Failure modes
+
+| Event | Behavior |
+|---|---|
+| `powershell.exe` missing (`ENOENT`) | Same 127 + current Linux-sandbox message. No retry loop. |
+| Host dies mid-frame | That frame fails with the close code / an unexpected-exit message. The next `run()` cold-starts a new host with `session.childEnv()` (cwd/env last synced from the sidecar files). **The failed script is not retried** (it may have been what killed the host). |
+| `ExecOptions.timeoutMs` | Node kills the host process (grandchildren may survive — same limitation as today's `child.kill()`). Exit **124**, session remains usable; next command starts a fresh host. Per-frame runspace `Stop()` is a later optimization, not required to beat spawn latency. |
+| Host ignores a frame / handshake timeout | Treated as a dead host: kill, cold start on the next command. |
+| `set -e` | Unchanged loud reject, exit 2. |
+
+## Non-goals
+
+- Defaulting to `pwsh` 7 or WSL.
+- Re-implementing bash inside PowerShell.
+- Word-level `$((…))` (already loud-reject via #113).
+- Windows job-object tree kill for timeout grandchildren.
+- Dropping Node-side redirect preflight (`>` must not truncate a later file when an earlier redirect fails).
+- Version bump / npm publish.
+
+## Correctness that must stay green
+
+Session cwd, `FAUXNIX_SETVALS` / array sidecars, prefix `VAR=value` non-leak, `[[ ]]` + `BASH_REMATCH`, `if`/`for`, redirects including `2>&1` and failed `>` order, timeout 124, no-powershell 127.

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,12 +1,12 @@
-import { spawn, ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { promises as fs, readFileSync, writeFileSync, existsSync, openSync, closeSync, writeSync } from 'node:fs';
+import { promises as fs, readFileSync, existsSync, openSync, closeSync, writeSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { Redirect } from './ast.js';
-import { SegmentPlan, normalizeLiteralPath } from './translator.js';
-import { decodeOutput, encodeCommand, normalizeHostNewlines, resolveNativePref } from './encoding.js';
+import { SegmentPlan, normalizeLiteralPath, wrapScript } from './translator.js';
+import { decodeOutput, normalizeHostNewlines, resolveNativePref } from './encoding.js';
 import { normalizeStderr } from './errors.js';
+import { PowerShellHost, PS_MISSING_MESSAGE } from './ps-host.js';
 
 export interface ExecResult {
   stdout: string;
@@ -21,7 +21,6 @@ export interface ExecOptions {
 }
 
 const DEFAULT_TIMEOUT_MS = 120_000;
-const PS_ARGS = ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass'];
 
 /** Resolve /dev/null and POSIX-ish literal targets to real Windows paths. */
 function winTarget(target: string): string {
@@ -178,15 +177,22 @@ export class FauxnixSession {
   env: Record<string, string> = {};
   /** Exit code of the previous segment — powers bash's `$?`. */
   prevExit: number | null = null;
-  private cwdFile: string;
-  private envFile: string;
-  private scriptFile: string;
+  private cwdFile!: string;
+  private envFile!: string;
+  private scriptFile!: string;
+  private hostFile!: string;
+  private host: PowerShellHost | null = null;
+  private runLock: Promise<unknown> = Promise.resolve();
 
   constructor() {
-    const id = randomUUID().slice(0, 8);
+    this.bindFiles(randomUUID().slice(0, 8));
+  }
+
+  private bindFiles(id: string): void {
     this.cwdFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-cwd.txt');
     this.envFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-env.json');
     this.scriptFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-script.ps1');
+    this.hostFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-host.ps1');
   }
 
   private syncFromDisk(): void {
@@ -208,12 +214,28 @@ export class FauxnixSession {
     }
   }
 
+  private ensureHost(): PowerShellHost {
+    if (!this.host) {
+      this.host = new PowerShellHost(this.hostFile, () => this.childEnv());
+    }
+    return this.host;
+  }
+
   async dispose(): Promise<void> {
+    if (this.host) {
+      await this.host.stop();
+      this.host = null;
+    }
+    this.cwd = null;
+    this.env = {};
+    this.prevExit = null;
     await Promise.allSettled([
       fs.rm(this.cwdFile, { force: true }),
       fs.rm(this.envFile, { force: true }),
       fs.rm(this.scriptFile, { force: true }),
+      fs.rm(this.hostFile, { force: true }),
     ]);
+    this.bindFiles(randomUUID().slice(0, 8));
   }
 
   /** env for the child powershell process. */
@@ -236,13 +258,15 @@ export class FauxnixSession {
   }
 
   run(plans: SegmentPlan[], opts: ExecOptions = {}): Promise<ExecResult> {
-    return runPlans(plans, this, opts, () => this.syncFromDisk(), this.scriptFile);
+    const done = this.runLock.then(() =>
+      runPlans(plans, this, opts, () => this.syncFromDisk(), () => this.ensureHost()),
+    );
+    this.runLock = done.then(
+      () => undefined,
+      () => undefined,
+    );
+    return done;
   }
-}
-
-interface RunningChild {
-  proc: ChildProcess;
-  killed: boolean;
 }
 
 async function runPlans(
@@ -250,7 +274,7 @@ async function runPlans(
   session: FauxnixSession,
   opts: ExecOptions,
   afterSegment: () => void,
-  scriptFile: string,
+  ensureHost: () => PowerShellHost,
 ): Promise<ExecResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   let stdout = '';
@@ -343,59 +367,24 @@ async function runPlans(
       continue;
     }
 
-    const encoded = encodeCommand(plan.script);
+    const encoded = wrapScript(plan.body, { mode: 'host' });
+    const inv = await ensureHost().invoke(
+      encoded,
+      {
+        FAUXNIX_CWD: currentDir,
+        FAUXNIX_PREV_EXIT: session.prevExit === null ? '' : String(session.prevExit),
+        FAUXNIX_STDIN_FILE: red.stdinFile || '',
+      },
+      timeoutMs,
+    );
 
-    // -EncodedCommand is capped by the ~32K command-line limit; heavy
-    // pipelines fall back to a UTF-8 BOM temp script (PS 5.1 honors the BOM
-    // regardless of the console codepage, so non-ASCII stays intact).
-    let psArgs: string[];
-    if (encoded.length > 28000) {
-      writeFileSync(scriptFile, '\ufeff' + plan.script, 'utf8');
-      psArgs = [...PS_ARGS, '-File', scriptFile];
-    } else {
-      psArgs = [...PS_ARGS, '-EncodedCommand', encoded];
+    if (inv.spawnError === 'ENOENT') {
+      stderr += inv.stderr.toString('utf8') || PS_MISSING_MESSAGE;
+      exitCode = 127;
+      session.prevExit = exitCode;
+      chainOk = false;
+      continue;
     }
-
-    const child = spawn('powershell.exe', psArgs, {
-      env: session.childEnv(currentDir, red.stdinFile),
-      stdio: ['pipe', 'pipe', 'pipe'],
-      windowsHide: true,
-    });
-    const running: RunningChild = { proc: child, killed: false };
-
-    const outBufs: Buffer[] = [];
-    const errBufs: Buffer[] = [];
-    child.stdout!.on('data', (d: Buffer) => outBufs.push(d));
-    child.stderr!.on('data', (d: Buffer) => errBufs.push(d));
-    child.stdin!.end();
-
-    const timer = setTimeout(() => {
-      running.killed = true;
-      // Node-native termination — no external kill process, nothing injectable.
-      // Grandchildren of a timed-out script may survive; the `kill -9`/`pkill`
-      // builtins remain available for explicit Windows tree kills.
-      try {
-        child.kill();
-      } catch {
-        /* best effort */
-      }
-    }, timeoutMs);
-
-    const code = await new Promise<number | null>((resolve) => {
-      child.on('error', (e) => {
-        if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
-          stderr +=
-            'fauxnix: powershell.exe not found — fauxnix executes bash via native Windows PowerShell 5.1+.\n' +
-            'This host has no PowerShell on PATH (typical for Linux containers/sandboxes).\n' +
-            'Run fauxnix on Windows, or install PowerShell and make powershell.exe reachable on PATH.\n';
-        } else {
-          stderr += 'fauxnix: failed to start powershell.exe: ' + e.message + '\n';
-        }
-        resolve(127);
-      });
-      child.on('close', (c) => resolve(running.killed ? 124 : (c ?? 0)));
-    });
-    clearTimeout(timer);
 
     afterSegment();
 
@@ -403,12 +392,10 @@ async function runPlans(
     // GNU line discipline: the PS host terminates Write-Output lines with
     // CRLF. Exact writers (fx-write / printf / echo -n) must keep embedded
     // CR so `printf 'a\r\nb' > out` stays 4 bytes.
-    let segOut = normalizeHostNewlines(decodeOutput(Buffer.concat(outBufs), decodePref));
-    let segErr = normalizeHostNewlines(
-      normalizeStderr(decodeOutput(Buffer.concat(errBufs), decodePref)),
-    );
+    let segOut = normalizeHostNewlines(decodeOutput(inv.stdout, decodePref));
+    let segErr = normalizeHostNewlines(normalizeStderr(decodeOutput(inv.stderr, decodePref)));
 
-    if (running.killed) {
+    if (inv.timedOut) {
       segErr += '\nbash: command timed out after ' + Math.round(timeoutMs / 1000) + 's';
     }
 
@@ -451,7 +438,7 @@ async function runPlans(
 
     stdout += segOut;
     stderr += segErr;
-    exitCode = code ?? 0;
+    exitCode = inv.timedOut ? 124 : inv.exitCode;
     session.prevExit = exitCode;
     chainOk = exitCode === 0;
     // Only inherit cwd from a segment that actually ran and whose

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -48,7 +48,7 @@ Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), vari
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
 Not supported: heredocs, while/until/case, word-level \$((...)) arithmetic expansion, background jobs. if/then/else/fi and for-in loops are supported.
 
-CWD, environment variables, export/unset and cd persist across calls within this session — but prefer COMBINING related commands in one call with ; or && (e.g. 'cd src && ls | wc -l'); each call is a fresh translation+process, so batching is faster than many tiny calls.
+CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is reused, so batching with ; or && is still nicer but many tiny calls no longer each pay a powershell.exe spawn.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).
 
 Platform requirement: the execution backend is native Windows PowerShell 5.1+. On hosts without PowerShell on PATH (e.g. Linux containers/sandboxes), the bash tool returns exit code 127 with an actionable error instead of running the command.`;
@@ -58,7 +58,7 @@ export async function startMcpServer(): Promise<void> {
     { name: 'fauxnix', version: pkgVersion },
     { capabilities: { tools: {} } },
   );
-  const session = new FauxnixSession();
+  let session = new FauxnixSession();
 
   server.tool(
     TOOL_NAME,
@@ -122,6 +122,7 @@ export async function startMcpServer(): Promise<void> {
     async ({ action }) => {
       if (action === 'reset') {
         await session.dispose();
+        session = new FauxnixSession();
         return { content: [{ type: 'text', text: 'fauxnix: session reset' }] };
       }
       const envKeys = Object.keys(session.env).sort();

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -1,0 +1,346 @@
+import { spawn, ChildProcess } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { hostBootstrapScript } from './translator.js';
+
+const PS_ARGS = ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass'];
+const READY_TIMEOUT_MS = 30_000;
+
+export const PS_MISSING_MESSAGE =
+  'fauxnix: powershell.exe not found — fauxnix executes bash via native Windows PowerShell 5.1+.\n' +
+  'This host has no PowerShell on PATH (typical for Linux containers/sandboxes).\n' +
+  'Run fauxnix on Windows, or install PowerShell and make powershell.exe reachable on PATH.\n';
+
+export interface HostInvokeResult {
+  stdout: Buffer;
+  stderr: Buffer;
+  exitCode: number;
+  timedOut: boolean;
+  spawnError?: 'ENOENT' | 'START';
+  spawnMessage?: string;
+}
+
+export interface HostRequestEnv {
+  [key: string]: string;
+}
+
+export function encodeHostRequest(id: string, script: string, env: HostRequestEnv): string {
+  return JSON.stringify({
+    id,
+    scriptB64: Buffer.from(script, 'utf8').toString('base64'),
+    env,
+  });
+}
+
+export function decodeHostResponse(line: string): {
+  id: string;
+  stdout: Buffer;
+  stderr: Buffer;
+  exitCode: number;
+  ready?: boolean;
+} {
+  const j = JSON.parse(line) as {
+    id?: string;
+    stdoutB64?: string;
+    stderrB64?: string;
+    exitCode?: number;
+    ready?: boolean;
+  };
+  const n = Number(j.exitCode);
+  return {
+    id: j.id ?? '',
+    stdout: Buffer.from(j.stdoutB64 ?? '', 'base64'),
+    stderr: Buffer.from(j.stderrB64 ?? '', 'base64'),
+    exitCode: Number.isFinite(n) ? n : 0,
+    ready: j.ready === true,
+  };
+}
+
+/**
+ * One resident powershell.exe 5.1 process. Frames are UTF-8 JSON lines;
+ * command stdout/stderr come back as base64 so PS 5.1's UTF-16LE pipe
+ * encoding cannot scramble the payload.
+ */
+export class PowerShellHost {
+  private proc: ChildProcess | null = null;
+  private stdoutBuf = Buffer.alloc(0);
+  private queuedLines: string[] = [];
+  private waiters: Array<{
+    resolve: (line: string) => void;
+    reject: (err: Error) => void;
+  }> = [];
+  private stderrChunks: Buffer[] = [];
+  private closeCode: number | null | undefined;
+  private closeErr: Error | null = null;
+  private closed = false;
+  private startLock: Promise<void> | null = null;
+  private invokeLock: Promise<unknown> = Promise.resolve();
+
+  constructor(
+    private readonly hostFile: string,
+    private readonly envFn: () => NodeJS.ProcessEnv,
+  ) {}
+
+  async invoke(script: string, env: HostRequestEnv, timeoutMs: number): Promise<HostInvokeResult> {
+    const run = this.invokeLock.then(() => this.invokeSerial(script, env, timeoutMs));
+    this.invokeLock = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  async stop(): Promise<void> {
+    const proc = this.proc;
+    this.proc = null;
+    this.closed = true;
+    this.failWaiters(new Error('fauxnix: powershell host stopped'));
+    if (!proc) return;
+    try {
+      proc.stdin?.end();
+    } catch {
+      /* ignore */
+    }
+    try {
+      proc.kill();
+    } catch {
+      /* ignore */
+    }
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(resolve, 2000);
+      proc.once('close', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+  }
+
+  private async invokeSerial(
+    script: string,
+    env: HostRequestEnv,
+    timeoutMs: number,
+  ): Promise<HostInvokeResult> {
+    const started = await this.ensureStarted();
+    if (started) return started;
+
+    const id = 'f' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+    const line = encodeHostRequest(id, script, env);
+    try {
+      this.proc!.stdin!.write(line + '\n');
+    } catch (e) {
+      await this.deadRestart();
+      return {
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.from('fauxnix: powershell host exited unexpectedly\n', 'utf8'),
+        exitCode: 1,
+        timedOut: false,
+        spawnMessage: (e as Error).message,
+      };
+    }
+
+    try {
+      const raw = await this.nextJsonLine(timeoutMs, id);
+      const msg = decodeHostResponse(raw);
+      return {
+        stdout: msg.stdout,
+        stderr: msg.stderr,
+        exitCode: msg.exitCode,
+        timedOut: false,
+      };
+    } catch (e) {
+      const timedOut = (e as { timedOut?: boolean }).timedOut === true;
+      await this.stop();
+      if (timedOut) {
+        return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), exitCode: 124, timedOut: true };
+      }
+      if (this.closeErr && (this.closeErr as NodeJS.ErrnoException).code === 'ENOENT') {
+        return {
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.from(PS_MISSING_MESSAGE, 'utf8'),
+          exitCode: 127,
+          timedOut: false,
+          spawnError: 'ENOENT',
+        };
+      }
+      const code = this.closeCode ?? 1;
+      return {
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.from(
+          'fauxnix: powershell host exited unexpectedly' +
+            (code !== 1 ? ' (exit ' + String(code) + ')' : '') +
+            '\n',
+          'utf8',
+        ),
+        exitCode: code === 0 ? 1 : code,
+        timedOut: false,
+      };
+    }
+  }
+
+  private async ensureStarted(): Promise<HostInvokeResult | null> {
+    if (this.proc && !this.closed) return null;
+    if (!this.startLock) this.startLock = this.start();
+    try {
+      await this.startLock;
+      return null;
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') {
+        return {
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.from(PS_MISSING_MESSAGE, 'utf8'),
+          exitCode: 127,
+          timedOut: false,
+          spawnError: 'ENOENT',
+        };
+      }
+      return {
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.from(
+          'fauxnix: failed to start powershell.exe: ' + err.message + '\n',
+          'utf8',
+        ),
+        exitCode: 127,
+        timedOut: false,
+        spawnError: 'START',
+        spawnMessage: err.message,
+      };
+    } finally {
+      this.startLock = null;
+    }
+  }
+
+  private async deadRestart(): Promise<void> {
+    await this.stop();
+    this.closed = false;
+    this.closeCode = undefined;
+    this.closeErr = null;
+    this.stdoutBuf = Buffer.alloc(0);
+    this.queuedLines = [];
+    this.stderrChunks = [];
+  }
+
+  private async start(): Promise<void> {
+    await this.deadRestart();
+    this.closed = false;
+    writeFileSync(this.hostFile, '\ufeff' + hostBootstrapScript(), 'utf8');
+    const child = spawn('powershell.exe', [...PS_ARGS, '-File', this.hostFile], {
+      env: this.envFn(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    this.proc = child;
+    child.stdout!.on('data', (d: Buffer) => this.onStdout(d));
+    child.stderr!.on('data', (d: Buffer) => this.stderrChunks.push(d));
+    child.on('error', (e) => {
+      this.closeErr = e;
+      this.closed = true;
+      this.failWaiters(e);
+    });
+    child.on('close', (c) => {
+      this.closeCode = c;
+      this.closed = true;
+      this.proc = null;
+      this.failWaiters(new Error('fauxnix: powershell host closed'));
+    });
+    try {
+      const readyLine = await this.nextReadyLine(READY_TIMEOUT_MS);
+      const msg = decodeHostResponse(readyLine);
+      if (!msg.ready) {
+        throw new Error('fauxnix: powershell host handshake failed');
+      }
+    } catch (e) {
+      await this.stop();
+      throw e;
+    }
+  }
+
+  private onStdout(chunk: Buffer): void {
+    this.stdoutBuf = Buffer.concat([this.stdoutBuf, chunk]);
+    while (true) {
+      const i = this.stdoutBuf.indexOf(0x0a);
+      if (i < 0) break;
+      let line = this.stdoutBuf.subarray(0, i);
+      this.stdoutBuf = this.stdoutBuf.subarray(i + 1);
+      if (line.length && line[line.length - 1] === 0x0d) line = line.subarray(0, line.length - 1);
+      const s = line.toString('utf8').replace(/^\uFEFF/, '');
+      const w = this.waiters.shift();
+      if (w) w.resolve(s);
+      else this.queuedLines.push(s);
+    }
+  }
+
+  private nextLine(timeoutMs: number): Promise<string> {
+    if (this.queuedLines.length) return Promise.resolve(this.queuedLines.shift()!);
+    if (this.closed) {
+      return Promise.reject(this.closeErr ?? new Error('fauxnix: powershell host closed'));
+    }
+    return new Promise<string>((resolve, reject) => {
+      const waiter = {
+        resolve: (line: string) => {
+          clearTimeout(timer);
+          resolve(line);
+        },
+        reject: (err: Error) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      };
+      const timer = setTimeout(() => {
+        const idx = this.waiters.indexOf(waiter);
+        if (idx >= 0) this.waiters.splice(idx, 1);
+        const err = new Error('fauxnix: powershell host timed out') as Error & { timedOut: boolean };
+        err.timedOut = true;
+        reject(err);
+      }, timeoutMs);
+      this.waiters.push(waiter);
+    });
+  }
+
+  private async nextReadyLine(timeoutMs: number): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const line = await this.nextLine(Math.max(1, deadline - Date.now()));
+      if (!line.trim()) continue;
+      try {
+        const msg = decodeHostResponse(line);
+        if (msg.ready) return line;
+      } catch {
+        /* skip PS boot noise */
+      }
+    }
+    const err = new Error('fauxnix: powershell host handshake timed out') as Error & {
+      timedOut: boolean;
+    };
+    err.timedOut = true;
+    throw err;
+  }
+
+  private async nextJsonLine(timeoutMs: number, id: string): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const line = await this.nextLine(Math.max(1, deadline - Date.now()));
+      if (!line.trim()) continue;
+      try {
+        const msg = decodeHostResponse(line);
+        if (msg.ready) continue;
+        if (msg.id === id) return line;
+      } catch {
+        /* skip noise */
+      }
+    }
+    const err = new Error('fauxnix: powershell host timed out') as Error & { timedOut: boolean };
+    err.timedOut = true;
+    throw err;
+  }
+
+  private failWaiters(err: Error): void {
+    const ws = this.waiters.splice(0);
+    for (const w of ws) {
+      try {
+        w.reject(err);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -860,8 +860,10 @@ export function translatePipelineBody(p: {
 
 export interface SegmentPlan {
   op: ';' | '&&' | '||';
-  /** Complete PowerShell script for one powershell.exe invocation. */
+  /** Spawn-mode wrapScript (CLI/MCP `translate`, one-shot powershell.exe). */
   script: string;
+  /** Pipeline body before wrapScript — executor host mode re-wraps this. */
+  body: string;
   /** All redirects collected from this segment (executor handles them). */
   redirects: Redirect[];
 }
@@ -886,7 +888,7 @@ export function translateCommandList(list: CommandList): SegmentPlan[] {
         call +
         ' }';
     }
-    plans.push({ op: seg.op, script: wrapScript(body), redirects });
+    plans.push({ op: seg.op, script: wrapScript(body), body, redirects });
   }
   return plans;
 }
@@ -950,20 +952,17 @@ function wrapHelpersNeeded(body: string): Set<WrapHelper> {
   return needed;
 }
 
-/**
- * Wrap a pipeline body with the Fauxnix executor contract:
- * UTF-8 everywhere, bash-style exit codes, cwd/env persistence channels.
- * Only the fx- helpers the body actually calls are emitted — the full
- * catalog is ~170 lines and was paid on every `echo hi`.
- */
-export function wrapScript(body: string): string {
-  const needed = wrapHelpersNeeded(body);
-  const lines = [
+export type WrapMode = 'spawn' | 'host';
+
+export interface WrapScriptOptions {
+  /** spawn (default): one-shot process, `exit` at the end. host: no `exit`, no helper re-emit. */
+  mode?: WrapMode;
+}
+
+function wrapEncodingPreamble(): string[] {
+  return [
     '$ErrorActionPreference = "Continue"',
     "$ProgressPreference = 'SilentlyContinue'",
-    '$fx_exit = 0',
-    '$fx_prev = 0',
-    'if ($env:FAUXNIX_PREV_EXIT) { try { $fx_prev = [int]$env:FAUXNIX_PREV_EXIT } catch { $fx_prev = 0 } }',
     // single console-encoding knob in PS 5.1: ansi mode decodes GBK-native
     // admin tools correctly, utf8 mode decodes UTF-8-native dev tools
     // (see encoding.ts — file reads sniff per file and are always right)
@@ -974,6 +973,14 @@ export function wrapScript(body: string): string {
     '  try { chcp 65001 > $null } catch {}',
     '}',
     '$OutputEncoding = [System.Text.Encoding]::UTF8',
+  ];
+}
+
+function wrapCwdPreamble(): string[] {
+  return [
+    '$script:fx_exit = 0',
+    '$fx_prev = 0',
+    'if ($env:FAUXNIX_PREV_EXIT) { try { $fx_prev = [int]$env:FAUXNIX_PREV_EXIT } catch { $fx_prev = 0 } }',
     'if ($env:FAUXNIX_CWD) { try { Set-Location -LiteralPath $env:FAUXNIX_CWD } catch {} }',
     // capture AFTER the session cwd is applied — OLDPWD must refer to the
     // shell's previous directory, not the host process' startup directory
@@ -982,6 +989,45 @@ export function wrapScript(body: string): string {
     // process working directory, NOT the PS location — keep them in sync.
     'try { [Environment]::CurrentDirectory = (Get-Location).ProviderPath } catch {}',
   ];
+}
+
+function wrapBodyAndPersist(body: string, exitProcess: boolean): string[] {
+  const lines = [
+    'try {',
+    ...body.split('\n').map((l) => '  ' + l),
+    '} catch [System.Management.Automation.CommandNotFoundException] {',
+    "  [Console]::Error.WriteLine('bash: ' + $_.Exception.TargetName + ': command not found')",
+    '  $script:fx_exit = 127',
+    '} catch {',
+    '  [Console]::Error.WriteLine(($_.Exception.Message).Split("`n")[0])',
+    '  $script:fx_exit = 1',
+    '}',
+    '# persist session cwd and environment for the next segment',
+    'try { [IO.File]::WriteAllText($env:FAUXNIX_CWD_FILE, (Get-Location).Path) } catch {}',
+    'if ((Get-Location).Path -ne $fx_oldcwd) { $env:FAUXNIX_OLDPWD = $fx_oldcwd }',
+    'try {',
+    '  $envObj = @{}',
+    '  Get-ChildItem Env: | ForEach-Object { $envObj[$_.Name] = $_.Value }',
+    '  [IO.File]::WriteAllText($env:FAUXNIX_ENV_FILE, (ConvertTo-Json $envObj -Compress))',
+    '} catch {}',
+  ];
+  if (exitProcess) lines.push('exit $script:fx_exit');
+  return lines;
+}
+
+/**
+ * Wrap a pipeline body with the Fauxnix executor contract:
+ * UTF-8 everywhere, bash-style exit codes, cwd/env persistence channels.
+ * Spawn mode emits only the fx- helpers the body actually calls. Host mode
+ * assumes the resident process already loaded the catalog and must not `exit`.
+ */
+export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
+  const mode = opts.mode ?? 'spawn';
+  const needed = mode === 'host' ? new Set<WrapHelper>() : wrapHelpersNeeded(body);
+  const lines =
+    mode === 'host'
+      ? wrapCwdPreamble()
+      : [...wrapEncodingPreamble(), ...wrapCwdPreamble()];
   const helpers: Record<WrapHelper, string[]> = {
     'fx-readlines': [
       'function fx-readlines($p) {',
@@ -1162,28 +1208,105 @@ export function wrapScript(body: string): string {
       '}',
     ],
   };
+  cachedWrapHelpers = helpers;
   for (const name of WRAP_HELPER_ORDER) {
     if (needed.has(name)) lines.push(...helpers[name]);
   }
-  lines.push(
-    'try {',
-    ...body.split('\n').map((l) => '  ' + l),
-    '} catch [System.Management.Automation.CommandNotFoundException] {',
-    "  [Console]::Error.WriteLine('bash: ' + $_.Exception.TargetName + ': command not found')",
-    '  $script:fx_exit = 127',
-    '} catch {',
-    '  [Console]::Error.WriteLine(($_.Exception.Message).Split("`n")[0])',
-    '  $script:fx_exit = 1',
-    '}',
-    '# persist session cwd and environment for the next segment',
-    'try { [IO.File]::WriteAllText($env:FAUXNIX_CWD_FILE, (Get-Location).Path) } catch {}',
-    'if ((Get-Location).Path -ne $fx_oldcwd) { $env:FAUXNIX_OLDPWD = $fx_oldcwd }',
-    'try {',
-    '  $envObj = @{}',
-    '  Get-ChildItem Env: | ForEach-Object { $envObj[$_.Name] = $_.Value }',
-    '  [IO.File]::WriteAllText($env:FAUXNIX_ENV_FILE, (ConvertTo-Json $envObj -Compress))',
-    '} catch {}',
-    'exit $script:fx_exit',
-  );
+  lines.push(...wrapBodyAndPersist(body, mode === 'spawn'));
   return lines.join('\n');
 }
+
+let cachedWrapHelpers: Record<WrapHelper, string[]> | null = null;
+
+function wrapHelperCatalog(): Record<WrapHelper, string[]> {
+  if (!cachedWrapHelpers) wrapScript('');
+  return cachedWrapHelpers!;
+}
+
+/**
+ * Resident-host bootstrap: encoding + full fx-* catalog + JSON-line RPC loop.
+ * Loaded once via `powershell.exe -File`. Must never `exit` a successful frame.
+ */
+export function hostBootstrapScript(): string {
+  const helpers = wrapHelperCatalog();
+  const helperLines: string[] = [];
+  for (const name of WRAP_HELPER_ORDER) helperLines.push(...helpers[name]);
+  return [
+    ...wrapEncodingPreamble(),
+    '$script:fx_exit = 0',
+    ...helperLines,
+    HOST_RPC_LOOP,
+  ].join('\n');
+}
+
+/** Raw UTF-8 JSON lines on stdin/stdout; command streams captured per frame. */
+const HOST_RPC_LOOP = `
+$fx_utf8 = New-Object System.Text.UTF8Encoding $false
+$fx_in = [Console]::OpenStandardInput()
+$fx_out = [Console]::OpenStandardOutput()
+$fx_reader = New-Object System.IO.StreamReader($fx_in, $fx_utf8, $true, 8192, $true)
+$fx_proto = New-Object System.IO.StreamWriter($fx_out, $fx_utf8, 8192, $true)
+$fx_proto.NewLine = [string][char]10
+$fx_proto.AutoFlush = $true
+$fx_proto.WriteLine('{"ready":true}')
+while ($true) {
+  $fx_line = $fx_reader.ReadLine()
+  if ($null -eq $fx_line) { break }
+  if ($fx_line -eq '') { continue }
+  $fx_id = ''
+  $fx_msOut = $null
+  $fx_msErr = $null
+  $fx_outW = $null
+  $fx_errW = $null
+  $fx_oldOut = [Console]::Out
+  $fx_oldErr = [Console]::Error
+  try {
+    $fx_req = $fx_line | ConvertFrom-Json
+    $fx_id = [string]$fx_req.id
+    if ($fx_req.env) {
+      foreach ($fx_p in $fx_req.env.PSObject.Properties) {
+        $fx_en = [string]$fx_p.Name
+        $fx_ev = [string]$fx_p.Value
+        if ($fx_ev -eq '') {
+          Remove-Item -LiteralPath ('Env:\\' + $fx_en) -ErrorAction SilentlyContinue
+        } else {
+          Set-Item -LiteralPath ('Env:\\' + $fx_en) -Value $fx_ev
+        }
+      }
+    }
+    $fx_script = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String([string]$fx_req.scriptB64))
+    $fx_msOut = New-Object System.IO.MemoryStream
+    $fx_msErr = New-Object System.IO.MemoryStream
+    $fx_outW = New-Object System.IO.StreamWriter($fx_msOut, $fx_utf8, 1024, $true)
+    $fx_errW = New-Object System.IO.StreamWriter($fx_msErr, $fx_utf8, 1024, $true)
+    $fx_outW.NewLine = [string][char]13 + [string][char]10
+    $fx_errW.NewLine = [string][char]13 + [string][char]10
+    $fx_outW.AutoFlush = $true
+    $fx_errW.AutoFlush = $true
+    [Console]::SetOut($fx_outW)
+    [Console]::SetError($fx_errW)
+    $script:fx_exit = 0
+    $fx_sb = [scriptblock]::Create($fx_script)
+    & $fx_sb | ForEach-Object { [Console]::Out.WriteLine([string]$_) }
+  } catch [System.Management.Automation.CommandNotFoundException] {
+    [Console]::Error.WriteLine('bash: ' + $_.Exception.TargetName + ': command not found')
+    $script:fx_exit = 127
+  } catch {
+    [Console]::Error.WriteLine(($_.Exception.Message).Split([string][char]10)[0])
+    $script:fx_exit = 1
+  } finally {
+    try { if ($null -ne $fx_outW) { $fx_outW.Flush() } } catch {}
+    try { if ($null -ne $fx_errW) { $fx_errW.Flush() } } catch {}
+    try { [Console]::SetOut($fx_oldOut) } catch {}
+    try { [Console]::SetError($fx_oldErr) } catch {}
+  }
+  $fx_outB64 = ''
+  $fx_errB64 = ''
+  if ($null -ne $fx_msOut) { $fx_outB64 = [Convert]::ToBase64String($fx_msOut.ToArray()) }
+  if ($null -ne $fx_msErr) { $fx_errB64 = [Convert]::ToBase64String($fx_msErr.ToArray()) }
+  $fx_code = 0
+  try { $fx_code = [int]$script:fx_exit } catch { $fx_code = 1 }
+  $fx_res = @{ id = $fx_id; stdoutB64 = $fx_outB64; stderrB64 = $fx_errB64; exitCode = $fx_code }
+  $fx_proto.WriteLine(($fx_res | ConvertTo-Json -Compress))
+}
+`.trim();

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -814,4 +814,44 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     const r = await run('yes | head -3');
     expect(r.stdout.split(/\r?\n/).filter((l) => l === 'y').length).toBe(3);
   }, 30000);
+
+  it('15x echo hi on a warm host is far below the 1.25s spawn baseline', async () => {
+    const extra = new FauxnixSession();
+    try {
+      const warm = await extra.run(translateCommandList(parseCommand('echo hi')));
+      expect(warm.stdout.trim()).toBe('hi');
+      const times: number[] = [];
+      for (let i = 0; i < 15; i++) {
+        const t0 = Date.now();
+        const r = await extra.run(translateCommandList(parseCommand('echo hi')));
+        times.push(Date.now() - t0);
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout.trim()).toBe('hi');
+      }
+      const sorted = [...times].sort((a, b) => a - b);
+      const p50 = sorted[Math.floor(sorted.length / 2)]!;
+      const mean = times.reduce((a, b) => a + b, 0) / times.length;
+      // Maintainer baseline after #114: 1.25s/cmd, dominated by powershell.exe spawn.
+      // A persistent host must beat that by a lot, not 5%.
+      expect(p50).toBeLessThan(250);
+      expect(mean).toBeLessThan(400);
+      expect(Math.max(...times)).toBeLessThan(1250);
+    } finally {
+      await extra.dispose();
+    }
+  }, 60000);
+
+  it('executor timeout 124 leaves the same session usable', async () => {
+    const extra = new FauxnixSession();
+    try {
+      const r = await extra.run(translateCommandList(parseCommand('sleep 5')), { timeoutMs: 800 });
+      expect(r.exitCode).toBe(124);
+      expect(r.stderr).toMatch(/timed out/);
+      const next = await extra.run(translateCommandList(parseCommand('echo after-timeout')));
+      expect(next.exitCode).toBe(0);
+      expect(next.stdout.trim()).toBe('after-timeout');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -9,10 +9,12 @@ import {
   translateCommandList,
   varExpr,
   wrapScript,
+  hostBootstrapScript,
 } from '../src/translator.js';
 import { lookup, parseWords, psStr } from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import { normalizeStderr } from '../src/errors.js';
+import { decodeHostResponse, encodeHostRequest } from '../src/ps-host.js';
 import '../src/commands/install-all.js';
 
 /* ---------------------------- parser ---------------------------- */
@@ -421,6 +423,24 @@ describe('translator', () => {
     expect(s).toContain('[Environment]::CurrentDirectory');
   });
 
+  it('host-mode wrapScript does not exit and skips helper re-emit', () => {
+    const s = wrapScript('echo ${X[@]}', { mode: 'host' });
+    expect(s).not.toContain('exit $script:fx_exit');
+    expect(s).toContain('$script:fx_exit = 0');
+    expect(s).toContain('[Environment]::CurrentDirectory');
+    expect(s).not.toContain('function fx-arrload');
+    expect(s).not.toContain('function fx-csub');
+  });
+
+  it('host bootstrap loads helpers and speaks JSON lines without exit', () => {
+    const boot = hostBootstrapScript();
+    expect(boot).toContain('function fx-arrload');
+    expect(boot).toContain('function fx-csub');
+    expect(boot).toContain('{"ready":true}');
+    expect(boot).toContain('ConvertFrom-Json');
+    expect(boot).not.toContain('exit $script:fx_exit');
+  });
+
   it('omits unused wrapScript helpers on a body that calls none of them', () => {
     const s = wrapScript('x');
     expect(s).not.toContain('function fx-arrload');
@@ -529,6 +549,32 @@ describe('encoding', () => {
 
   it('encodes -EncodedCommand as UTF-16LE base64', () => {
     expect(Buffer.from(encodeCommand('dir'), 'base64').toString('utf16le')).toBe('dir');
+  });
+});
+
+describe('persistent PowerShell host protocol', () => {
+  it('round-trips script bytes and env unsets through JSON lines', () => {
+    const script = 'Write-Output "hi"\n$script:fx_exit = 0';
+    const line = encodeHostRequest('abc', script, { FAUXNIX_STDIN_FILE: '', FAUXNIX_CWD: 'D:\\tmp' });
+    expect(line).not.toContain('\n');
+    const parsed = JSON.parse(line) as { id: string; scriptB64: string; env: Record<string, string> };
+    expect(parsed.id).toBe('abc');
+    expect(Buffer.from(parsed.scriptB64, 'base64').toString('utf8')).toBe(script);
+    expect(parsed.env.FAUXNIX_STDIN_FILE).toBe('');
+    expect(parsed.env.FAUXNIX_CWD).toBe('D:\\tmp');
+  });
+
+  it('decodes base64 stdout/stderr and the ready handshake', () => {
+    const stdoutB64 = Buffer.from('hi\n', 'utf8').toString('base64');
+    const stderrB64 = Buffer.from('err', 'utf8').toString('base64');
+    const msg = decodeHostResponse(
+      JSON.stringify({ id: 'abc', stdoutB64, stderrB64, exitCode: 2 }),
+    );
+    expect(msg.id).toBe('abc');
+    expect(msg.stdout.toString('utf8')).toBe('hi\n');
+    expect(msg.stderr.toString('utf8')).toBe('err');
+    expect(msg.exitCode).toBe(2);
+    expect(decodeHostResponse('{"ready":true}').ready).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Why

#114 slimmed `wrapScript` but did not move wall time. Your measurement:

> 15× `echo hi` averages **1.25s/cmd vs 1.26s on main** — spawn + Node startup dominate.

This PR takes the lever you named: **one resident `powershell.exe` 5.1 per `FauxnixSession`**, RPC-style frames, no `exit` on the host.

RFC: `docs/rfc-persistent-powershell-host.md`.

## What

- New `src/ps-host.ts`: UTF-8 JSON lines, `scriptB64` in, stdout/stderr base64 out, handshake `{"ready":true}`.
- `wrapScript(body, { mode: 'host' })` does not re-emit helpers and does not `exit`.
- `fauxnix_session reset` / `dispose()` kill the host. `fauxnix translate` still prints spawn-style scripts.
- Timeout still kills the host process (exit **124**); next command cold-starts. Per-frame runspace `Stop()` left as a later optimization (same grandchild caveat as today's `child.kill()`).

## Verification (this machine, after review)

```
npm run typecheck                          # clean
npx vitest run --dir test                  # 135 passed (78 unit + 57 integration, ~25s)
```

The `[[ ]]` file/string suite that used to sit near 180–370s is **~8.7s** on the same host.

Hand matrix on one `FauxnixSession`: `echo hi`, `echo $(echo nested)`, empty `${X[@]}` promotion, `BASH_REMATCH`, `cd` then `pwd` on the next call, `VAR=tmp echo $VAR; echo x$VAR` → `tmp\nx`, `set -e` → 2, `sleep 5` @ 800ms → 124, then `echo still-ok` → 0.

Warm 15× `echo hi` (this review):

```
times_ms [9,5,6,5,5,5,5,5,6,6,6,6,6,5,6]
p50 6ms   mean 5.7ms   max 9ms
```

vs your **1250ms/cmd** spawn baseline (~200×). First shot on a new session is still ~1s (process start). One-shot CLI `fauxnix "echo hi"` still pays that once.

One commit. Not merging.
