### PR TITLE
fix(grep): restore recursive search and file filters

### DIFF
--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -83,7 +83,7 @@ function textExpr(w: Word): string {
 }
 
 /** Collect EVERY value of a short option (-kN, -k N) — parseWords keeps only the last. */
-function collectShortValues(args: Word[], letter: string, longName?: string): string[] {
+function collectShortValues(args: Word[], letter: string): string[] {
   const out: string[] = [];
   let onlyOps = false;
   for (let i = 0; i < args.length; i++) {
@@ -93,14 +93,42 @@ function collectShortValues(args: Word[], letter: string, longName?: string): st
       continue;
     }
     if (onlyOps) continue;
-    if (longName && t.startsWith(longName + '=')) out.push(t.slice(longName.length + 1));
-    else if (t === '-' + letter) {
+    if (t === '-' + letter) {
       if (i + 1 < args.length) {
         out.push(wordToString(args[i + 1]));
         i++;
       }
     } else if (t.startsWith('-' + letter) && t.length > 2 && !t.startsWith('--')) {
       out.push(t.slice(2));
+    }
+  }
+  return out;
+}
+
+interface LongOptionValue {
+  name: string;
+  value: string;
+}
+
+/** Collect repeated value-taking long options without mistaking short bundles for values. */
+function collectLongValues(args: Word[], names: string[]): LongOptionValue[] {
+  const out: LongOptionValue[] = [];
+  let onlyOps = false;
+  for (let i = 0; i < args.length; i++) {
+    const t = wordToString(args[i]);
+    if (t === '--') {
+      onlyOps = true;
+      continue;
+    }
+    if (onlyOps || !t.startsWith('--')) continue;
+    const eq = t.indexOf('=');
+    const name = eq >= 0 ? t.slice(0, eq) : t;
+    if (!names.includes(name)) continue;
+    if (eq >= 0) {
+      out.push({ name, value: t.slice(eq + 1) });
+    } else if (i + 1 < args.length) {
+      out.push({ name, value: wordToString(args[i + 1]) });
+      i++;
     }
   }
   return out;
@@ -248,9 +276,26 @@ function ereToDotNet(re: string): string {
 /* ------------------------------------------------------------------ */
 
 const grep: Handler = (args) => {
-  const includeGlobs = collectShortValues(args, '', '--include');
+  const filterOptionNames = ['--include', '--exclude', '--exclude-dir'];
+  const filterOptions = collectLongValues(args, filterOptionNames);
+  const fileFilterOptions = filterOptions.filter((o) => o.name !== '--exclude-dir');
+  const excludeDirGlobs = filterOptions
+    .filter((o) => o.name === '--exclude-dir')
+    .map((o) => o.value.replace(/[\\/]+$/, ''));
 
-  const { flags, operandWords, values } = parseWords(args, ['A', 'B', 'C']);
+  const { flags, operandWords, values, missingValue } = parseWords(
+    args,
+    ['A', 'B', 'C'],
+    filterOptionNames,
+  );
+  const missingFilterOption = missingValue.find((o) => filterOptionNames.includes(o));
+  if (missingFilterOption) {
+    return (
+      '[Console]::Error.WriteLine(' +
+      psStr("grep: option '" + missingFilterOption + "' requires an argument") +
+      '); $script:fx_exit = 2'
+    );
+  }
   const ci = flags.has('i');
   const inv = flags.has('v');
   const num = flags.has('n');
@@ -339,11 +384,74 @@ const grep: Handler = (args) => {
   if (fileWords.length > 0) {
     lines.push(PS_GLOB_FN);
     lines.push(
-      '$fx_inc = @(' + includeGlobs.map((g) => psStr(g)).join(', ') + ')',
+      '$fx_fsel = @(' +
+        fileFilterOptions
+          .map(
+            (o) =>
+              '[pscustomobject]@{ Keep = ' +
+              pb(o.name === '--include') +
+              '; Glob = ' +
+              psStr(o.value) +
+              ' }',
+          )
+          .join(', ') +
+        ')',
+      '$fx_excd = @(' + excludeDirGlobs.map((g) => psStr(g)).join(', ') + ')',
       '$fx_srcs = @()',
       '$fx_err = $false',
       '$fx_recd = $false',
     );
+    lines.push('function fx-globmatch($fx_name, $fx_glob, $fx_suffix) {');
+    lines.push("  $fx_n = ([string]$fx_name).Replace('\\', '/')");
+    lines.push("  $fx_p = ([string]$fx_glob).Replace('\\', '/')");
+    lines.push('  if ($fx_n -like $fx_p) { return $true }');
+    lines.push('  if ($fx_suffix) {');
+    lines.push("    $fx_slash = $fx_n.IndexOf('/')");
+    lines.push('    while ($fx_slash -ge 0 -and $fx_slash + 1 -lt $fx_n.Length) {');
+    lines.push('      $fx_n = $fx_n.Substring($fx_slash + 1)');
+    lines.push('      if ($fx_n -like $fx_p) { return $true }');
+    lines.push("      $fx_slash = $fx_n.IndexOf('/')");
+    lines.push('    }');
+    lines.push('  }');
+    lines.push('  return $false');
+    lines.push('}');
+    lines.push('function fx-anyglob($fx_name, $fx_globs, $fx_suffix) {');
+    lines.push(
+      '  foreach ($fx_glob in $fx_globs) { if (fx-globmatch $fx_name $fx_glob $fx_suffix) { return $true } }',
+    );
+    lines.push('  return $false');
+    lines.push('}');
+    lines.push('function fx-filewanted($fx_path, $fx_suffix) {');
+    lines.push('  if ($fx_fsel.Count -eq 0) { return $true }');
+    lines.push(
+      '  $fx_name = if ($fx_suffix) { [string]$fx_path } else { [IO.Path]::GetFileName([string]$fx_path) }',
+    );
+    lines.push('  $fx_keep = -not [bool]$fx_fsel[0].Keep');
+    lines.push(
+      '  foreach ($fx_rule in $fx_fsel) { if (fx-globmatch $fx_name $fx_rule.Glob $fx_suffix) { $fx_keep = [bool]$fx_rule.Keep } }',
+    );
+    lines.push('  return $fx_keep');
+    lines.push('}');
+    if (rec) {
+      lines.push('function fx-walkfiles($fx_root) {');
+      lines.push('  $fx_dirs = New-Object System.Collections.Stack');
+      lines.push('  $fx_dirs.Push([string]$fx_root)');
+      lines.push('  while ($fx_dirs.Count -gt 0) {');
+      lines.push('    $fx_cur = [string]$fx_dirs.Pop()');
+      lines.push(
+        '    foreach ($fx_item in @(Get-ChildItem -LiteralPath $fx_cur -Force -ErrorAction SilentlyContinue)) {',
+      );
+      lines.push('      if ($fx_item.PSIsContainer) {');
+      lines.push(
+        '        if (($fx_item.Attributes -band [IO.FileAttributes]::ReparsePoint) -eq 0 -and -not (fx-anyglob $fx_item.Name $fx_excd $false)) { $fx_dirs.Push($fx_item.FullName) }',
+      );
+      lines.push(
+        '      } elseif (fx-filewanted $fx_item.FullName $false) { $fx_item.FullName }',
+      );
+      lines.push('    }');
+      lines.push('  }');
+      lines.push('}');
+    }
     lines.push('foreach ($fx_o in ' + psArray(fileWords) + ') {');
     lines.push('  foreach ($fx_g in (fx-glob $fx_o)) {');
     lines.push(
@@ -351,22 +459,16 @@ const grep: Handler = (args) => {
     );
     lines.push('    if (Test-Path -LiteralPath $fx_g -PathType Container) {');
     if (rec) {
+      lines.push('      $fx_dir = Get-Item -LiteralPath $fx_g');
+      lines.push('      if (fx-anyglob $fx_g $fx_excd $true) { continue }');
       lines.push('      $fx_recd = $true');
-      lines.push(
-        '      $fx_subs = @(Get-ChildItem -LiteralPath $fx_g -Recurse -Force -File -ErrorAction SilentlyContinue)',
-      );
-      lines.push('      if ($fx_inc.Count -gt 0) {');
-      lines.push(
-        "        $fx_subs = @($fx_subs | Where-Object { $fx_ok = $false; foreach ($fx_gi in $fx_inc) { if ($_.Name -like $fx_gi) { $fx_ok = $true; break } }; $fx_ok })",
-      );
-      lines.push('      }');
-      lines.push('      foreach ($fx_s in $fx_subs) { $fx_srcs += $fx_s.FullName }');
+      lines.push('      $fx_srcs += @(fx-walkfiles $fx_dir.FullName)');
     } else {
       lines.push(
         "      [Console]::Error.WriteLine('grep: ' + $fx_g + ': Is a directory'); $fx_err = $true",
       );
     }
-    lines.push('    } else { $fx_srcs += $fx_g }');
+    lines.push('    } elseif (fx-filewanted $fx_g $true) { $fx_srcs += $fx_g }');
     lines.push('  }');
     lines.push('}');
     lines.push('$fx_pre = $false');

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -28,6 +28,16 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     writeFileSync(join(dir, 'dups.txt'), 'aaa\naaa\nbbb\n', 'utf8');
     mkdirSync(join(dir, 'sub'));
     writeFileSync(join(dir, 'sub', 'b.txt'), 'third line\n', 'utf8');
+    mkdirSync(join(dir, 'grep-tree', 'src'), { recursive: true });
+    mkdirSync(join(dir, 'grep-tree', 'vendor'), { recursive: true });
+    mkdirSync(join(dir, 'grep-tree', 'generated'), { recursive: true });
+    writeFileSync(join(dir, 'grep-tree', 'keep.ts'), 'token keep\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'notes.md'), 'token notes\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'skip.test.ts'), 'token test\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'explicit.txt'), 'token explicit\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'src', 'nested.ts'), 'token nested\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'vendor', 'vendor.ts'), 'token vendor\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'generated', 'generated.md'), 'token generated\n', 'utf8');
     session = new FauxnixSession();
     // seed the session cwd like a real shell login directory
     await session.run(translateCommandList(parseCommand('cd "' + dir + '"')));
@@ -78,6 +88,58 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('grep apple fruits.txt')).exitCode).toBe(0);
     expect((await run('grep zz fruits.txt')).exitCode).toBe(1);
     expect((await run('grep x missing-file')).exitCode).toBe(2);
+  });
+
+  it('grep -rn recursively searches instead of treating bundled flags as an include glob', async () => {
+    const r = await run('grep -rn token grep-tree');
+    const stdout = r.stdout.replaceAll('\\', '/');
+    expect(r.exitCode).toBe(0);
+    expect(stdout).toMatch(/grep-tree\/keep\.ts:1:token keep/);
+    expect(stdout).toMatch(/grep-tree\/src\/nested\.ts:1:token nested/);
+  });
+
+  it('grep applies repeated include, exclude, and exclude-dir filters', async () => {
+    const r = await run(
+      "grep -rn --include='*.ts' --include '*.md' --exclude='*.test.ts' --exclude notes.md --exclude-dir=vendor --exclude-dir generated token grep-tree",
+    );
+    const stdout = r.stdout.replaceAll('\\', '/');
+    expect(r.exitCode).toBe(0);
+    expect(stdout).toMatch(/grep-tree\/keep\.ts:1:token keep/);
+    expect(stdout).toMatch(/grep-tree\/src\/nested\.ts:1:token nested/);
+    expect(stdout).not.toContain('notes.md');
+    expect(stdout).not.toContain('skip.test.ts');
+    expect(stdout).not.toContain('/vendor/');
+    expect(stdout).not.toContain('/generated/');
+  });
+
+  it('grep exclusions apply to explicit file and directory operands', async () => {
+    const file = await run(
+      "grep -n --exclude='grep-tree/*.txt' token grep-tree/explicit.txt",
+    );
+    expect(file.exitCode).toBe(1);
+    expect(file.stdout).toBe('');
+    expect(file.stderr).toBe('');
+
+    const directory = await run(
+      "grep -rn --exclude-dir='grep-tree/vendor/' token grep-tree/vendor",
+    );
+    expect(directory.exitCode).toBe(1);
+    expect(directory.stdout).toBe('');
+    expect(directory.stderr).toBe('');
+  });
+
+  it('grep uses the last matching include or exclude rule', async () => {
+    const included = await run(
+      "grep -n --exclude='*.txt' --include=explicit.txt token grep-tree/explicit.txt",
+    );
+    expect(included.exitCode).toBe(0);
+    expect(included.stdout).toContain('token explicit');
+
+    const excluded = await run(
+      "grep -n --include='*.txt' --exclude=explicit.txt token grep-tree/explicit.txt",
+    );
+    expect(excluded.exitCode).toBe(1);
+    expect(excluded.stdout).toBe('');
   });
 
   it('pipeline: cat | grep | sort', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -484,6 +484,38 @@ describe('translator', () => {
     expect(echo).not.toContain('function fx-arith');
   });
 
+  it('keeps grep short flag bundles separate from long-option values', () => {
+    const body = translateCommandList(parse('grep -rn TODO src'))[0].body;
+    expect(body).toContain("$fx_pat = 'TODO'");
+    expect(body).toContain('$fx_fsel = @()');
+    expect(body).toContain("foreach ($fx_o in (@('src')))");
+    expect(body).toContain('$fx_recd = $true');
+  });
+
+  it('preserves repeated grep file filters in command-line order', () => {
+    const body = translateCommandList(
+      parse(
+        "grep -r --include='*.ts' --exclude '*.test.ts' --include=*.tsx --exclude='*.snap' --exclude-dir node_modules --exclude-dir=dist token src",
+      ),
+    )[0].body;
+    const includeTs = body.indexOf("Keep = $true; Glob = '*.ts'");
+    const excludeTest = body.indexOf("Keep = $false; Glob = '*.test.ts'");
+    const includeTsx = body.indexOf("Keep = $true; Glob = '*.tsx'");
+    const excludeSnap = body.indexOf("Keep = $false; Glob = '*.snap'");
+    expect(includeTs).toBeGreaterThan(-1);
+    expect(excludeTest).toBeGreaterThan(includeTs);
+    expect(includeTsx).toBeGreaterThan(excludeTest);
+    expect(excludeSnap).toBeGreaterThan(includeTsx);
+    expect(body).toContain("$fx_excd = @('node_modules', 'dist')");
+    expect(body).toContain("foreach ($fx_o in (@('src')))");
+  });
+
+  it('reports a missing grep file-filter value', () => {
+    const body = translateCommandList(parse('grep token file --exclude-dir'))[0].body;
+    expect(body).toContain("grep: option ''--exclude-dir'' requires an argument");
+    expect(body).toContain('$script:fx_exit = 2');
+  });
+
   it('feeds stdin for < redirects', () => {
     const plan = translateCommandList(parse('wc -l < f.txt'))[0];
     expect(plan.script).toContain('fx-readlines $env:FAUXNIX_STDIN_FILE |');


### PR DESCRIPTION
## Problem

The README-style command `grep -rn TOKEN DIR` silently returned no matches. The helper that collected `--include` values was called with an empty short-option name, so a bundle such as `-rn` became an include glob (`n`) and filtered every file out.

The same path also only handled `--include=PATTERN`; common GNU forms such as `--include PATTERN`, `--exclude`, and `--exclude-dir` were either misparsed or ignored.

## Change

- separate repeated long-option collection from short option bundles
- support both `--opt=value` and `--opt value` for include/exclude filters
- preserve GNU ordering when include/exclude rules overlap
- prune excluded directories during recursive traversal
- apply filters to explicit operands as well as recursively discovered files
- reject missing filter values with exit 2

## Verification

- `npm ci` (0 vulnerabilities)
- `npm run typecheck`
- `npm run build`
- `npm test` — 146/146 (82 unit, 64 real-PowerShell integration)
- manual before/after reproduction of `grep -rn` and comparison with Git Bash

