### PR TITLE
fix(executor): enforce one deadline per request

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -282,6 +282,9 @@ async function runPlans(
   ensureHost: () => PowerShellHost,
 ): Promise<ExecResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  const timeoutMessage =
+    '\nbash: command timed out after ' + Math.round(timeoutMs / 1000) + 's';
   let stdout = '';
   let stderr = '';
   let exitCode = 0;
@@ -300,6 +303,12 @@ async function runPlans(
   for (const plan of plans) {
     if (plan.op === '&&' && !chainOk) continue;
     if (plan.op === '||' && chainOk) continue;
+    if (Date.now() >= deadline) {
+      stderr += timeoutMessage;
+      exitCode = 124;
+      session.prevExit = exitCode;
+      break;
+    }
 
     const red = planRedirects(plan.redirects);
     red.stdinFile = red.stdinFile ? resolveTarget(red.stdinFile) : null;
@@ -372,6 +381,14 @@ async function runPlans(
       continue;
     }
 
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      stderr += timeoutMessage;
+      exitCode = 124;
+      session.prevExit = exitCode;
+      break;
+    }
+
     const encoded = wrapScript(plan.body, { mode: 'host' });
     const inv = await ensureHost().invoke(
       encoded,
@@ -380,7 +397,7 @@ async function runPlans(
         FAUXNIX_PREV_EXIT: session.prevExit === null ? '' : String(session.prevExit),
         FAUXNIX_STDIN_FILE: red.stdinFile || '',
       },
-      timeoutMs,
+      remainingMs,
     );
 
     if (inv.spawnError === 'ENOENT') {
@@ -401,7 +418,7 @@ async function runPlans(
     let segErr = normalizeHostNewlines(normalizeStderr(decodeOutput(inv.stderr, decodePref)));
 
     if (inv.timedOut) {
-      segErr += '\nbash: command timed out after ' + Math.round(timeoutMs / 1000) + 's';
+      segErr += timeoutMessage;
     }
 
     if (red.mergeStderr) {
@@ -450,6 +467,7 @@ async function runPlans(
     // output redirects succeeded. A failed `cd dir > missing/out` must
     // not move later relative redirects.
     if (redirectOk && session.cwd) currentDir = session.cwd;
+    if (inv.timedOut) break;
     } finally {
       closePrepFds(prepFds);
     }

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -881,6 +881,45 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     }
   }, 60000);
 
+  it('executor timeout stops later segments before output or side effects', async () => {
+    const extra = new FauxnixSession();
+    const marker = join(dir, 'timeout-later-segment.txt');
+    rmSync(marker, { force: true });
+    try {
+      const r = await extra.run(
+        translateCommandList(
+          parseCommand('sleep 5; echo should-not-run; touch "' + marker + '"'),
+        ),
+        { timeoutMs: 800 },
+      );
+      expect(r.exitCode).toBe(124);
+      expect(r.stderr).toMatch(/timed out/);
+      expect(r.stdout).not.toContain('should-not-run');
+      expect(existsSync(marker)).toBe(false);
+    } finally {
+      await extra.dispose();
+      rmSync(marker, { force: true });
+    }
+  }, 30000);
+
+  it('executor timeout is one deadline across all segments', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const r = await extra.run(
+        translateCommandList(
+          parseCommand('sleep 0.8; echo before-deadline; sleep 0.8; echo after-deadline'),
+        ),
+        { timeoutMs: 1200 },
+      );
+      expect(r.exitCode).toBe(124);
+      expect(r.stderr).toMatch(/timed out/);
+      expect(r.stdout.trim()).toBe('before-deadline');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
   it('executor timeout 124 leaves the same session usable', async () => {
     const extra = new FauxnixSession();
     try {


### PR DESCRIPTION
## Problem

`timeout_ms` was restarted for every list segment. A timed-out segment also did not stop the rest of the command, so later output and side effects still ran and a successful final segment could overwrite exit 124.

For example, `sleep 5; echo after-timeout` with a 1 second budget returned `after-timeout` and final exit 0.

## Change

- establish one absolute deadline for the whole `FauxnixSession.run()` request
- pass only the remaining budget to each segment
- stop the list immediately on timeout
- preserve exit 124 and the timeout diagnostic
- retain the existing cold-restart/session-recovery behavior

## Verification

- regression tests prove later output and file side effects do not run
- regression test proves multiple individually-short segments share one deadline
- existing test proves the same session remains usable after timeout
- `npm ci`, typecheck, build, and full `npm test` — 141/141

