### PR TITLE
feat: evaluate word-level $((...)) via fx-arith

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,11 +193,10 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`, word-level
-  `$((...))` arithmetic expansion
+- `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`,
   and background `&` are rejected with actionable error messages instead of misbehaving.
   (`if/then/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
-  and dotenv-style `source` are supported.)
+  dotenv-style `source`, and word-level `$((...))` arithmetic expansion are supported.)
 - `command -v <builtin>` prints `/usr/bin/<name>` where bash prints the bare builtin name;
   exit codes and empty-result semantics match.
 - `chmod` maps only the read-only bit; exec bits are no-ops on Windows. `chown` is a silent no-op

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -8,12 +8,12 @@
  *   - quoting:              'literal'  "interp $VAR $(cmd)"
  *   - variables:            $VAR ${VAR} ${VAR[n]} plus special cases ($HOME $USER $PATH ...)
  *   - command substitution: $(...) and `...` (recursively translated)
+ *   - arithmetic expansion: $((...)) (existing fx-arith engine)
  *   - env assignment prefix: VAR=value cmd
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
  *   heredocs, subshells (...), background &, while/until/case,
- *   word-level $((...)) arithmetic expansion, globs inside quotes,
- *   process substitution <(...).
+ *   globs inside quotes, process substitution <(...).
  */
 
 export interface CommandList {
@@ -92,7 +92,8 @@ export type WordPart =
       /** `${#name}` / `${#name[@]}` — string/array length expansion. */
       length?: boolean;
     }
-  | { kind: 'CmdSub'; cmd: string };
+  | { kind: 'CmdSub'; cmd: string }
+  | { kind: 'Arith'; parts: WordPart[] };
 
 export function wordToString(w: Word): string {
   return w.map(partToString).join('');
@@ -124,6 +125,8 @@ function partToString(p: WordPart): string {
       return p.index !== undefined ? `\${${p.name}[${p.index}]}` : `$${p.name}`;
     case 'CmdSub':
       return '$(' + p.cmd + ')';
+    case 'Arith':
+      return '$((' + p.parts.map(partToString).join('') + '))';
   }
 }
 

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -13,6 +13,8 @@ import {
   pathExpr,
   paramExpr,
   varExpr,
+  arithExpr,
+  setArithHelperPreamble,
 } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
@@ -1470,6 +1472,8 @@ const FX_ENVGET_FN = [
   '}',
 ].join('\n');
 
+setArithHelperPreamble(FX_TNK_FN + '\n' + FX_ENVGET_FN);
+
 /** Like exprOfWord, but $var is an exact-case env lookup (bash, not $env:). */
 function kshExprOfWord(w: Word): string {
   const expanded: WordPart[] = [];
@@ -1488,6 +1492,9 @@ function kshExprOfWord(w: Word): string {
     expanded.push(...w);
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
+  if (!tilde && expanded.length === 1 && expanded[0].kind === 'Arith') {
+    return arithExpr(expanded[0].parts);
+  }
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
     if (expanded[0].param) {
       return paramExpr(expanded[0].name, expanded[0].param.op, expanded[0].param.word);
@@ -1528,6 +1535,9 @@ function kshExprOfWord(w: Word): string {
       case 'CmdSub':
         // [[ ]] does not IFS-split, so keep the newline contract.
         out += '$(' + translateCmdSub(p.cmd, true) + ')';
+        break;
+      case 'Arith':
+        out += arithExpr(p.parts);
         break;
     }
   };

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, while/until/case, word-level \$((...)) arithmetic expansion, background jobs. if/then/else/fi and for-in loops are supported.
+Not supported: heredocs, while/until/case, background jobs. if/then/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is reused, so batching with ; or && is still nicer but many tiny calls no longer each pay a powershell.exe spawn.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -261,7 +261,32 @@ function readBacktick(input: string, i: number): { part: WordPart; next: number 
   throw new FauxnixParseError('fauxnix: unclosed backtick');
 }
 
-/** Parse $VAR, ${VAR}, $(cmd substitution). Returns null when not a valid dollar construct. */
+/** Expand `$…` constructs that appear inside `$((…))`. */
+function readArithParts(input: string): WordPart[] {
+  const parts: WordPart[] = [];
+  let buf = '';
+  let i = 0;
+  while (i < input.length) {
+    if (input[i] === '$') {
+      const v = readDollar(input, i);
+      if (v) {
+        if (buf) {
+          parts.push({ kind: 'Text', text: buf });
+          buf = '';
+        }
+        parts.push(v.part);
+        i = v.next;
+        continue;
+      }
+    }
+    buf += input[i];
+    i++;
+  }
+  if (buf) parts.push({ kind: 'Text', text: buf });
+  return parts;
+}
+
+/** Parse $VAR, ${VAR}, $(cmd substitution), $((arith)). Returns null when not a valid dollar construct. */
 function readDollar(input: string, i: number): { part: WordPart; next: number } | null {
   const n = input.length;
   if (input[i] !== '$') return null;
@@ -299,13 +324,38 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     return { part: { kind: 'Var', name }, next: end + 1 };
   }
 
-  // $((...)) is arithmetic expansion, not command substitution of a
-  // parenthesized body. Today it was parsed as $( (expr) ) and became an
-  // empty/confusing command. Reject loudly until word-level arith lands.
+  // $((...)) arithmetic expansion — distinct from `$( (cmd) )` (space after
+  // the first paren is command substitution of a grouped body).
   if (input[j] === '(' && j + 1 < n && input[j + 1] === '(') {
-    throw new FauxnixParseError(
-      'fauxnix: $((...)) arithmetic expansion is not supported; compute the value in the agent or compare with [[ $n -eq m ]]',
-    );
+    let depth = 0;
+    let k = j;
+    while (k < n) {
+      const c = input[k];
+      if (c === "'" || c === '"') {
+        const q = c;
+        k++;
+        while (k < n && input[k] !== q) {
+          if (input[k] === '\\') k++;
+          k++;
+        }
+        k++;
+        continue;
+      }
+      if (c === '(') depth++;
+      else if (c === ')') {
+        depth--;
+        if (depth === 0) {
+          k++;
+          break;
+        }
+      }
+      k++;
+    }
+    if (depth !== 0) throw new FauxnixParseError('fauxnix: unclosed $(( ))');
+    return {
+      part: { kind: 'Arith', parts: readArithParts(input.slice(j + 2, k - 2)) },
+      next: k,
+    };
   }
 
   // $(cmd substitution) — captured with balanced parens; the translator

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -188,6 +188,9 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
   if (expanded.length === 1 && expanded[0].kind === 'CmdSub') {
     return '$(' + translateCmdSub(expanded[0].cmd, opts?.preserveCmdSub === true) + ')';
   }
+  if (expanded.length === 1 && expanded[0].kind === 'Arith') {
+    return arithExpr(expanded[0].parts);
+  }
 
   const literal = expanded.every((p) => p.kind === 'Text' || p.kind === 'SingleQuoted');
   if (literal) {
@@ -214,9 +217,69 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd, quoted || opts?.preserveCmdSub === true) + ')';
         break;
+      case 'Arith':
+        out += arithExpr(p.parts);
+        break;
     }
   };
   for (const p of expanded) emitPart(p, false);
