### PR TITLE
feat: translate if/then/elif/else/fi as nested If

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
 - `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`, word-level
   `$((...))` arithmetic expansion
   and background `&` are rejected with actionable error messages instead of misbehaving.
-  (`if/then/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
+  (`if/then/elif/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
   and dotenv-style `source` are supported.)
 - `command -v <builtin>` prints `/usr/bin/<name>` where bash prints the bare builtin name;
   exit codes and empty-result semantics match.

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, while/until/case, word-level \$((...)) arithmetic expansion, background jobs. if/then/else/fi and for-in loops are supported.
+Not supported: heredocs, while/until/case, word-level \$((...)) arithmetic expansion, background jobs. if/then/elif/else/fi and for-in loops are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is reused, so batching with ; or && is still nicer but many tiny calls no longer each pay a powershell.exe spawn.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -677,14 +677,24 @@ export function parseCommand(input: string): CommandList {
     return { kind: 'CommandList', segments };
   };
 
-  const parseIf = (): IfCommand => {
-    expectKw('if');
+  const parseIf = (start: 'if' | 'elif' = 'if'): IfCommand => {
+    expectKw(start);
     const test = parseListUntil(['then']);
     expectKw('then');
     const thenL = parseListUntil(['else', 'elif', 'fi']);
     let elseL: CommandList | undefined;
     if (peekKw() === 'elif') {
-      throw new FauxnixParseError('fauxnix: elif is not supported yet; use else + if');
+      // bash `elif` is `else` + nested `if`; the innermost clause eats `fi`.
+      elseL = {
+        kind: 'CommandList',
+        segments: [
+          {
+            op: ';',
+            pipeline: { kind: 'Pipeline', commands: [parseIf('elif')] },
+          },
+        ],
+      };
+      return { kind: 'If', test, then: thenL, else: elseL, redirects: [] };
     }
     if (peekKw() === 'else') {
       next();

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -770,6 +770,17 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('if false; then echo YES; fi')).stdout.trim()).toBe('');
   });
 
+  it('elif takes the first true branch and keeps compound exit status', async () => {
+    expect((await run('if false; then echo A; elif true; then echo B; else echo C; fi')).stdout.trim()).toBe('B');
+    expect((await run('if false; then echo A; elif false; then echo B; else echo C; fi')).stdout.trim()).toBe('C');
+    expect((await run('if false; then echo A; elif false; then echo B; elif true; then echo C; fi')).stdout.trim()).toBe('C');
+    const taken = await run('if false; then false; elif true; then true; fi');
+    expect(taken.exitCode).toBe(0);
+    const missed = await run('if false; then echo A; elif false; then echo B; fi');
+    expect(missed.exitCode).toBe(0);
+    expect(missed.stdout.trim()).toBe('');
+  });
+
   it('for x in words; do ...; done iterates in the same session', async () => {
     expect((await run('for x in a b c; do echo $x; done')).stdout.trim()).toBe('a\nb\nc');
     expect((await run('for x in 1 2; do echo n$x; done; echo z$x')).stdout.trim()).toBe(

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -112,6 +112,17 @@ describe('parser', () => {
     expect(c.else?.segments).toHaveLength(1);
   });
 
+  it('parses elif as a nested If in the else branch', () => {
+    const list = parse('if false; then echo a; elif true; then echo b; else echo c; fi');
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('If');
+    if (c.kind !== 'If') return;
+    const inner = c.else?.segments[0].pipeline.commands[0];
+    expect(inner?.kind).toBe('If');
+    if (inner?.kind !== 'If') return;
+    expect(inner.else?.segments).toHaveLength(1);
+  });
+
   it('parses for name in words; do ...; done', () => {
     const list = parse('for x in a b c; do echo $x; done');
     const c = list.segments[0].pipeline.commands[0];


### PR DESCRIPTION
## Summary
- Roadmap A1 slice: `elif` (the `if`/`for` family started in #109/#110). No `case` fallthrough decision needed.
- `elif` is `else` + a nested `If`; the innermost clause still eats `fi`. Existing `translateIf` handles the nest.
- README / MCP now list `if/then/elif/else/fi`. RFC: [docs/rfc-roadmap-to-1.0.md](https://github.com/20000419/fauxnix/blob/main/docs/rfc-roadmap-to-1.0.md) A1. Related: #111, #118.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run --dir test` — 137 passed (79 unit + 58 integration)
- [x] `if false; then echo A; elif true; then echo B; else echo C; fi` → `B`
- [x] `if false; then echo A; elif false; then echo B; else echo C; fi` → `C`
- [x] chained `elif` + compound exit 0 when a branch runs `true`
- [ ] Maintainer: `npx vitest run --dir test`

One commit. Not merging. Independent of #119.
