### PR TITLE
release: v0.7.0 — roadmap wave 1 (#119 #120 #121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.7.0 — 2026-08-20
+
+First roadmap wave (docs/rfc-roadmap-to-1.0.md): A2, part of A1, B1.
+
+- Word-level `$((...))` arithmetic expansion — implemented on the existing
+  fx-arith engine (replaces the #113 loud-reject); differential-checked
+  byte-identical with real bash on precedence, truncating division, modulo,
+  power, negatives, quoted embedding, and assignment-through-arith (#119)
+- `elif` chains — desugared to nested if (else + if), innermost clause
+  closes `fi` (#120)
+- MCP host prewarm — powershell.exe boots during initialize (and after
+  session reset), hiding the cold start: first tool call measured
+  1.12s -> 0.137s (#121)
+
+139/139 tests green.
 ## v0.6.0 — 2026-08-19
 
 - **Persistent PowerShell host per session** (#115, RFC in

--- a/README.md
+++ b/README.md
@@ -193,11 +193,10 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`, word-level
-  `$((...))` arithmetic expansion
+- `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`,
   and background `&` are rejected with actionable error messages instead of misbehaving.
   (`if/then/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
-  and dotenv-style `source` are supported.)
+  dotenv-style `source`, and word-level `$((...))` arithmetic expansion are supported.)
 - `command -v <builtin>` prints `/usr/bin/<name>` where bash prints the bare builtin name;
   exit codes and empty-result semantics match.
 - `chmod` maps only the read-only bit; exec bits are no-ops on Windows. `chown` is a silent no-op

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
 - `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`, word-level
   `$((...))` arithmetic expansion
   and background `&` are rejected with actionable error messages instead of misbehaving.
-  (`if/then/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
+  (`if/then/elif/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
   and dotenv-style `source` are supported.)
 - `command -v <builtin>` prints `/usr/bin/<name>` where bash prints the bare builtin name;
   exit codes and empty-result semantics match.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fauxnix-cli",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Fauxnix — run Linux-style commands on Windows via deterministic PowerShell translation. No VM, no WSL. MCP server + CLI for AI agents.",
   "type": "module",
   "bin": {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -8,12 +8,12 @@
  *   - quoting:              'literal'  "interp $VAR $(cmd)"
  *   - variables:            $VAR ${VAR} ${VAR[n]} plus special cases ($HOME $USER $PATH ...)
  *   - command substitution: $(...) and `...` (recursively translated)
+ *   - arithmetic expansion: $((...)) (existing fx-arith engine)
  *   - env assignment prefix: VAR=value cmd
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
  *   heredocs, subshells (...), background &, while/until/case,
- *   word-level $((...)) arithmetic expansion, globs inside quotes,
- *   process substitution <(...).
+ *   globs inside quotes, process substitution <(...).
  */
 
 export interface CommandList {
@@ -92,7 +92,8 @@ export type WordPart =
       /** `${#name}` / `${#name[@]}` — string/array length expansion. */
       length?: boolean;
     }
-  | { kind: 'CmdSub'; cmd: string };
+  | { kind: 'CmdSub'; cmd: string }
+  | { kind: 'Arith'; parts: WordPart[] };
 
 export function wordToString(w: Word): string {
   return w.map(partToString).join('');
@@ -124,6 +125,8 @@ function partToString(p: WordPart): string {
       return p.index !== undefined ? `\${${p.name}[${p.index}]}` : `$${p.name}`;
     case 'CmdSub':
       return '$(' + p.cmd + ')';
+    case 'Arith':
+      return '$((' + p.parts.map(partToString).join('') + '))';
   }
 }
 

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -13,6 +13,8 @@ import {
   pathExpr,
   paramExpr,
   varExpr,
+  arithExpr,
+  setArithHelperPreamble,
 } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
@@ -1470,6 +1472,8 @@ const FX_ENVGET_FN = [
   '}',
 ].join('\n');
 
+setArithHelperPreamble(FX_TNK_FN + '\n' + FX_ENVGET_FN);
+
 /** Like exprOfWord, but $var is an exact-case env lookup (bash, not $env:). */
 function kshExprOfWord(w: Word): string {
   const expanded: WordPart[] = [];
@@ -1488,6 +1492,9 @@ function kshExprOfWord(w: Word): string {
     expanded.push(...w);
   }
   if (tilde && expanded.length === 0) return '(fx-home)';
+  if (!tilde && expanded.length === 1 && expanded[0].kind === 'Arith') {
+    return arithExpr(expanded[0].parts);
+  }
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
     if (expanded[0].param) {
       return paramExpr(expanded[0].name, expanded[0].param.op, expanded[0].param.word);
@@ -1528,6 +1535,9 @@ function kshExprOfWord(w: Word): string {
       case 'CmdSub':
         // [[ ]] does not IFS-split, so keep the newline contract.
         out += '$(' + translateCmdSub(p.cmd, true) + ')';
+        break;
+      case 'Arith':
+        out += arithExpr(p.parts);
         break;
     }
   };

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -221,6 +221,11 @@ export class FauxnixSession {
     return this.host;
   }
 
+  /** Boot powershell.exe now so the first run() is not the 1.1s cold start. */
+  async prewarm(): Promise<void> {
+    await this.ensureHost().ready();
+  }
+
   async dispose(): Promise<void> {
     if (this.host) {
       await this.host.stop();

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, while/until/case, word-level \$((...)) arithmetic expansion, background jobs. if/then/else/fi and for-in loops are supported.
+Not supported: heredocs, while/until/case, word-level \$((...)) arithmetic expansion, background jobs. if/then/elif/else/fi and for-in loops are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is reused, so batching with ; or && is still nicer but many tiny calls no longer each pay a powershell.exe spawn.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -48,7 +48,7 @@ Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), vari
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
 Not supported: heredocs, while/until/case, word-level \$((...)) arithmetic expansion, background jobs. if/then/else/fi and for-in loops are supported.
 
-CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is reused, so batching with ; or && is still nicer but many tiny calls no longer each pay a powershell.exe spawn.
+CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is started when the MCP session begins (and after reset), so the first bash tool call is already warm.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).
 
 Platform requirement: the execution backend is native Windows PowerShell 5.1+. On hosts without PowerShell on PATH (e.g. Linux containers/sandboxes), the bash tool returns exit code 127 with an actionable error instead of running the command.`;
@@ -59,6 +59,7 @@ export async function startMcpServer(): Promise<void> {
     { capabilities: { tools: {} } },
   );
   let session = new FauxnixSession();
+  await session.prewarm();
 
   server.tool(
     TOOL_NAME,
@@ -123,6 +124,7 @@ export async function startMcpServer(): Promise<void> {
       if (action === 'reset') {
         await session.dispose();
         session = new FauxnixSession();
+        await session.prewarm();
         return { content: [{ type: 'text', text: 'fauxnix: session reset' }] };
       }
       const envKeys = Object.keys(session.env).sort();

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -46,7 +46,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, while/until/case, word-level \$((...)) arithmetic expansion, background jobs. if/then/else/fi and for-in loops are supported.
+Not supported: heredocs, while/until/case, background jobs. if/then/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is reused, so batching with ; or && is still nicer but many tiny calls no longer each pay a powershell.exe spawn.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -261,7 +261,32 @@ function readBacktick(input: string, i: number): { part: WordPart; next: number 
   throw new FauxnixParseError('fauxnix: unclosed backtick');
 }
 
-/** Parse $VAR, ${VAR}, $(cmd substitution). Returns null when not a valid dollar construct. */
+/** Expand `$…` constructs that appear inside `$((…))`. */
+function readArithParts(input: string): WordPart[] {
+  const parts: WordPart[] = [];
+  let buf = '';
+  let i = 0;
+  while (i < input.length) {
+    if (input[i] === '$') {
+      const v = readDollar(input, i);
+      if (v) {
+        if (buf) {
+          parts.push({ kind: 'Text', text: buf });
+          buf = '';
+        }
+        parts.push(v.part);
+        i = v.next;
+        continue;
+      }
+    }
+    buf += input[i];
+    i++;
+  }
+  if (buf) parts.push({ kind: 'Text', text: buf });
+  return parts;
+}
+
+/** Parse $VAR, ${VAR}, $(cmd substitution), $((arith)). Returns null when not a valid dollar construct. */
 function readDollar(input: string, i: number): { part: WordPart; next: number } | null {
   const n = input.length;
   if (input[i] !== '$') return null;
@@ -299,13 +324,38 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
     return { part: { kind: 'Var', name }, next: end + 1 };
   }
 
-  // $((...)) is arithmetic expansion, not command substitution of a
-  // parenthesized body. Today it was parsed as $( (expr) ) and became an
-  // empty/confusing command. Reject loudly until word-level arith lands.
+  // $((...)) arithmetic expansion — distinct from `$( (cmd) )` (space after
+  // the first paren is command substitution of a grouped body).
   if (input[j] === '(' && j + 1 < n && input[j + 1] === '(') {
-    throw new FauxnixParseError(
-      'fauxnix: $((...)) arithmetic expansion is not supported; compute the value in the agent or compare with [[ $n -eq m ]]',
-    );
+    let depth = 0;
+    let k = j;
+    while (k < n) {
+      const c = input[k];
+      if (c === "'" || c === '"') {
+        const q = c;
+        k++;
+        while (k < n && input[k] !== q) {
+          if (input[k] === '\\') k++;
+          k++;
+        }
+        k++;
+        continue;
+      }
+      if (c === '(') depth++;
+      else if (c === ')') {
+        depth--;
+        if (depth === 0) {
+          k++;
+          break;
+        }
+      }
+      k++;
+    }
+    if (depth !== 0) throw new FauxnixParseError('fauxnix: unclosed $(( ))');
+    return {
+      part: { kind: 'Arith', parts: readArithParts(input.slice(j + 2, k - 2)) },
+      next: k,
+    };
   }
 
   // $(cmd substitution) — captured with balanced parens; the translator

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -677,14 +677,24 @@ export function parseCommand(input: string): CommandList {
     return { kind: 'CommandList', segments };
   };
 
-  const parseIf = (): IfCommand => {
-    expectKw('if');
+  const parseIf = (start: 'if' | 'elif' = 'if'): IfCommand => {
+    expectKw(start);
     const test = parseListUntil(['then']);
     expectKw('then');
     const thenL = parseListUntil(['else', 'elif', 'fi']);
     let elseL: CommandList | undefined;
     if (peekKw() === 'elif') {
-      throw new FauxnixParseError('fauxnix: elif is not supported yet; use else + if');
+      // bash `elif` is `else` + nested `if`; the innermost clause eats `fi`.
+      elseL = {
+        kind: 'CommandList',
+        segments: [
+          {
+            op: ';',
+            pipeline: { kind: 'Pipeline', commands: [parseIf('elif')] },
+          },
+        ],
+      };
+      return { kind: 'If', test, then: thenL, else: elseL, redirects: [] };
     }
     if (peekKw() === 'else') {
       next();

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -80,6 +80,11 @@ export class PowerShellHost {
     private readonly envFn: () => NodeJS.ProcessEnv,
   ) {}
 
+  /** Start the resident process and wait for the ready handshake (B1 prewarm). */
+  async ready(): Promise<HostInvokeResult | null> {
+    return this.ensureStarted();
+  }
+
   async invoke(script: string, env: HostRequestEnv, timeoutMs: number): Promise<HostInvokeResult> {
     const run = this.invokeLock.then(() => this.invokeSerial(script, env, timeoutMs));
     this.invokeLock = run.then(

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -188,6 +188,9 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
   if (expanded.length === 1 && expanded[0].kind === 'CmdSub') {
     return '$(' + translateCmdSub(expanded[0].cmd, opts?.preserveCmdSub === true) + ')';
   }
+  if (expanded.length === 1 && expanded[0].kind === 'Arith') {
+    return arithExpr(expanded[0].parts);
+  }
 
   const literal = expanded.every((p) => p.kind === 'Text' || p.kind === 'SingleQuoted');
   if (literal) {
@@ -214,9 +217,69 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd, quoted || opts?.preserveCmdSub === true) + ')';
         break;
+      case 'Arith':
+        out += arithExpr(p.parts);
+        break;
     }
   };
   for (const p of expanded) emitPart(p, false);
+  out += '"';
+  return out;
+}
+
+let arithHelperPreamble = '';
+
+/** Registered by sysinfo so wrapScript can emit fx-arith without a circular import. */
+export function setArithHelperPreamble(s: string): void {
+  arithHelperPreamble = s;
+}
+
+function injectArithHelpers(body: string): string {
+  if (!arithHelperPreamble) return body;
+  if (!/\bfx-arith\b/.test(body)) return body;
+  if (/function\s+fx-arith\b/.test(body)) return body;
+  return arithHelperPreamble + '\n' + body;
+}
+
+/** PowerShell expression: evaluate `$((…))` via fx-arith; errors are loud, expansion empty. */
+export function arithExpr(parts: WordPart[]): string {
+  const src = arithSourceExpr(parts);
+  return (
+    '$(try { [string](fx-arith (' +
+    src +
+    ')) } catch { [Console]::Error.WriteLine((\'bash: \' + [string](' +
+    src +
+    ') + \': integer expression expected\')); $script:fx_exit = 1; \'\' })'
+  );
+}
+
+function arithSourceExpr(parts: WordPart[]): string {
+  if (parts.length === 0) return "''";
+  if (parts.every((p) => p.kind === 'Text')) {
+    return psStr(parts.map((p) => p.text).join(''));
+  }
+  let out = '"';
+  const emit = (p: WordPart) => {
+    switch (p.kind) {
+      case 'Text':
+      case 'SingleQuoted':
+        out += escapeDq(p.text);
+        break;
+      case 'DoubleQuoted':
+        for (const q of p.parts) emit(q);
+        break;
+      case 'Var':
+        out += '$(' + varExpr(p.name, p.index, p.param, p.length === true) + ')';
+        break;
+      case 'CmdSub':
+        out += '$(' + translateCmdSub(p.cmd, true) + ')';
+        break;
+      case 'Arith':
+        out += arithExpr(p.parts);
+        break;
+    }
+  };
+  for (const p of parts) emit(p);
   out += '"';
   return out;
 }
@@ -1023,6 +1086,7 @@ function wrapBodyAndPersist(body: string, exitProcess: boolean): string[] {
  */
 export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
   const mode = opts.mode ?? 'spawn';
+  body = injectArithHelpers(body);
   const needed = mode === 'host' ? new Set<WrapHelper>() : wrapHelpersNeeded(body);
   const lines =
     mode === 'host'

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -815,6 +815,21 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout.split(/\r?\n/).filter((l) => l === 'y').length).toBe(3);
   }, 30000);
 
+  it('prewarm hides host boot from the first echo hi', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const t0 = Date.now();
+      const r = await extra.run(translateCommandList(parseCommand('echo hi')));
+      const ms = Date.now() - t0;
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe('hi');
+      expect(ms).toBeLessThan(400);
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
   it('15x echo hi on a warm host is far below the 1.25s spawn baseline', async () => {
     const extra = new FauxnixSession();
     try {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -770,6 +770,17 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('if false; then echo YES; fi')).stdout.trim()).toBe('');
   });
 
+  it('elif takes the first true branch and keeps compound exit status', async () => {
+    expect((await run('if false; then echo A; elif true; then echo B; else echo C; fi')).stdout.trim()).toBe('B');
+    expect((await run('if false; then echo A; elif false; then echo B; else echo C; fi')).stdout.trim()).toBe('C');
+    expect((await run('if false; then echo A; elif false; then echo B; elif true; then echo C; fi')).stdout.trim()).toBe('C');
+    const taken = await run('if false; then false; elif true; then true; fi');
+    expect(taken.exitCode).toBe(0);
+    const missed = await run('if false; then echo A; elif false; then echo B; fi');
+    expect(missed.exitCode).toBe(0);
+    expect(missed.stdout.trim()).toBe('');
+  });
+
   it('for x in words; do ...; done iterates in the same session', async () => {
     expect((await run('for x in a b c; do echo $x; done')).stdout.trim()).toBe('a\nb\nc');
     expect((await run('for x in 1 2; do echo n$x; done; echo z$x')).stdout.trim()).toBe(

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -815,6 +815,20 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout.split(/\r?\n/).filter((l) => l === 'y').length).toBe(3);
   }, 30000);
 
+  it('word-level $((...)) evaluates through fx-arith', async () => {
+    expect((await run('echo $((1+1))')).stdout.trim()).toBe('2');
+    expect((await run('x=3; echo $((x+1))')).stdout.trim()).toBe('4');
+    expect((await run('x=3; echo $(($x+1))')).stdout.trim()).toBe('4');
+    expect((await run('echo "$((2*3))"')).stdout.trim()).toBe('6');
+    expect((await run('echo $(())')).stdout.trim()).toBe('0');
+    const step = await run('i=3; i=$((i+1)); echo $i');
+    expect(step.exitCode).toBe(0);
+    expect(step.stdout.trim()).toBe('4');
+    const bad = await run('echo $((1+))');
+    expect(bad.exitCode).toBe(1);
+    expect(bad.stderr).toMatch(/integer expression expected/);
+  });
+
   it('15x echo hi on a warm host is far below the 1.25s spawn baseline', async () => {
     const extra = new FauxnixSession();
     try {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -112,6 +112,17 @@ describe('parser', () => {
     expect(c.else?.segments).toHaveLength(1);
   });
 
+  it('parses elif as a nested If in the else branch', () => {
+    const list = parse('if false; then echo a; elif true; then echo b; else echo c; fi');
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('If');
+    if (c.kind !== 'If') return;
+    const inner = c.else?.segments[0].pipeline.commands[0];
+    expect(inner?.kind).toBe('If');
+    if (inner?.kind !== 'If') return;
+    expect(inner.else?.segments).toHaveLength(1);
+  });
+
   it('parses for name in words; do ...; done', () => {
     const list = parse('for x in a b c; do echo $x; done');
     const c = list.segments[0].pipeline.commands[0];

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -167,14 +167,20 @@ describe('parser', () => {
     expect(() => parse('cat <<EOF')).toThrow(/heredoc/);
   });
 
-  it('rejects word-level $((...)) instead of treating it as $( (expr) )', () => {
-    expect(() => parse('echo $((1+1))')).toThrow(FauxnixParseError);
-    expect(() => parse('echo $((1+1))')).toThrow(/\$\(\(\.\.\.\)\) arithmetic expansion is not supported/);
-    expect(() => parse('X=$((x+1))')).toThrow(/arithmetic expansion/);
-    expect(() => parse('echo "$((1+1))"')).toThrow(/arithmetic expansion/);
-    expect(() => parse('echo ok; echo $((x+1))')).toThrow(/arithmetic expansion/);
-    // space after $( is command substitution of a subshell, not arith
-    expect(() => parse('echo $( (true) )')).not.toThrow(/arithmetic expansion/);
+  it('parses word-level $((...)) as Arith, not $( (expr) )', () => {
+    const cmd = parse('echo $((1+1))').segments[0].pipeline.commands[0];
+    expect(cmd.kind).toBe('SimpleCommand');
+    if (cmd.kind !== 'SimpleCommand') return;
+    expect(cmd.args[0].some((p) => p.kind === 'Arith')).toBe(true);
+    expect(wordToString(cmd.args[0])).toBe('$((1+1))');
+    const quoted = parse('echo "$((x+1))"').segments[0].pipeline.commands[0];
+    if (quoted.kind !== 'SimpleCommand') return;
+    const dq = quoted.args[0].find((p) => p.kind === 'DoubleQuoted');
+    expect(dq && dq.kind === 'DoubleQuoted' && dq.parts.some((p) => p.kind === 'Arith')).toBe(true);
+    expect(() => parse('X=$((x+1))')).not.toThrow();
+    expect(() => parse('echo $((1+1')).toThrow(/unclosed/);
+    // space after $( is command substitution of a grouped body, not arith
+    expect(() => parse('echo $( (true) )')).not.toThrow(/unclosed/);
   });
 
   it('parses backticks as command substitution', () => {
@@ -461,6 +467,10 @@ describe('translator', () => {
     expect(csub).toContain('function fx-csub');
     const stdin = translateCommandList(parse('wc -l < f.txt'))[0].script;
     expect(stdin).toContain('function fx-readlines');
+    const arith = translateCommandList(parse('echo $((1+1))'))[0];
+    expect(arith.body).toContain('fx-arith');
+    expect(arith.script).toContain('function fx-arith');
+    expect(echo).not.toContain('function fx-arith');
   });
 
   it('feeds stdin for < redirects', () => {


### PR DESCRIPTION
Integration of the first roadmap wave (docs/rfc-roadmap-to-1.0.md): **A2** word-level $((...)) arithmetic on the fx-arith engine, **A1(partial)** elif chains desugared to nested if, **B1** MCP host prewarm.

Maintainer verification on the integrated tree:
- Differential vs real Git Bash: **10/10 byte-identical** (precedence, truncating division, modulo, power, negatives, quoted embedding, assignment-through-arith)
- elif: 3-branch + else-fallthrough correct
- Prewarm: initialize absorbs host boot; first tool call **1.12s → 0.137s** measured
- Full suite **139/139**; conflicts were doc-anchor + test-anchor only (unioned; one stray closer fixed)

Closes #119, closes #120, closes #121.