+  out += '"';
+  return out;
+}
+
+let arithHelperPreamble = '';
+
+/** Registered by sysinfo so wrapScript can emit fx-arith without a circular import. */
+export function setArithHelperPreamble(s: string): void {
+  arithHelperPreamble = s;
+}
+
+function injectArithHelpers(body: string): string {
+  if (!arithHelperPreamble) return body;
+  if (!/\bfx-arith\b/.test(body)) return body;
+  if (/function\s+fx-arith\b/.test(body)) return body;
+  return arithHelperPreamble + '\n' + body;
+}
+
+/** PowerShell expression: evaluate `$((…))` via fx-arith; errors are loud, expansion empty. */
+export function arithExpr(parts: WordPart[]): string {
+  const src = arithSourceExpr(parts);
+  return (
+    '$(try { [string](fx-arith (' +
+    src +
+    ')) } catch { [Console]::Error.WriteLine((\'bash: \' + [string](' +
+    src +
+    ') + \': integer expression expected\')); $script:fx_exit = 1; \'\' })'
+  );
+}
+
+function arithSourceExpr(parts: WordPart[]): string {
+  if (parts.length === 0) return "''";
+  if (parts.every((p) => p.kind === 'Text')) {
+    return psStr(parts.map((p) => p.text).join(''));
+  }
+  let out = '"';
+  const emit = (p: WordPart) => {
+    switch (p.kind) {
+      case 'Text':
+      case 'SingleQuoted':
+        out += escapeDq(p.text);
+        break;
+      case 'DoubleQuoted':
+        for (const q of p.parts) emit(q);
+        break;
+      case 'Var':
+        out += '$(' + varExpr(p.name, p.index, p.param, p.length === true) + ')';
+        break;
+      case 'CmdSub':
+        out += '$(' + translateCmdSub(p.cmd, true) + ')';
+        break;
+      case 'Arith':
+        out += arithExpr(p.parts);
+        break;
+    }
+  };
+  for (const p of parts) emit(p);
   out += '"';
   return out;
 }
@@ -1023,6 +1086,7 @@ function wrapBodyAndPersist(body: string, exitProcess: boolean): string[] {
  */
 export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
   const mode = opts.mode ?? 'spawn';
+  body = injectArithHelpers(body);
   const needed = mode === 'host' ? new Set<WrapHelper>() : wrapHelpersNeeded(body);
   const lines =
     mode === 'host'

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -815,6 +815,20 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout.split(/\r?\n/).filter((l) => l === 'y').length).toBe(3);
   }, 30000);
 
