### PR TITLE
test: widen deadline-test margins for cold CI runners

### DIFF
--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1039,9 +1039,11 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
       await extra.prewarm();
       const r = await extra.run(
         translateCommandList(
-          parseCommand('sleep 0.8; echo before-deadline; sleep 0.8; echo after-deadline'),
+          parseCommand('sleep 1; echo before-deadline; sleep 5; echo after-deadline'),
         ),
-        { timeoutMs: 1200 },
+        // wide margins for cold CI runners: segment 1 must finish inside the
+        // budget even with ~2s host overhead, segment 3 must blow it by a lot
+        { timeoutMs: 3500 },
       );
       expect(r.exitCode).toBe(124);
       expect(r.stderr).toMatch(/timed out/);


### PR DESCRIPTION
The one-deadline test from #127 went red on main post-merge (passed on the PR run): 1200ms budget assumed segment 1 (sleep 0.8 + host round-trip) fits — locally yes, on a cold windows runner the first frame can take ~2s and the whole request times out before any output. Mechanism verified correct (rc=124, later segments suppressed); this widens the margins (sleep 1 / budget 3500 / sleep 5) so the test still proves the deadline but tolerates ~2.5s of cold-start slack. Same class as the #97 hookTimeout flake.