### PR TITLE
release: v0.7.1 — post-v0.7 audit fixes (#123-#128)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install
+      - run: npm ci
       - run: npm run typecheck
       - run: npm run build
       - run: npm test
+      - run: npm run test:package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.7.1 — 2026-08-23
+
+Post-v0.7 audit fixes (issue #131 by @vulragrag-star; integration of #123–#128):
+
+- `grep -r` restored: recursive search honors `--include`/`--exclude`/
+  `--exclude-dir` filters without misparsing short bundles (#123)
+- Pipeline exit status now comes from the final stage (per-stage status slots
+  replace the shared flag that let earlier failures leak) (#124)
+- `find -maxdepth`/`-mindepth` semantics fixed + GNU-style argument
+  validation (#125)
+- Release integrity: CI uses `npm ci`, a `test:package` job validates the
+  packed tarball and clean-source install (catches missing executables and
+  stale versions), README source-install instructions fixed (#126)
+- One timeout deadline per request: later segments no longer run after the
+  budget expires; exit 124 propagates immediately (#127)
+- `PATHEXT` restored when the official MCP SDK's sanitized Windows
+  environment omits it (extensionless native commands like `node` resolve
+  again in real clients) (#128)
+
+156/156 tests green.
 ## v0.7.0 — 2026-08-20
 
 First roadmap wave (docs/rfc-roadmap-to-1.0.md): A2, part of A1, B1.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ npm install -g fauxnix-cli
 Or from source:
 
 ```bash
-git clone https://github.com/20000419/fauxnix && cd fauxnix && npm install -g .
+git clone https://github.com/20000419/fauxnix && cd fauxnix
+npm ci
+npm install -g .
 ```
 
 > npm package name is `fauxnix-cli` (the `fauxnix` name on npm belongs to an

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fauxnix-cli",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   ],
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "test": "vitest run",
+    "test:package": "node scripts/package-smoke.mjs",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "dev": "tsx src/index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Fauxnix — run Linux-style commands on Windows via deterministic PowerShell translation. No VM, no WSL. MCP server + CLI for AI agents.",
   "type": "module",
   "bin": {

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, delimiter, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = fileURLToPath(new URL('..', import.meta.url));
+const metadata = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: packageRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  });
+
+  if (result.error || result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(
+      `${command} ${args.join(' ')} failed${result.status === null ? '' : ` (${result.status})`}` +
+        `${result.error ? `: ${result.error.message}` : ''}` +
+        `${detail ? `\n${detail}` : ''}`,
+    );
+  }
+
+  return result.stdout.trim();
+}
+
+function runNpm(args, options = {}) {
+  if (process.env.npm_execpath) {
+    return run(process.execPath, [process.env.npm_execpath, ...args], options);
+  }
+
+  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  return run(npmCommand, args, {
+    shell: process.platform === 'win32',
+    ...options,
+  });
+}
+
+function withoutProjectBin() {
+  const environment = { ...process.env };
+  const pathKey = Object.keys(environment).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+  const projectBin = resolve(packageRoot, 'node_modules', '.bin');
+  environment[pathKey] = (environment[pathKey] ?? '')
+    .split(delimiter)
+    .filter((entry) => entry && resolve(entry) !== projectBin)
+    .join(delimiter);
+  return environment;
+}
+
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'fauxnix-package-smoke-'));
+const sourceDirectory = join(temporaryRoot, 'source');
+const sourceInstallDirectory = join(temporaryRoot, 'source-install');
+const packDirectory = join(temporaryRoot, 'pack');
+const installDirectory = join(temporaryRoot, 'install');
+
+try {
+  mkdirSync(sourceDirectory);
+  mkdirSync(sourceInstallDirectory);
+  mkdirSync(packDirectory);
+  mkdirSync(installDirectory);
+
+  for (const filename of ['package.json', 'package-lock.json', 'tsconfig.json', 'README.md', 'LICENSE']) {
+    cpSync(join(packageRoot, filename), join(sourceDirectory, filename));
+  }
+  cpSync(join(packageRoot, 'src'), join(sourceDirectory, 'src'), { recursive: true });
+
+  const cleanEnvironment = withoutProjectBin();
+  runNpm(['ci', '--no-audit', '--no-fund'], {
+    cwd: sourceDirectory,
+    env: cleanEnvironment,
+  });
+  const sourceCliEntry = join(sourceDirectory, 'dist', 'index.js');
+  assert.ok(existsSync(sourceCliEntry), 'npm ci in clean source should build dist/index.js');
+
+  runNpm(
+    [
+      'install',
+      '--global',
+      '--prefix',
+      sourceInstallDirectory,
+      '--no-audit',
+      '--no-fund',
+      sourceDirectory,
+    ],
+    { cwd: sourceDirectory, env: cleanEnvironment },
+  );
+
+  const globalPackageRoot =
+    process.platform === 'win32'
+      ? join(sourceInstallDirectory, 'node_modules', metadata.name)
+      : join(sourceInstallDirectory, 'lib', 'node_modules', metadata.name);
+  const globalCliShim =
+    process.platform === 'win32'
+      ? join(sourceInstallDirectory, 'fauxnix.cmd')
+      : join(sourceInstallDirectory, 'bin', 'fauxnix');
+  assert.ok(existsSync(sourceCliEntry), 'installing clean source should build dist/index.js');
+  assert.ok(
+    existsSync(join(globalPackageRoot, 'dist', 'index.js')),
+    'global source install should expose dist/index.js',
+  );
+  assert.ok(existsSync(globalCliShim), 'global source install should expose the fauxnix executable');
+  const sourceVersion = run(process.execPath, [sourceCliEntry, '--version'], {
+    cwd: temporaryRoot,
+    env: cleanEnvironment,
+  });
+  assert.equal(sourceVersion, `fauxnix ${metadata.version}`);
+
+  runNpm(['pack', '--silent', '--pack-destination', packDirectory]);
+  const tarballs = readdirSync(packDirectory).filter((name) => name.endsWith('.tgz'));
+  assert.equal(tarballs.length, 1, 'npm pack should produce exactly one tarball');
+
+  const tarball = join(packDirectory, tarballs[0]);
+  runNpm(
+    ['install', '--prefix', installDirectory, '--no-audit', '--no-fund', tarball],
+    { cwd: temporaryRoot, env: cleanEnvironment },
+  );
+
+  const installedRoot = join(installDirectory, 'node_modules', metadata.name);
+  const cliEntry = join(installedRoot, 'dist', 'index.js');
+  const cliShim = join(
+    installDirectory,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'fauxnix.cmd' : 'fauxnix',
+  );
+  assert.ok(existsSync(cliEntry), 'packed install should contain dist/index.js');
+  assert.ok(existsSync(cliShim), 'packed install should expose the fauxnix executable');
+
+  const version = runNpm(
+    ['exec', '--prefix', installDirectory, '--offline', '--', 'fauxnix', '--version'],
+    { cwd: temporaryRoot, env: cleanEnvironment },
+  );
+  assert.equal(version, `fauxnix ${metadata.version}`);
+
+  const translation = runNpm(
+    [
+      'exec',
+      '--prefix',
+      installDirectory,
+      '--offline',
+      '--',
+      'fauxnix',
+      'translate',
+      'echo',
+      'package-smoke',
+    ],
+    { cwd: temporaryRoot, env: cleanEnvironment },
+  );
+  assert.match(translation, /package-smoke/);
+
+  console.log(`clean source install passed: ${sourceVersion}`);
+  console.log(`package smoke passed: ${basename(tarball)}`);
+  console.log(`  ${version}`);
+} finally {
+  const temporaryParent = dirname(temporaryRoot);
+  assert.equal(temporaryParent, tmpdir(), 'refusing to clean a non-temporary path');
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { translateCommandList } from './translator.js';
 import { registeredNames } from './registry.js';
 import { encodeCommand } from './encoding.js';
 import { startMcpServer } from './mcp.js';
+import { packageVersion } from './version.js';
 import './commands/install-all.js';
 
 const USAGE = `fauxnix — run Linux-style commands on Windows via PowerShell translation
@@ -30,7 +31,7 @@ export async function runCli(argv: string[]): Promise<void> {
   const [verb, ...rest] = argv;
 
   if (verb === '--version' || verb === '-v') {
-    console.log('fauxnix 0.4.0');
+    console.log(`fauxnix ${packageVersion}`);
     return;
   }
 

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -532,6 +532,28 @@ const find: Handler = (args) => {
   const wantDelete = preds.includes('-delete');
   const paths = pathWords.length ? argListExpr(pathWords) : "@('.')";
 
+  for (const option of ['-maxdepth', '-mindepth']) {
+    const optionIndex = preds.indexOf(option);
+    if (optionIndex < 0) continue;
+    if (optionIndex + 1 >= preds.length) {
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr(`find: missing argument to '${option}'`) +
+        '); $script:fx_exit = 1'
+      );
+    }
+    const value = preds[optionIndex + 1];
+    if (!/^\d+$/.test(value)) {
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr(
+          `find: expected a non-negative decimal integer argument to ${option}, but got '${value}'`,
+        ) +
+        '); $script:fx_exit = 1'
+      );
+    }
+  }
+
   const conditions: string[] = [];
   if (namePat !== null) conditions.push("($fx_i.Name -like '" + likeOf(namePat) + "')");
   if (inamePat !== null)
@@ -554,9 +576,9 @@ const find: Handler = (args) => {
     '  foreach ($fx_i in $fx_all) {',
     "    $fx_rel = $fx_i.FullName.Substring($fx_root.Length).TrimStart('\\').Replace('\\', '/')",
     "    if ($fx_rel -eq '') { $fx_disp = $fx_p } else { $fx_disp = ($fx_p.TrimEnd('/') + '/' + $fx_rel) }",
-    '    $fx_depth = 0; foreach ($fx_c in $fx_rel.ToCharArray()) { if ($fx_c -eq \'/\') { $fx_depth++ } }',
-    '    if ($fx_depth -lt ' + (minDepthS && /^\d+$/.test(minDepthS) ? minDepthS : '0') + ') { continue }',
-    maxDepthS && /^\d+$/.test(maxDepthS) ? '    if ($fx_depth -gt ' + maxDepthS + ') { continue }' : '',
+    '    $fx_depth = 0; if ($fx_rel -ne \'\') { $fx_depth = 1; foreach ($fx_c in $fx_rel.ToCharArray()) { if ($fx_c -eq \'/\') { $fx_depth++ } } }',
+    '    if ($fx_depth -lt ' + (minDepthS ?? '0') + ') { continue }',
+    maxDepthS !== null ? '    if ($fx_depth -gt ' + maxDepthS + ') { continue }' : '',
     '    if (-not (' + cond + ')) { continue }',
     sizeCond ? '    $fx_sz = 0; if (-not $fx_i.PSIsContainer) { try { $fx_sz = $fx_i.Length } catch {} }' : '',
     sizeCond ? '    if (-not (' + sizeCond + ')) { continue }' : '',

--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -83,7 +83,7 @@ function textExpr(w: Word): string {
 }
 
 /** Collect EVERY value of a short option (-kN, -k N) — parseWords keeps only the last. */
-function collectShortValues(args: Word[], letter: string, longName?: string): string[] {
+function collectShortValues(args: Word[], letter: string): string[] {
   const out: string[] = [];
   let onlyOps = false;
   for (let i = 0; i < args.length; i++) {
@@ -93,14 +93,42 @@ function collectShortValues(args: Word[], letter: string, longName?: string): st
       continue;
     }
     if (onlyOps) continue;
-    if (longName && t.startsWith(longName + '=')) out.push(t.slice(longName.length + 1));
-    else if (t === '-' + letter) {
+    if (t === '-' + letter) {
       if (i + 1 < args.length) {
         out.push(wordToString(args[i + 1]));
         i++;
       }
     } else if (t.startsWith('-' + letter) && t.length > 2 && !t.startsWith('--')) {
       out.push(t.slice(2));
+    }
+  }
+  return out;
+}
+
+interface LongOptionValue {
+  name: string;
+  value: string;
+}
+
+/** Collect repeated value-taking long options without mistaking short bundles for values. */
+function collectLongValues(args: Word[], names: string[]): LongOptionValue[] {
+  const out: LongOptionValue[] = [];
+  let onlyOps = false;
+  for (let i = 0; i < args.length; i++) {
+    const t = wordToString(args[i]);
+    if (t === '--') {
+      onlyOps = true;
+      continue;
+    }
+    if (onlyOps || !t.startsWith('--')) continue;
+    const eq = t.indexOf('=');
+    const name = eq >= 0 ? t.slice(0, eq) : t;
+    if (!names.includes(name)) continue;
+    if (eq >= 0) {
+      out.push({ name, value: t.slice(eq + 1) });
+    } else if (i + 1 < args.length) {
+      out.push({ name, value: wordToString(args[i + 1]) });
+      i++;
     }
   }
   return out;
@@ -248,9 +276,26 @@ function ereToDotNet(re: string): string {
 /* ------------------------------------------------------------------ */
 
 const grep: Handler = (args) => {
-  const includeGlobs = collectShortValues(args, '', '--include');
+  const filterOptionNames = ['--include', '--exclude', '--exclude-dir'];
+  const filterOptions = collectLongValues(args, filterOptionNames);
+  const fileFilterOptions = filterOptions.filter((o) => o.name !== '--exclude-dir');
+  const excludeDirGlobs = filterOptions
+    .filter((o) => o.name === '--exclude-dir')
+    .map((o) => o.value.replace(/[\\/]+$/, ''));
 
-  const { flags, operandWords, values } = parseWords(args, ['A', 'B', 'C']);
+  const { flags, operandWords, values, missingValue } = parseWords(
+    args,
+    ['A', 'B', 'C'],
+    filterOptionNames,
+  );
+  const missingFilterOption = missingValue.find((o) => filterOptionNames.includes(o));
+  if (missingFilterOption) {
+    return (
+      '[Console]::Error.WriteLine(' +
+      psStr("grep: option '" + missingFilterOption + "' requires an argument") +
+      '); $script:fx_exit = 2'
+    );
+  }
   const ci = flags.has('i');
   const inv = flags.has('v');
   const num = flags.has('n');
@@ -339,11 +384,74 @@ const grep: Handler = (args) => {
   if (fileWords.length > 0) {
     lines.push(PS_GLOB_FN);
     lines.push(
-      '$fx_inc = @(' + includeGlobs.map((g) => psStr(g)).join(', ') + ')',
+      '$fx_fsel = @(' +
+        fileFilterOptions
+          .map(
+            (o) =>
+              '[pscustomobject]@{ Keep = ' +
+              pb(o.name === '--include') +
+              '; Glob = ' +
+              psStr(o.value) +
+              ' }',
+          )
+          .join(', ') +
+        ')',
+      '$fx_excd = @(' + excludeDirGlobs.map((g) => psStr(g)).join(', ') + ')',
       '$fx_srcs = @()',
       '$fx_err = $false',
       '$fx_recd = $false',
     );
+    lines.push('function fx-globmatch($fx_name, $fx_glob, $fx_suffix) {');
+    lines.push("  $fx_n = ([string]$fx_name).Replace('\\', '/')");
+    lines.push("  $fx_p = ([string]$fx_glob).Replace('\\', '/')");
+    lines.push('  if ($fx_n -like $fx_p) { return $true }');
+    lines.push('  if ($fx_suffix) {');
+    lines.push("    $fx_slash = $fx_n.IndexOf('/')");
+    lines.push('    while ($fx_slash -ge 0 -and $fx_slash + 1 -lt $fx_n.Length) {');
+    lines.push('      $fx_n = $fx_n.Substring($fx_slash + 1)');
+    lines.push('      if ($fx_n -like $fx_p) { return $true }');
+    lines.push("      $fx_slash = $fx_n.IndexOf('/')");
+    lines.push('    }');
+    lines.push('  }');
+    lines.push('  return $false');
+    lines.push('}');
+    lines.push('function fx-anyglob($fx_name, $fx_globs, $fx_suffix) {');
+    lines.push(
+      '  foreach ($fx_glob in $fx_globs) { if (fx-globmatch $fx_name $fx_glob $fx_suffix) { return $true } }',
+    );
+    lines.push('  return $false');
+    lines.push('}');
+    lines.push('function fx-filewanted($fx_path, $fx_suffix) {');
+    lines.push('  if ($fx_fsel.Count -eq 0) { return $true }');
+    lines.push(
+      '  $fx_name = if ($fx_suffix) { [string]$fx_path } else { [IO.Path]::GetFileName([string]$fx_path) }',
+    );
+    lines.push('  $fx_keep = -not [bool]$fx_fsel[0].Keep');
+    lines.push(
+      '  foreach ($fx_rule in $fx_fsel) { if (fx-globmatch $fx_name $fx_rule.Glob $fx_suffix) { $fx_keep = [bool]$fx_rule.Keep } }',
+    );
+    lines.push('  return $fx_keep');
+    lines.push('}');
+    if (rec) {
+      lines.push('function fx-walkfiles($fx_root) {');
+      lines.push('  $fx_dirs = New-Object System.Collections.Stack');
+      lines.push('  $fx_dirs.Push([string]$fx_root)');
+      lines.push('  while ($fx_dirs.Count -gt 0) {');
+      lines.push('    $fx_cur = [string]$fx_dirs.Pop()');
+      lines.push(
+        '    foreach ($fx_item in @(Get-ChildItem -LiteralPath $fx_cur -Force -ErrorAction SilentlyContinue)) {',
+      );
+      lines.push('      if ($fx_item.PSIsContainer) {');
+      lines.push(
+        '        if (($fx_item.Attributes -band [IO.FileAttributes]::ReparsePoint) -eq 0 -and -not (fx-anyglob $fx_item.Name $fx_excd $false)) { $fx_dirs.Push($fx_item.FullName) }',
+      );
+      lines.push(
+        '      } elseif (fx-filewanted $fx_item.FullName $false) { $fx_item.FullName }',
+      );
+      lines.push('    }');
+      lines.push('  }');
+      lines.push('}');
+    }
     lines.push('foreach ($fx_o in ' + psArray(fileWords) + ') {');
     lines.push('  foreach ($fx_g in (fx-glob $fx_o)) {');
     lines.push(
@@ -351,22 +459,16 @@ const grep: Handler = (args) => {
     );
     lines.push('    if (Test-Path -LiteralPath $fx_g -PathType Container) {');
     if (rec) {
+      lines.push('      $fx_dir = Get-Item -LiteralPath $fx_g');
+      lines.push('      if (fx-anyglob $fx_g $fx_excd $true) { continue }');
       lines.push('      $fx_recd = $true');
-      lines.push(
-        '      $fx_subs = @(Get-ChildItem -LiteralPath $fx_g -Recurse -Force -File -ErrorAction SilentlyContinue)',
-      );
-      lines.push('      if ($fx_inc.Count -gt 0) {');
-      lines.push(
-        "        $fx_subs = @($fx_subs | Where-Object { $fx_ok = $false; foreach ($fx_gi in $fx_inc) { if ($_.Name -like $fx_gi) { $fx_ok = $true; break } }; $fx_ok })",
-      );
-      lines.push('      }');
-      lines.push('      foreach ($fx_s in $fx_subs) { $fx_srcs += $fx_s.FullName }');
+      lines.push('      $fx_srcs += @(fx-walkfiles $fx_dir.FullName)');
     } else {
       lines.push(
         "      [Console]::Error.WriteLine('grep: ' + $fx_g + ': Is a directory'); $fx_err = $true",
       );
     }
-    lines.push('    } else { $fx_srcs += $fx_g }');
+    lines.push('    } elseif (fx-filewanted $fx_g $true) { $fx_srcs += $fx_g }');
     lines.push('  }');
     lines.push('}');
     lines.push('$fx_pre = $false');

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -21,6 +21,12 @@ export interface ExecOptions {
 }
 
 const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_WINDOWS_PATHEXT = '.COM;.EXE;.BAT;.CMD';
+
+function hasEnvKey(env: NodeJS.ProcessEnv, name: string): boolean {
+  const normalized = name.toUpperCase();
+  return Object.keys(env).some((key) => key.toUpperCase() === normalized);
+}
 
 /** Resolve /dev/null and POSIX-ish literal targets to real Windows paths. */
 function winTarget(target: string): string {
@@ -249,6 +255,14 @@ export class FauxnixSession {
     for (const [k, v] of Object.entries(this.env)) {
       if (v === undefined) delete env[k];
       else env[k] = v;
+    }
+    // The MCP SDK's safe Windows stdio environment omits PATHEXT. Without it,
+    // PowerShell cannot resolve extensionless native commands such as `node`.
+    // Windows environment names are case-insensitive, so preserve any explicit
+    // spelling/value supplied by the caller and only restore the OS default
+    // when no variant is present at all.
+    if (process.platform === 'win32' && !hasEnvKey(env, 'PATHEXT')) {
+      env.PATHEXT = DEFAULT_WINDOWS_PATHEXT;
     }
     env.FAUXNIX_CWD_FILE = this.cwdFile;
     env.FAUXNIX_ENV_FILE = this.envFile;

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -282,6 +282,9 @@ async function runPlans(
   ensureHost: () => PowerShellHost,
 ): Promise<ExecResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  const timeoutMessage =
+    '\nbash: command timed out after ' + Math.round(timeoutMs / 1000) + 's';
   let stdout = '';
   let stderr = '';
   let exitCode = 0;
@@ -300,6 +303,12 @@ async function runPlans(
   for (const plan of plans) {
     if (plan.op === '&&' && !chainOk) continue;
     if (plan.op === '||' && chainOk) continue;
+    if (Date.now() >= deadline) {
+      stderr += timeoutMessage;
+      exitCode = 124;
+      session.prevExit = exitCode;
+      break;
+    }
 
     const red = planRedirects(plan.redirects);
     red.stdinFile = red.stdinFile ? resolveTarget(red.stdinFile) : null;
@@ -372,6 +381,14 @@ async function runPlans(
       continue;
     }
 
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      stderr += timeoutMessage;
+      exitCode = 124;
+      session.prevExit = exitCode;
+      break;
+    }
+
     const encoded = wrapScript(plan.body, { mode: 'host' });
     const inv = await ensureHost().invoke(
       encoded,
@@ -380,7 +397,7 @@ async function runPlans(
         FAUXNIX_PREV_EXIT: session.prevExit === null ? '' : String(session.prevExit),
         FAUXNIX_STDIN_FILE: red.stdinFile || '',
       },
-      timeoutMs,
+      remainingMs,
     );
 
     if (inv.spawnError === 'ENOENT') {
@@ -401,7 +418,7 @@ async function runPlans(
     let segErr = normalizeHostNewlines(normalizeStderr(decodeOutput(inv.stderr, decodePref)));
 
     if (inv.timedOut) {
-      segErr += '\nbash: command timed out after ' + Math.round(timeoutMs / 1000) + 's';
+      segErr += timeoutMessage;
     }
 
     if (red.mergeStderr) {
@@ -450,6 +467,7 @@ async function runPlans(
     // output redirects succeeded. A failed `cd dir > missing/out` must
     // not move later relative redirects.
     if (redirectOk && session.cwd) currentDir = session.cwd;
+    if (inv.timedOut) break;
     } finally {
       closePrepFds(prepFds);
     }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,20 +1,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { FauxnixSession } from './executor.js';
 import { parseCommand } from './parser.js';
 import { translateCommandList, wrapScript, translatePipelineBody } from './translator.js';
 import { registeredNames } from './registry.js';
+import { packageVersion } from './version.js';
 import './commands/install-all.js';
-
-// single source of truth: the npm package version in package.json
-// (src/ and dist/ sit one level below the root, so the relative path holds in both)
-const pkgVersion: string = JSON.parse(
-  readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8'),
-).version;
 
 const TOOL_NAME = process.env.FAUXNIX_TOOL_NAME || 'bash';
 
@@ -55,7 +48,7 @@ Platform requirement: the execution backend is native Windows PowerShell 5.1+. O
 
 export async function startMcpServer(): Promise<void> {
   const server = new McpServer(
-    { name: 'fauxnix', version: pkgVersion },
+    { name: 'fauxnix', version: packageVersion },
     { capabilities: { tools: {} } },
   );
   let session = new FauxnixSession();

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -816,6 +816,9 @@ export function wrapTempEnv(
 /** Unique suffix for generated stage functions (nested pipelines included). */
 let stageSeq = 0;
 
+/** Unique suffix for generated pipeline wrappers and their local status arrays. */
+let pipelineSeq = 0;
+
 export interface PipelineParts {
   /** Generated function definitions (empty for single commands). */
   defs: string;
@@ -888,6 +891,12 @@ function translateFor(cmd: ForCommand): string {
 export function translatePipelineBody(p: {
   commands: Array<SimpleCommand | IfCommand | ForCommand>;
 }): PipelineParts {
+  // Every pipeline stage needs its own status slot. Handlers deliberately use
+  // `$script:fx_exit` because their helper functions run in child scopes; in a
+  // pipeline that shared flag lets an earlier failure leak into a successful
+  // last stage. Reserve the wrapper id before translating bodies so nested
+  // command substitutions cannot reuse it.
+  const pipelineId = p.commands.length > 1 ? pipelineSeq++ : -1;
   const bodies: string[] = [];
   for (let i = 0; i < p.commands.length; i++) {
     const c = p.commands[i];
@@ -905,16 +914,38 @@ export function translatePipelineBody(p: {
 
   const names: string[] = [];
   const defs: string[] = [];
+  const statusVar = '$fx_pipe_status' + pipelineId;
   for (let i = 0; i < bodies.length; i++) {
     const name = '__fx_s' + stageSeq++;
     names.push(name);
-    const indented = bodies[i]
+    const isolatedBody = bodies[i].split('$script:fx_exit').join(statusVar + '[' + i + ']');
+    const indented = isolatedBody
       .split('\n')
       .map((l) => (l ? '  ' + l : l))
       .join('\n');
     defs.push('function ' + name + ' {\n' + indented + '\n}');
   }
-  return { defs: defs.join('\n'), call: names.join(' | ') };
+  const pipelineName = '__fx_p' + pipelineId;
+  const statuses = bodies.map(() => '0').join(', ');
+  const pipelineCall = names.join(' | ');
+  defs.push(
+    [
+      'function ' + pipelineName + ' {',
+      '  ' + statusVar + ' = @(' + statuses + ')',
+      '  try {',
+      // The wrapper forwards redirect input to stage zero. With no input,
+      // PowerShell still invokes a regular function once, which preserves the
+      // existing no-stdin pipeline behavior on Windows PowerShell 5.1.
+      '    $input | ' + pipelineCall,
+      '  } finally {',
+      // Bash defaults to pipefail off: only the last stage controls the list
+      // status used by a following && / || segment.
+      '    $script:fx_exit = [int]' + statusVar + '[' + (bodies.length - 1) + ']',
+      '  }',
+      '}',
+    ].join('\n'),
+  );
+  return { defs: defs.join('\n'), call: pipelineName };
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+
+interface PackageMetadata {
+  version?: unknown;
+}
+
+// src/ and dist/ are both one level below the package root, so package.json is
+// the runtime source of truth in development and in the published tarball.
+const metadata = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as PackageMetadata;
+
+if (typeof metadata.version !== 'string' || metadata.version.length === 0) {
+  throw new Error('fauxnix: package.json does not contain a valid version');
+}
+
+export const packageVersion = metadata.version;

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -881,6 +881,45 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     }
   }, 60000);
 
+  it('executor timeout stops later segments before output or side effects', async () => {
+    const extra = new FauxnixSession();
+    const marker = join(dir, 'timeout-later-segment.txt');
+    rmSync(marker, { force: true });
+    try {
+      const r = await extra.run(
+        translateCommandList(
+          parseCommand('sleep 5; echo should-not-run; touch "' + marker + '"'),
+        ),
+        { timeoutMs: 800 },
+      );
+      expect(r.exitCode).toBe(124);
+      expect(r.stderr).toMatch(/timed out/);
+      expect(r.stdout).not.toContain('should-not-run');
+      expect(existsSync(marker)).toBe(false);
+    } finally {
+      await extra.dispose();
+      rmSync(marker, { force: true });
+    }
+  }, 30000);
+
+  it('executor timeout is one deadline across all segments', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const r = await extra.run(
+        translateCommandList(
+          parseCommand('sleep 0.8; echo before-deadline; sleep 0.8; echo after-deadline'),
+        ),
+        { timeoutMs: 1200 },
+      );
+      expect(r.exitCode).toBe(124);
+      expect(r.stderr).toMatch(/timed out/);
+      expect(r.stdout.trim()).toBe('before-deadline');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
   it('executor timeout 124 leaves the same session usable', async () => {
     const extra = new FauxnixSession();
     try {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -3,6 +3,7 @@
  * PowerShell 5.1. Skipped automatically on non-Windows platforms.
  */
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
+import { getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync, appendFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -890,6 +891,46 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
       const next = await extra.run(translateCommandList(parseCommand('echo after-timeout')));
       expect(next.exitCode).toBe(0);
       expect(next.stdout.trim()).toBe('after-timeout');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('adds a default PATHEXT only when no case variant is present', async () => {
+    const extra = new FauxnixSession();
+    const overrides = extra.env as Record<string, string | undefined>;
+    for (const key of Object.keys(process.env)) {
+      if (key.toUpperCase() === 'PATHEXT') overrides[key] = undefined;
+    }
+    try {
+      const fallbackEnv = extra.childEnv();
+      expect(fallbackEnv.PATHEXT).toBe('.COM;.EXE;.BAT;.CMD');
+
+      extra.env.PathExt = '.EXPLICIT';
+      const explicitEnv = extra.childEnv();
+      const pathExtKeys = Object.keys(explicitEnv).filter((key) => key.toUpperCase() === 'PATHEXT');
+      expect(pathExtKeys).toEqual(['PathExt']);
+      expect(explicitEnv.PathExt).toBe('.EXPLICIT');
+    } finally {
+      await extra.dispose();
+    }
+  });
+
+  it('runs an extensionless native executable when the official MCP environment omits PATHEXT', async () => {
+    const inheritedEnv = getDefaultEnvironment();
+    expect(Object.keys(inheritedEnv).some((key) => key.toUpperCase() === 'PATHEXT')).toBe(false);
+
+    const extra = new FauxnixSession();
+    const overrides = extra.env as Record<string, string | undefined>;
+    for (const key of Object.keys(process.env)) {
+      if (key.toUpperCase() === 'PATHEXT') overrides[key] = undefined;
+    }
+    try {
+      await extra.prewarm();
+      const result = await extra.run(translateCommandList(parseCommand('node --version')));
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/^v\d+\.\d+\.\d+/m);
+      expect(result.stderr).toBe('');
     } finally {
       await extra.dispose();
     }

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -28,6 +28,14 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     writeFileSync(join(dir, 'dups.txt'), 'aaa\naaa\nbbb\n', 'utf8');
     mkdirSync(join(dir, 'sub'));
     writeFileSync(join(dir, 'sub', 'b.txt'), 'third line\n', 'utf8');
+    mkdirSync(join(dir, 'find-depth', 'level-one', 'level-two'), { recursive: true });
+    writeFileSync(join(dir, 'find-depth', 'root.txt'), 'root\n', 'utf8');
+    writeFileSync(join(dir, 'find-depth', 'level-one', 'child.txt'), 'child\n', 'utf8');
+    writeFileSync(
+      join(dir, 'find-depth', 'level-one', 'level-two', 'grandchild.txt'),
+      'grandchild\n',
+      'utf8',
+    );
     session = new FauxnixSession();
     // seed the session cwd like a real shell login directory
     await session.run(translateCommandList(parseCommand('cd "' + dir + '"')));
@@ -560,6 +568,46 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
   it('find + wc -l counts rows', async () => {
     const r = await run("find sub -name '*.txt' | wc -l");
     expect(r.stdout.trim()).toBe('1');
+  });
+
+  it('find applies maxdepth and mindepth from root depth zero', async () => {
+    const paths = async (cmd: string) => {
+      const r = await run(cmd);
+      expect(r.exitCode).toBe(0);
+      return r.stdout.split(/\r?\n/).filter(Boolean).sort();
+    };
+
+    expect(await paths('find find-depth -maxdepth 0')).toEqual(['find-depth']);
+    expect(await paths('find find-depth -maxdepth 1')).toEqual([
+      'find-depth',
+      'find-depth/level-one',
+      'find-depth/root.txt',
+    ]);
+    expect(await paths('find find-depth -mindepth 1 -maxdepth 1')).toEqual([
+      'find-depth/level-one',
+      'find-depth/root.txt',
+    ]);
+    expect(await paths('find find-depth -mindepth 2 -maxdepth 2')).toEqual([
+      'find-depth/level-one/child.txt',
+      'find-depth/level-one/level-two',
+    ]);
+    expect(await paths('find find-depth -mindepth 3')).toEqual([
+      'find-depth/level-one/level-two/grandchild.txt',
+    ]);
+  });
+
+  it('find rejects missing and invalid depth arguments', async () => {
+    const missing = await run('find find-depth -maxdepth');
+    expect(missing.exitCode).toBe(1);
+    expect(missing.stderr).toContain("find: missing argument to '-maxdepth'");
+
+    for (const value of ['nope', '-1']) {
+      const invalid = await run(`find find-depth -mindepth ${value}`);
+      expect(invalid.exitCode).toBe(1);
+      expect(invalid.stderr).toContain(
+        `find: expected a non-negative decimal integer argument to -mindepth, but got '${value}'`,
+      );
+    }
   });
 
   it('stat -c format', async () => {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -85,6 +85,25 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout.split(/\r?\n/).filter(Boolean)).toEqual(['apple', 'apple pie']);
   });
 
+  it('pipeline exit status comes from the last stage (pipefail off)', async () => {
+    expect((await run('false | true')).exitCode).toBe(0);
+    expect((await run('true | false')).exitCode).toBe(1);
+  });
+
+  it('pipeline exit status controls following && and || lists', async () => {
+    const andResult = await run('grep NO fruits.txt | head -1 && echo AFTER');
+    expect(andResult.stdout.trim()).toBe('AFTER');
+    expect(andResult.exitCode).toBe(0);
+
+    const ignoredFailure = await run('false | true || echo FALLBACK');
+    expect(ignoredFailure.stdout.trim()).toBe('');
+    expect(ignoredFailure.exitCode).toBe(0);
+
+    const lastStageFailure = await run('true | false || echo FALLBACK');
+    expect(lastStageFailure.stdout.trim()).toBe('FALLBACK');
+    expect(lastStageFailure.exitCode).toBe(0);
+  });
+
   it('sed substitution', async () => {
     const r = await run("sed 's/apple/MANGO/g' fruits.txt");
     expect(r.stdout).toContain('MANGO pie');

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -28,6 +28,16 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     writeFileSync(join(dir, 'dups.txt'), 'aaa\naaa\nbbb\n', 'utf8');
     mkdirSync(join(dir, 'sub'));
     writeFileSync(join(dir, 'sub', 'b.txt'), 'third line\n', 'utf8');
+    mkdirSync(join(dir, 'grep-tree', 'src'), { recursive: true });
+    mkdirSync(join(dir, 'grep-tree', 'vendor'), { recursive: true });
+    mkdirSync(join(dir, 'grep-tree', 'generated'), { recursive: true });
+    writeFileSync(join(dir, 'grep-tree', 'keep.ts'), 'token keep\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'notes.md'), 'token notes\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'skip.test.ts'), 'token test\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'explicit.txt'), 'token explicit\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'src', 'nested.ts'), 'token nested\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'vendor', 'vendor.ts'), 'token vendor\n', 'utf8');
+    writeFileSync(join(dir, 'grep-tree', 'generated', 'generated.md'), 'token generated\n', 'utf8');
     session = new FauxnixSession();
     // seed the session cwd like a real shell login directory
     await session.run(translateCommandList(parseCommand('cd "' + dir + '"')));
@@ -78,6 +88,58 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('grep apple fruits.txt')).exitCode).toBe(0);
     expect((await run('grep zz fruits.txt')).exitCode).toBe(1);
     expect((await run('grep x missing-file')).exitCode).toBe(2);
+  });
+
+  it('grep -rn recursively searches instead of treating bundled flags as an include glob', async () => {
+    const r = await run('grep -rn token grep-tree');
+    const stdout = r.stdout.replaceAll('\\', '/');
+    expect(r.exitCode).toBe(0);
+    expect(stdout).toMatch(/grep-tree\/keep\.ts:1:token keep/);
+    expect(stdout).toMatch(/grep-tree\/src\/nested\.ts:1:token nested/);
+  });
+
+  it('grep applies repeated include, exclude, and exclude-dir filters', async () => {
+    const r = await run(
+      "grep -rn --include='*.ts' --include '*.md' --exclude='*.test.ts' --exclude notes.md --exclude-dir=vendor --exclude-dir generated token grep-tree",
+    );
+    const stdout = r.stdout.replaceAll('\\', '/');
+    expect(r.exitCode).toBe(0);
+    expect(stdout).toMatch(/grep-tree\/keep\.ts:1:token keep/);
+    expect(stdout).toMatch(/grep-tree\/src\/nested\.ts:1:token nested/);
+    expect(stdout).not.toContain('notes.md');
+    expect(stdout).not.toContain('skip.test.ts');
+    expect(stdout).not.toContain('/vendor/');
+    expect(stdout).not.toContain('/generated/');
+  });
+
+  it('grep exclusions apply to explicit file and directory operands', async () => {
+    const file = await run(
+      "grep -n --exclude='grep-tree/*.txt' token grep-tree/explicit.txt",
+    );
+    expect(file.exitCode).toBe(1);
+    expect(file.stdout).toBe('');
+    expect(file.stderr).toBe('');
+
+    const directory = await run(
+      "grep -rn --exclude-dir='grep-tree/vendor/' token grep-tree/vendor",
+    );
+    expect(directory.exitCode).toBe(1);
+    expect(directory.stdout).toBe('');
+    expect(directory.stderr).toBe('');
+  });
+
+  it('grep uses the last matching include or exclude rule', async () => {
+    const included = await run(
+      "grep -n --exclude='*.txt' --include=explicit.txt token grep-tree/explicit.txt",
+    );
+    expect(included.exitCode).toBe(0);
+    expect(included.stdout).toContain('token explicit');
+
+    const excluded = await run(
+      "grep -n --include='*.txt' --exclude=explicit.txt token grep-tree/explicit.txt",
+    );
+    expect(excluded.exitCode).toBe(1);
+    expect(excluded.stdout).toBe('');
   });
 
   it('pipeline: cat | grep | sort', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -495,6 +495,17 @@ describe('translator', () => {
     expect(plan.script).toMatch(/__fx_s\d+ \| __fx_s\d+ \| __fx_s\d+/);
   });
 
+  it.each([
+    ['false | true', 0],
+    ['true | false', 1],
+  ])('isolates stage exit flags for %s (failing stage %i)', (command, failingStage) => {
+    const plan = translateCommandList(parse(command))[0];
+    const statusName = plan.body.match(/\$(fx_pipe_status\d+) = @\(0, 0\)/)?.[1];
+    expect(statusName).toBeDefined();
+    expect(plan.body).toContain(`$${statusName}[${failingStage}] = 1`);
+    expect(plan.body).toContain(`$script:fx_exit = [int]$${statusName}[1]`);
+  });
+
   it('scopes VAR=value prefixes and evaluates values before applying them', () => {
     const leak = translateCommandList(parse('FOO=bar echo x'))[0].script;
     expect(leak).toContain('try {');

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -484,6 +484,38 @@ describe('translator', () => {
     expect(echo).not.toContain('function fx-arith');
   });
 
+  it('keeps grep short flag bundles separate from long-option values', () => {
+    const body = translateCommandList(parse('grep -rn TODO src'))[0].body;
+    expect(body).toContain("$fx_pat = 'TODO'");
+    expect(body).toContain('$fx_fsel = @()');
+    expect(body).toContain("foreach ($fx_o in (@('src')))");
+    expect(body).toContain('$fx_recd = $true');
+  });
+
+  it('preserves repeated grep file filters in command-line order', () => {
+    const body = translateCommandList(
+      parse(
+        "grep -r --include='*.ts' --exclude '*.test.ts' --include=*.tsx --exclude='*.snap' --exclude-dir node_modules --exclude-dir=dist token src",
+      ),
+    )[0].body;
+    const includeTs = body.indexOf("Keep = $true; Glob = '*.ts'");
+    const excludeTest = body.indexOf("Keep = $false; Glob = '*.test.ts'");
+    const includeTsx = body.indexOf("Keep = $true; Glob = '*.tsx'");
+    const excludeSnap = body.indexOf("Keep = $false; Glob = '*.snap'");
+    expect(includeTs).toBeGreaterThan(-1);
+    expect(excludeTest).toBeGreaterThan(includeTs);
+    expect(includeTsx).toBeGreaterThan(excludeTest);
+    expect(excludeSnap).toBeGreaterThan(includeTsx);
+    expect(body).toContain("$fx_excd = @('node_modules', 'dist')");
+    expect(body).toContain("foreach ($fx_o in (@('src')))");
+  });
+
+  it('reports a missing grep file-filter value', () => {
+    const body = translateCommandList(parse('grep token file --exclude-dir'))[0].body;
+    expect(body).toContain("grep: option ''--exclude-dir'' requires an argument");
+    expect(body).toContain('$script:fx_exit = 2');
+  });
+
   it('feeds stdin for < redirects', () => {
     const plan = translateCommandList(parse('wc -l < f.txt'))[0];
     expect(plan.script).toContain('fx-readlines $env:FAUXNIX_STDIN_FILE |');


### PR DESCRIPTION
Integration of the six bounded fixes from the post-v0.7 audit (#131, by @vulragrag-star).

**Maintainer verification on the integrated tree** (all six confirmed fixed):
- `grep -r` filters: include/exclude/exclude-dir work; short bundles no longer misparsed (#123) — one residual cosmetic note: recursive grep prints absolute paths where GNU prints `./relative`, flagged for a follow-up
- Pipeline status from the final stage: `cat missing | wc -l; echo $?` → rc=0 (#124)
- `find -maxdepth 1` → exactly depth-1 entries; GNU argument validation (#125)
- `npm run test:package`: clean-source install + packed-tarball smoke both pass (#126)
- One deadline per request: `sleep 5; echo after` @2s budget → rc=124, no later segments, 2.3s wall (#127)
- PATHEXT restoration reviewed: case-insensitive, caller's explicit value preserved, win32-gated (#128)

**Reproduced and confirmed as still-open** (correctly out of this batch's scope, tracked for #129/#130 architecture work): `cp -n`/`mv -n` overwrite, `touch -c` creates, `>/dev/null` inert on stdout, trailing `&&` and `;;` accepted, native stderr dropped.

Full suite **156/156** (139 + 17 new tests from the six PRs).

Closes #123, closes #124, closes #125, closes #126, closes #127, closes #128.