### PR TITLE
perf: prewarm the PowerShell host at MCP session start

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -221,6 +221,11 @@ export class FauxnixSession {
     return this.host;
   }
 
+  /** Boot powershell.exe now so the first run() is not the 1.1s cold start. */
+  async prewarm(): Promise<void> {
+    await this.ensureHost().ready();
+  }
+
   async dispose(): Promise<void> {
     if (this.host) {
       await this.host.stop();

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -48,7 +48,7 @@ Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), vari
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
 Not supported: heredocs, while/until/case, word-level \$((...)) arithmetic expansion, background jobs. if/then/else/fi and for-in loops are supported.
 
-CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is reused, so batching with ; or && is still nicer but many tiny calls no longer each pay a powershell.exe spawn.
+CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is started when the MCP session begins (and after reset), so the first bash tool call is already warm.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).
 
 Platform requirement: the execution backend is native Windows PowerShell 5.1+. On hosts without PowerShell on PATH (e.g. Linux containers/sandboxes), the bash tool returns exit code 127 with an actionable error instead of running the command.`;
@@ -59,6 +59,7 @@ export async function startMcpServer(): Promise<void> {
     { capabilities: { tools: {} } },
   );
   let session = new FauxnixSession();
+  await session.prewarm();
 
   server.tool(
     TOOL_NAME,
@@ -123,6 +124,7 @@ export async function startMcpServer(): Promise<void> {
       if (action === 'reset') {
         await session.dispose();
         session = new FauxnixSession();
+        await session.prewarm();
         return { content: [{ type: 'text', text: 'fauxnix: session reset' }] };
       }
       const envKeys = Object.keys(session.env).sort();

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -80,6 +80,11 @@ export class PowerShellHost {
     private readonly envFn: () => NodeJS.ProcessEnv,
   ) {}
 
+  /** Start the resident process and wait for the ready handshake (B1 prewarm). */
+  async ready(): Promise<HostInvokeResult | null> {
+    return this.ensureStarted();
+  }
+
   async invoke(script: string, env: HostRequestEnv, timeoutMs: number): Promise<HostInvokeResult> {
     const run = this.invokeLock.then(() => this.invokeSerial(script, env, timeoutMs));
     this.invokeLock = run.then(

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -815,6 +815,21 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout.split(/\r?\n/).filter((l) => l === 'y').length).toBe(3);
   }, 30000);
 
+  it('prewarm hides host boot from the first echo hi', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const t0 = Date.now();
+      const r = await extra.run(translateCommandList(parseCommand('echo hi')));
+      const ms = Date.now() - t0;
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe('hi');
+      expect(ms).toBeLessThan(400);
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
   it('15x echo hi on a warm host is far below the 1.25s spawn baseline', async () => {
     const extra = new FauxnixSession();
     try {


### PR DESCRIPTION
## Summary
- Roadmap B1: start the resident `powershell.exe` at MCP session create (and after `fauxnix_session reset`) so the first `bash` tool call is already warm.
- CLI one-shot is unchanged — it still pays boot on the command it immediately runs.
- RFC: [docs/rfc-roadmap-to-1.0.md](https://github.com/20000419/fauxnix/blob/main/docs/rfc-roadmap-to-1.0.md) track B1. Follow-up to #115. Related: #118.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run --dir test` — 136 passed (78 unit + 58 integration)
- [x] `prewarm()` then first `echo hi` is &lt; 400ms (not the ~1.1s cold boot)
- [ ] Maintainer: MCP initialize then first tool call should no longer show ~1.12s host boot

One commit. Not merging. Independent of #119 / #120.
