### PR TITLE
fix(release): make package artifacts self-validating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install
+      - run: npm ci
       - run: npm run typecheck
       - run: npm run build
       - run: npm test
+      - run: npm run test:package

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ npm install -g fauxnix-cli
 Or from source:
 
 ```bash
-git clone https://github.com/20000419/fauxnix && cd fauxnix && npm install -g .
+git clone https://github.com/20000419/fauxnix && cd fauxnix
+npm ci
+npm install -g .
 ```
 
 > npm package name is `fauxnix-cli` (the `fauxnix` name on npm belongs to an

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   ],
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "test": "vitest run",
+    "test:package": "node scripts/package-smoke.mjs",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "dev": "tsx src/index.ts"

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, delimiter, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = fileURLToPath(new URL('..', import.meta.url));
+const metadata = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: packageRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  });
+
+  if (result.error || result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(
+      `${command} ${args.join(' ')} failed${result.status === null ? '' : ` (${result.status})`}` +
+        `${result.error ? `: ${result.error.message}` : ''}` +
+        `${detail ? `\n${detail}` : ''}`,
+    );
+  }
+
+  return result.stdout.trim();
+}
+
+function runNpm(args, options = {}) {
+  if (process.env.npm_execpath) {
+    return run(process.execPath, [process.env.npm_execpath, ...args], options);
+  }
+
+  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  return run(npmCommand, args, {
+    shell: process.platform === 'win32',
+    ...options,
+  });
+}
+
+function withoutProjectBin() {
+  const environment = { ...process.env };
+  const pathKey = Object.keys(environment).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+  const projectBin = resolve(packageRoot, 'node_modules', '.bin');
+  environment[pathKey] = (environment[pathKey] ?? '')
+    .split(delimiter)
+    .filter((entry) => entry && resolve(entry) !== projectBin)
+    .join(delimiter);
+  return environment;
+}
+
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'fauxnix-package-smoke-'));
+const sourceDirectory = join(temporaryRoot, 'source');
+const sourceInstallDirectory = join(temporaryRoot, 'source-install');
+const packDirectory = join(temporaryRoot, 'pack');
+const installDirectory = join(temporaryRoot, 'install');
+
+try {
+  mkdirSync(sourceDirectory);
+  mkdirSync(sourceInstallDirectory);
+  mkdirSync(packDirectory);
+  mkdirSync(installDirectory);
+
+  for (const filename of ['package.json', 'package-lock.json', 'tsconfig.json', 'README.md', 'LICENSE']) {
+    cpSync(join(packageRoot, filename), join(sourceDirectory, filename));
+  }
+  cpSync(join(packageRoot, 'src'), join(sourceDirectory, 'src'), { recursive: true });
+
+  const cleanEnvironment = withoutProjectBin();
+  runNpm(['ci', '--no-audit', '--no-fund'], {
+    cwd: sourceDirectory,
+    env: cleanEnvironment,
+  });
+  const sourceCliEntry = join(sourceDirectory, 'dist', 'index.js');
+  assert.ok(existsSync(sourceCliEntry), 'npm ci in clean source should build dist/index.js');
+
+  runNpm(
+    [
+      'install',
+      '--global',
+      '--prefix',
+      sourceInstallDirectory,
+      '--no-audit',
+      '--no-fund',
+      sourceDirectory,
+    ],
+    { cwd: sourceDirectory, env: cleanEnvironment },
+  );
+
+  const globalPackageRoot =
+    process.platform === 'win32'
+      ? join(sourceInstallDirectory, 'node_modules', metadata.name)
+      : join(sourceInstallDirectory, 'lib', 'node_modules', metadata.name);
+  const globalCliShim =
+    process.platform === 'win32'
+      ? join(sourceInstallDirectory, 'fauxnix.cmd')
+      : join(sourceInstallDirectory, 'bin', 'fauxnix');
+  assert.ok(existsSync(sourceCliEntry), 'installing clean source should build dist/index.js');
+  assert.ok(
+    existsSync(join(globalPackageRoot, 'dist', 'index.js')),
+    'global source install should expose dist/index.js',
+  );
+  assert.ok(existsSync(globalCliShim), 'global source install should expose the fauxnix executable');
+  const sourceVersion = run(process.execPath, [sourceCliEntry, '--version'], {
+    cwd: temporaryRoot,
+    env: cleanEnvironment,
+  });
+  assert.equal(sourceVersion, `fauxnix ${metadata.version}`);
+
+  runNpm(['pack', '--silent', '--pack-destination', packDirectory]);
+  const tarballs = readdirSync(packDirectory).filter((name) => name.endsWith('.tgz'));
+  assert.equal(tarballs.length, 1, 'npm pack should produce exactly one tarball');
+
+  const tarball = join(packDirectory, tarballs[0]);
+  runNpm(
+    ['install', '--prefix', installDirectory, '--no-audit', '--no-fund', tarball],
+    { cwd: temporaryRoot, env: cleanEnvironment },
+  );
+
+  const installedRoot = join(installDirectory, 'node_modules', metadata.name);
+  const cliEntry = join(installedRoot, 'dist', 'index.js');
+  const cliShim = join(
+    installDirectory,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'fauxnix.cmd' : 'fauxnix',
+  );
+  assert.ok(existsSync(cliEntry), 'packed install should contain dist/index.js');
+  assert.ok(existsSync(cliShim), 'packed install should expose the fauxnix executable');
+
+  const version = runNpm(
+    ['exec', '--prefix', installDirectory, '--offline', '--', 'fauxnix', '--version'],
+    { cwd: temporaryRoot, env: cleanEnvironment },
+  );
+  assert.equal(version, `fauxnix ${metadata.version}`);
+
+  const translation = runNpm(
+    [
+      'exec',
+      '--prefix',
+      installDirectory,
+      '--offline',
+      '--',
+      'fauxnix',
+      'translate',
+      'echo',
+      'package-smoke',
+    ],
+    { cwd: temporaryRoot, env: cleanEnvironment },
+  );
+  assert.match(translation, /package-smoke/);
+
+  console.log(`clean source install passed: ${sourceVersion}`);
+  console.log(`package smoke passed: ${basename(tarball)}`);
+  console.log(`  ${version}`);
+} finally {
+  const temporaryParent = dirname(temporaryRoot);
+  assert.equal(temporaryParent, tmpdir(), 'refusing to clean a non-temporary path');
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { translateCommandList } from './translator.js';
 import { registeredNames } from './registry.js';
 import { encodeCommand } from './encoding.js';
 import { startMcpServer } from './mcp.js';
+import { packageVersion } from './version.js';
 import './commands/install-all.js';
 
 const USAGE = `fauxnix — run Linux-style commands on Windows via PowerShell translation
@@ -30,7 +31,7 @@ export async function runCli(argv: string[]): Promise<void> {
   const [verb, ...rest] = argv;
 
   if (verb === '--version' || verb === '-v') {
-    console.log('fauxnix 0.4.0');
+    console.log(`fauxnix ${packageVersion}`);
     return;
   }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,20 +1,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { FauxnixSession } from './executor.js';
 import { parseCommand } from './parser.js';
 import { translateCommandList, wrapScript, translatePipelineBody } from './translator.js';
 import { registeredNames } from './registry.js';
+import { packageVersion } from './version.js';
 import './commands/install-all.js';
-
-// single source of truth: the npm package version in package.json
-// (src/ and dist/ sit one level below the root, so the relative path holds in both)
-const pkgVersion: string = JSON.parse(
-  readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8'),
-).version;
 
 const TOOL_NAME = process.env.FAUXNIX_TOOL_NAME || 'bash';
 
@@ -55,7 +48,7 @@ Platform requirement: the execution backend is native Windows PowerShell 5.1+. O
 
 export async function startMcpServer(): Promise<void> {
   const server = new McpServer(
-    { name: 'fauxnix', version: pkgVersion },
+    { name: 'fauxnix', version: packageVersion },
     { capabilities: { tools: {} } },
   );
   let session = new FauxnixSession();

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+
+interface PackageMetadata {
+  version?: unknown;
+}
+
+// src/ and dist/ are both one level below the package root, so package.json is
+// the runtime source of truth in development and in the published tarball.
+const metadata = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as PackageMetadata;
+
+if (typeof metadata.version !== 'string' || metadata.version.length === 0) {
+  throw new Error('fauxnix: package.json does not contain a valid version');
+}
+
+export const packageVersion = metadata.version;


### PR DESCRIPTION
## Problem

Two release invariants had drifted:

1. package.json, npm, the GitHub release, and MCP reported 0.7.0, while the shipped CLI printed `fauxnix 0.4.0`.
2. `dist/` is required by the bin entry but is gitignored and was not built by a package lifecycle hook. From a clean checkout, `npm pack --dry-run` contained only LICENSE, README, and package.json; the documented `npm install -g .` exited successfully but installed no usable `fauxnix` command.

## Change

- load the package version once in `src/version.ts` and share it between CLI and MCP
- build during `prepare`, covering clean source installs and pack/publish
- use `npm ci` in CI
- add an isolated package smoke test that builds clean source, installs from source, packs, installs the tarball, and executes `--version` plus `translate`
- make the README source-install steps reproducible

## Verification

- clean `npm ci` builds `dist/index.js`
- clean pack grows from 3 files to 41 and includes the executable
- source install and tarball install both expose a working shim
- CLI reports `fauxnix 0.7.0`
- typecheck/build and 139/139 tests pass
- `npm run test:package` passes end to end

