### PR TITLE
fix(pipeline): use final stage exit status

### DIFF
--- a/src/translator.ts
+++ b/src/translator.ts
@@ -816,6 +816,9 @@ export function wrapTempEnv(
 /** Unique suffix for generated stage functions (nested pipelines included). */
 let stageSeq = 0;
 
+/** Unique suffix for generated pipeline wrappers and their local status arrays. */
+let pipelineSeq = 0;
+
 export interface PipelineParts {
   /** Generated function definitions (empty for single commands). */
   defs: string;
@@ -888,6 +891,12 @@ function translateFor(cmd: ForCommand): string {
 export function translatePipelineBody(p: {
   commands: Array<SimpleCommand | IfCommand | ForCommand>;
 }): PipelineParts {
+  // Every pipeline stage needs its own status slot. Handlers deliberately use
+  // `$script:fx_exit` because their helper functions run in child scopes; in a
+  // pipeline that shared flag lets an earlier failure leak into a successful
+  // last stage. Reserve the wrapper id before translating bodies so nested
+  // command substitutions cannot reuse it.
+  const pipelineId = p.commands.length > 1 ? pipelineSeq++ : -1;
   const bodies: string[] = [];
   for (let i = 0; i < p.commands.length; i++) {
     const c = p.commands[i];
@@ -905,16 +914,38 @@ export function translatePipelineBody(p: {
 
   const names: string[] = [];
   const defs: string[] = [];
+  const statusVar = '$fx_pipe_status' + pipelineId;
   for (let i = 0; i < bodies.length; i++) {
     const name = '__fx_s' + stageSeq++;
     names.push(name);
-    const indented = bodies[i]
+    const isolatedBody = bodies[i].split('$script:fx_exit').join(statusVar + '[' + i + ']');
+    const indented = isolatedBody
       .split('\n')
       .map((l) => (l ? '  ' + l : l))
       .join('\n');
     defs.push('function ' + name + ' {\n' + indented + '\n}');
   }
-  return { defs: defs.join('\n'), call: names.join(' | ') };
+  const pipelineName = '__fx_p' + pipelineId;
+  const statuses = bodies.map(() => '0').join(', ');
+  const pipelineCall = names.join(' | ');
+  defs.push(
+    [
+      'function ' + pipelineName + ' {',
+      '  ' + statusVar + ' = @(' + statuses + ')',
+      '  try {',
+      // The wrapper forwards redirect input to stage zero. With no input,
+      // PowerShell still invokes a regular function once, which preserves the
+      // existing no-stdin pipeline behavior on Windows PowerShell 5.1.
+      '    $input | ' + pipelineCall,
+      '  } finally {',
+      // Bash defaults to pipefail off: only the last stage controls the list
+      // status used by a following && / || segment.
+      '    $script:fx_exit = [int]' + statusVar + '[' + (bodies.length - 1) + ']',
+      '  }',
+      '}',
+    ].join('\n'),
+  );
+  return { defs: defs.join('\n'), call: pipelineName };
 }
 
 /* ------------------------------------------------------------------ */

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -85,6 +85,25 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout.split(/\r?\n/).filter(Boolean)).toEqual(['apple', 'apple pie']);
   });
 
+  it('pipeline exit status comes from the last stage (pipefail off)', async () => {
+    expect((await run('false | true')).exitCode).toBe(0);
+    expect((await run('true | false')).exitCode).toBe(1);
+  });
+
+  it('pipeline exit status controls following && and || lists', async () => {
+    const andResult = await run('grep NO fruits.txt | head -1 && echo AFTER');
+    expect(andResult.stdout.trim()).toBe('AFTER');
+    expect(andResult.exitCode).toBe(0);
+
+    const ignoredFailure = await run('false | true || echo FALLBACK');
+    expect(ignoredFailure.stdout.trim()).toBe('');
+    expect(ignoredFailure.exitCode).toBe(0);
+
+    const lastStageFailure = await run('true | false || echo FALLBACK');
+    expect(lastStageFailure.stdout.trim()).toBe('FALLBACK');
+    expect(lastStageFailure.exitCode).toBe(0);
+  });
+
   it('sed substitution', async () => {
     const r = await run("sed 's/apple/MANGO/g' fruits.txt");
     expect(r.stdout).toContain('MANGO pie');

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -495,6 +495,17 @@ describe('translator', () => {
     expect(plan.script).toMatch(/__fx_s\d+ \| __fx_s\d+ \| __fx_s\d+/);
   });
 
+  it.each([
+    ['false | true', 0],
+    ['true | false', 1],
+  ])('isolates stage exit flags for %s (failing stage %i)', (command, failingStage) => {
+    const plan = translateCommandList(parse(command))[0];
+    const statusName = plan.body.match(/\$(fx_pipe_status\d+) = @\(0, 0\)/)?.[1];
+    expect(statusName).toBeDefined();
+    expect(plan.body).toContain(`$${statusName}[${failingStage}] = 1`);
+    expect(plan.body).toContain(`$script:fx_exit = [int]$${statusName}[1]`);
+  });
+
   it('scopes VAR=value prefixes and evaluates values before applying them', () => {
     const leak = translateCommandList(parse('FOO=bar echo x'))[0].script;
     expect(leak).toContain('try {');


### PR DESCRIPTION
## Problem

All pipeline stages wrote to one shared `$script:fx_exit`. A failure in any earlier stage therefore leaked into the pipeline result even when the last stage succeeded:

- `false | true` returned 1 instead of Bash's default 0
- `grep NO file | head -1 && echo AFTER` incorrectly suppressed `AFTER`

## Change

- give every generated pipeline stage an isolated status slot
- publish only the final stage's status after the pipeline finishes (Bash default, `pipefail` off)
- preserve existing pipeline data flow and nested translation behavior

## Verification

- `false | true` => 0
- `true | false` => 1
- following `&&` and `||` lists now use the final stage
- `npm ci`, typecheck, build, and full `npm test` — 143/143