+  it('word-level $((...)) evaluates through fx-arith', async () => {
+    expect((await run('echo $((1+1))')).stdout.trim()).toBe('2');
+    expect((await run('x=3; echo $((x+1))')).stdout.trim()).toBe('4');
+    expect((await run('x=3; echo $(($x+1))')).stdout.trim()).toBe('4');
+    expect((await run('echo "$((2*3))"')).stdout.trim()).toBe('6');
+    expect((await run('echo $(())')).stdout.trim()).toBe('0');
+    const step = await run('i=3; i=$((i+1)); echo $i');
+    expect(step.exitCode).toBe(0);
+    expect(step.stdout.trim()).toBe('4');
+    const bad = await run('echo $((1+))');
+    expect(bad.exitCode).toBe(1);
+    expect(bad.stderr).toMatch(/integer expression expected/);
+  });
+
   it('15x echo hi on a warm host is far below the 1.25s spawn baseline', async () => {
     const extra = new FauxnixSession();
     try {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -167,14 +167,20 @@ describe('parser', () => {
     expect(() => parse('cat <<EOF')).toThrow(/heredoc/);
   });
 
-  it('rejects word-level $((...)) instead of treating it as $( (expr) )', () => {
-    expect(() => parse('echo $((1+1))')).toThrow(FauxnixParseError);
-    expect(() => parse('echo $((1+1))')).toThrow(/\$\(\(\.\.\.\)\) arithmetic expansion is not supported/);
-    expect(() => parse('X=$((x+1))')).toThrow(/arithmetic expansion/);
-    expect(() => parse('echo "$((1+1))"')).toThrow(/arithmetic expansion/);
-    expect(() => parse('echo ok; echo $((x+1))')).toThrow(/arithmetic expansion/);
-    // space after $( is command substitution of a subshell, not arith
-    expect(() => parse('echo $( (true) )')).not.toThrow(/arithmetic expansion/);
+  it('parses word-level $((...)) as Arith, not $( (expr) )', () => {
+    const cmd = parse('echo $((1+1))').segments[0].pipeline.commands[0];
+    expect(cmd.kind).toBe('SimpleCommand');
+    if (cmd.kind !== 'SimpleCommand') return;
+    expect(cmd.args[0].some((p) => p.kind === 'Arith')).toBe(true);
+    expect(wordToString(cmd.args[0])).toBe('$((1+1))');
+    const quoted = parse('echo "$((x+1))"').segments[0].pipeline.commands[0];
+    if (quoted.kind !== 'SimpleCommand') return;
+    const dq = quoted.args[0].find((p) => p.kind === 'DoubleQuoted');
+    expect(dq && dq.kind === 'DoubleQuoted' && dq.parts.some((p) => p.kind === 'Arith')).toBe(true);
+    expect(() => parse('X=$((x+1))')).not.toThrow();
+    expect(() => parse('echo $((1+1')).toThrow(/unclosed/);
+    // space after $( is command substitution of a grouped body, not arith
+    expect(() => parse('echo $( (true) )')).not.toThrow(/unclosed/);
   });
 
   it('parses backticks as command substitution', () => {
@@ -461,6 +467,10 @@ describe('translator', () => {
     expect(csub).toContain('function fx-csub');
     const stdin = translateCommandList(parse('wc -l < f.txt'))[0].script;
     expect(stdin).toContain('function fx-readlines');
+    const arith = translateCommandList(parse('echo $((1+1))'))[0];
+    expect(arith.body).toContain('fx-arith');
+    expect(arith.script).toContain('function fx-arith');
+    expect(echo).not.toContain('function fx-arith');
   });
 
   it('feeds stdin for < redirects', () => {


### PR DESCRIPTION
## Summary
- Roadmap A2 / follow-up to #113: implement word-level `$((...))` on the existing `fx-arith` engine instead of loud-reject.
- Parser keeps `$( (cmd) )` as command substitution; unclosed `$((` fails loudly.
- `wrapScript` injects the `[[ ]]` arith helpers only when a body calls `fx-arith`. README / MCP reject lists updated.
- RFC: [docs/rfc-roadmap-to-1.0.md](https://github.com/20000419/fauxnix/blob/main/docs/rfc-roadmap-to-1.0.md) track A2. Related: #111, #118.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run --dir test` — 136 passed (78 unit + 58 integration)
- [x] `echo $((1+1))` → `2`
- [x] `x=3; echo $((x+1))` and `echo $(($x+1))` → `4`
- [x] `i=3; i=$((i+1)); echo $i` → `4`
- [x] `echo $(())` → `0`
- [x] `echo $((1+))` → exit 1, stderr `integer expression expected`
- [x] `$( (true) )` is still not treated as arith
- [ ] Maintainer: `npx vitest run --dir test` on your box; compare a few cases against Git Bash if you want a C1 corpus seed

One commit. Not merging.
