### PR TITLE
fix(mcp): restore PATHEXT for native passthrough

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -21,6 +21,12 @@ export interface ExecOptions {
 }
 
 const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_WINDOWS_PATHEXT = '.COM;.EXE;.BAT;.CMD';
+
+function hasEnvKey(env: NodeJS.ProcessEnv, name: string): boolean {
+  const normalized = name.toUpperCase();
+  return Object.keys(env).some((key) => key.toUpperCase() === normalized);
+}
 
 /** Resolve /dev/null and POSIX-ish literal targets to real Windows paths. */
 function winTarget(target: string): string {
@@ -249,6 +255,14 @@ export class FauxnixSession {
     for (const [k, v] of Object.entries(this.env)) {
       if (v === undefined) delete env[k];
       else env[k] = v;
+    }
+    // The MCP SDK's safe Windows stdio environment omits PATHEXT. Without it,
+    // PowerShell cannot resolve extensionless native commands such as `node`.
+    // Windows environment names are case-insensitive, so preserve any explicit
+    // spelling/value supplied by the caller and only restore the OS default
+    // when no variant is present at all.
+    if (process.platform === 'win32' && !hasEnvKey(env, 'PATHEXT')) {
+      env.PATHEXT = DEFAULT_WINDOWS_PATHEXT;
     }
     env.FAUXNIX_CWD_FILE = this.cwdFile;
     env.FAUXNIX_ENV_FILE = this.envFile;

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -3,6 +3,7 @@
  * PowerShell 5.1. Skipped automatically on non-Windows platforms.
  */
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
+import { getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync, appendFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -890,6 +891,46 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
       const next = await extra.run(translateCommandList(parseCommand('echo after-timeout')));
       expect(next.exitCode).toBe(0);
       expect(next.stdout.trim()).toBe('after-timeout');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('adds a default PATHEXT only when no case variant is present', async () => {
+    const extra = new FauxnixSession();
+    const overrides = extra.env as Record<string, string | undefined>;
+    for (const key of Object.keys(process.env)) {
+      if (key.toUpperCase() === 'PATHEXT') overrides[key] = undefined;
+    }
+    try {
+      const fallbackEnv = extra.childEnv();
+      expect(fallbackEnv.PATHEXT).toBe('.COM;.EXE;.BAT;.CMD');
+
+      extra.env.PathExt = '.EXPLICIT';
+      const explicitEnv = extra.childEnv();
+      const pathExtKeys = Object.keys(explicitEnv).filter((key) => key.toUpperCase() === 'PATHEXT');
+      expect(pathExtKeys).toEqual(['PathExt']);
+      expect(explicitEnv.PathExt).toBe('.EXPLICIT');
+    } finally {
+      await extra.dispose();
+    }
+  });
+
+  it('runs an extensionless native executable when the official MCP environment omits PATHEXT', async () => {
+    const inheritedEnv = getDefaultEnvironment();
+    expect(Object.keys(inheritedEnv).some((key) => key.toUpperCase() === 'PATHEXT')).toBe(false);
+
+    const extra = new FauxnixSession();
+    const overrides = extra.env as Record<string, string | undefined>;
+    for (const key of Object.keys(process.env)) {
+      if (key.toUpperCase() === 'PATHEXT') overrides[key] = undefined;
+    }
+    try {
+      await extra.prewarm();
+      const result = await extra.run(translateCommandList(parseCommand('node --version')));
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/^v\d+\.\d+\.\d+/m);
+      expect(result.stderr).toBe('');
     } finally {
       await extra.dispose();
     }


### PR DESCRIPTION
## Problem

On Windows, the pinned official MCP SDK's safe stdio environment omits `PATHEXT`. Fauxnix inherited that environment unchanged, so PowerShell could not resolve extensionless native passthrough commands such as `node`, `git`, or `npm`; `node --version` returned exit 127 when invoked through the official client.

## Change

- add the Windows default `.COM;.EXE;.BAT;.CMD` only when no case variant of `PATHEXT` exists
- preserve every explicit caller-supplied value and spelling
- add a regression using the official SDK environment plus an actual extensionless native execution

## Verification

- before: official-client environment + `node --version` => exit 127
- after: the same condition resolves Node and exits 0
- `npm ci`, typecheck, build, and full `npm test` — 141/141

