### PR TITLE
fix(find): correct depth filtering semantics

### DIFF
--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -532,6 +532,28 @@ const find: Handler = (args) => {
   const wantDelete = preds.includes('-delete');
   const paths = pathWords.length ? argListExpr(pathWords) : "@('.')";
 
+  for (const option of ['-maxdepth', '-mindepth']) {
+    const optionIndex = preds.indexOf(option);
+    if (optionIndex < 0) continue;
+    if (optionIndex + 1 >= preds.length) {
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr(`find: missing argument to '${option}'`) +
+        '); $script:fx_exit = 1'
+      );
+    }
+    const value = preds[optionIndex + 1];
+    if (!/^\d+$/.test(value)) {
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr(
+          `find: expected a non-negative decimal integer argument to ${option}, but got '${value}'`,
+        ) +
+        '); $script:fx_exit = 1'
+      );
+    }
+  }
+
   const conditions: string[] = [];
   if (namePat !== null) conditions.push("($fx_i.Name -like '" + likeOf(namePat) + "')");
   if (inamePat !== null)
@@ -554,9 +576,9 @@ const find: Handler = (args) => {
     '  foreach ($fx_i in $fx_all) {',
     "    $fx_rel = $fx_i.FullName.Substring($fx_root.Length).TrimStart('\\').Replace('\\', '/')",
     "    if ($fx_rel -eq '') { $fx_disp = $fx_p } else { $fx_disp = ($fx_p.TrimEnd('/') + '/' + $fx_rel) }",
-    '    $fx_depth = 0; foreach ($fx_c in $fx_rel.ToCharArray()) { if ($fx_c -eq \'/\') { $fx_depth++ } }',
-    '    if ($fx_depth -lt ' + (minDepthS && /^\d+$/.test(minDepthS) ? minDepthS : '0') + ') { continue }',
-    maxDepthS && /^\d+$/.test(maxDepthS) ? '    if ($fx_depth -gt ' + maxDepthS + ') { continue }' : '',
+    '    $fx_depth = 0; if ($fx_rel -ne \'\') { $fx_depth = 1; foreach ($fx_c in $fx_rel.ToCharArray()) { if ($fx_c -eq \'/\') { $fx_depth++ } } }',
+    '    if ($fx_depth -lt ' + (minDepthS ?? '0') + ') { continue }',
+    maxDepthS !== null ? '    if ($fx_depth -gt ' + maxDepthS + ') { continue }' : '',
     '    if (-not (' + cond + ')) { continue }',
     sizeCond ? '    $fx_sz = 0; if (-not $fx_i.PSIsContainer) { try { $fx_sz = $fx_i.Length } catch {} }' : '',
     sizeCond ? '    if (-not (' + sizeCond + ')) { continue }' : '',

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -28,6 +28,14 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     writeFileSync(join(dir, 'dups.txt'), 'aaa\naaa\nbbb\n', 'utf8');
     mkdirSync(join(dir, 'sub'));
     writeFileSync(join(dir, 'sub', 'b.txt'), 'third line\n', 'utf8');
+    mkdirSync(join(dir, 'find-depth', 'level-one', 'level-two'), { recursive: true });
+    writeFileSync(join(dir, 'find-depth', 'root.txt'), 'root\n', 'utf8');
+    writeFileSync(join(dir, 'find-depth', 'level-one', 'child.txt'), 'child\n', 'utf8');
+    writeFileSync(
+      join(dir, 'find-depth', 'level-one', 'level-two', 'grandchild.txt'),
+      'grandchild\n',
+      'utf8',
+    );
     session = new FauxnixSession();
     // seed the session cwd like a real shell login directory
     await session.run(translateCommandList(parseCommand('cd "' + dir + '"')));
@@ -560,6 +568,46 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
   it('find + wc -l counts rows', async () => {
     const r = await run("find sub -name '*.txt' | wc -l");
     expect(r.stdout.trim()).toBe('1');
+  });
+
+  it('find applies maxdepth and mindepth from root depth zero', async () => {
+    const paths = async (cmd: string) => {
+      const r = await run(cmd);
+      expect(r.exitCode).toBe(0);
+      return r.stdout.split(/\r?\n/).filter(Boolean).sort();
+    };
+
+    expect(await paths('find find-depth -maxdepth 0')).toEqual(['find-depth']);
+    expect(await paths('find find-depth -maxdepth 1')).toEqual([
+      'find-depth',
+      'find-depth/level-one',
+      'find-depth/root.txt',
+    ]);
+    expect(await paths('find find-depth -mindepth 1 -maxdepth 1')).toEqual([
+      'find-depth/level-one',
+      'find-depth/root.txt',
+    ]);
+    expect(await paths('find find-depth -mindepth 2 -maxdepth 2')).toEqual([
+      'find-depth/level-one/child.txt',
+      'find-depth/level-one/level-two',
+    ]);
+    expect(await paths('find find-depth -mindepth 3')).toEqual([
+      'find-depth/level-one/level-two/grandchild.txt',
+    ]);
+  });
+
+  it('find rejects missing and invalid depth arguments', async () => {
+    const missing = await run('find find-depth -maxdepth');
+    expect(missing.exitCode).toBe(1);
+    expect(missing.stderr).toContain("find: missing argument to '-maxdepth'");
+
+    for (const value of ['nope', '-1']) {
+      const invalid = await run(`find find-depth -mindepth ${value}`);
+      expect(invalid.exitCode).toBe(1);
+      expect(invalid.stderr).toContain(
+        `find: expected a non-negative decimal integer argument to -mindepth, but got '${value}'`,
+      );
+    }
   });
 
   it('stat -c format', async () => {


### PR DESCRIPTION
## Problem

`find` counted slashes in the relative path but did not count the first path component. The root and every direct child therefore both had depth 0:

- `find src -maxdepth 0` returned `src` plus all direct children (GNU returns only `src`)
- `-mindepth 1` skipped direct children

Missing, textual, and negative depth arguments were also accepted instead of failing.

## Change

- define the operand root as depth 0, direct children as 1, and increment per additional component
- reject missing or non-negative-decimal violations with exit 1 and an actionable message

## Verification

- three-level fixture covers maxdepth 0/1, mindepth 1/2/3, and combined bounds
- invalid-value behavior checked against GNU findutils 4.10.0
- `npm ci`, typecheck, build, and full `npm test` — 141/141

