### PR TITLE
fix: fail loud on trailing &&, ;;, and env -i

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
 - `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`,
+  `env -i`/`--ignore-environment`,
   and background `&` are rejected with actionable error messages instead of misbehaving.
   (`if/then/elif/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
   dotenv-style `source`, and word-level `$((...))` arithmetic expansion are supported.)

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -250,8 +250,13 @@ const env: Handler = (args, ctx) => {
       break;
     }
     if (t === '-i' || t === '--ignore-environment') {
-      i++; // best-effort: the flag is accepted and ignored
-      continue;
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr(
+          'fauxnix: env -i/--ignore-environment is not supported (would silently keep inherited secrets)',
+        ) +
+        '); $script:fx_exit = 2'
+      );
     }
     if (t === '-u' || t === '--unset') {
       if (i + 1 < raw.length) unsets.push(raw[i + 1]);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -39,7 +39,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, while/until/case, background jobs. if/then/elif/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
+Not supported: heredocs, while/until/case, env -i/--ignore-environment, background jobs. if/then/elif/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is started when the MCP session begins (and after reset), so the first bash tool call is already warm.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -622,24 +622,61 @@ export function parseCommand(input: string): CommandList {
   const peek = () => tokens[pos];
   const next = () => tokens[pos++];
 
+  const isListSep = (o?: string) => o === ';' || o === '\n';
+
+  /** Consume `;` / newline / `&&` / `||`. Trailing `&&`/`||` and `;;` fail loud (bash). */
+  const consumeListOp = (stops?: Set<string>): ';' | '&&' | '||' | null => {
+    const t = peek();
+    if (t.type !== 'OP') return null;
+    if (!(t.op === '&&' || t.op === '||' || isListSep(t.op))) return null;
+    if (t.op === ';') {
+      next();
+      if (peek().type === 'OP' && peek().op === ';') {
+        throw new FauxnixParseError("fauxnix: syntax error near unexpected token `;;'");
+      }
+      return ';';
+    }
+    if (t.op === '\n') {
+      next();
+      while (peek().type === 'OP' && peek().op === '\n') next();
+      return ';';
+    }
+    const sep = t.op as '&&' | '||';
+    next();
+    while (peek().type === 'OP' && peek().op === '\n') next();
+    const n = peek();
+    const kw = peekKw();
+    if (n.type === 'OP' && n.op === ';') {
+      throw new FauxnixParseError("fauxnix: syntax error near unexpected token `" + sep + "'");
+    }
+    if (n.type === 'EOF' || (stops && kw && stops.has(kw))) {
+      throw new FauxnixParseError(
+        n.type === 'EOF'
+          ? 'fauxnix: syntax error: unexpected end of file after `' + sep + "'"
+          : "fauxnix: syntax error near unexpected token `" + sep + "'",
+      );
+    }
+    return sep;
+  };
+
   const parseList = (): CommandList => {
     const segments: ListSegment[] = [];
     let op: ';' | '&&' | '||' = ';';
-    const isListSep = (o?: string) => o === ';' || o === '\n';
-    while (peek().type === 'OP' && isListSep(peek().op)) next();
+    while (peek().type === 'OP' && isListSep(peek().op)) {
+      if (peek().op === ';' && tokens[pos + 1]?.type === 'OP' && tokens[pos + 1]?.op === ';') {
+        throw new FauxnixParseError("fauxnix: syntax error near unexpected token `;;'");
+      }
+      next();
+    }
     while (peek().type !== 'EOF') {
       const pipeline = parsePipeline();
       segments.push({ pipeline, op });
-      const t = peek();
-      if (t.type === 'OP' && (t.op === '&&' || t.op === '||' || isListSep(t.op))) {
-        op = t.op === '\n' ? ';' : (t.op as '&&' | '||' | ';');
-        next();
-        while (peek().type === 'OP' && isListSep(peek().op)) next();
-      } else if (t.type === 'EOF') {
-        break;
-      } else {
+      const nextOp = consumeListOp();
+      if (nextOp === null) {
+        if (peek().type === 'EOF') break;
         throw new FauxnixParseError('fauxnix: unexpected token after pipeline');
       }
+      op = nextOp;
     }
     if (segments.length === 0) throw new FauxnixParseError('fauxnix: empty command');
     return { kind: 'CommandList', segments };
@@ -705,21 +742,20 @@ export function parseCommand(input: string): CommandList {
     const stop = new Set(stops);
     const segments: ListSegment[] = [];
     let op: ';' | '&&' | '||' = ';';
-    const isListSep = (o?: string) => o === ';' || o === '\n';
-    while (peek().type === 'OP' && isListSep(peek().op)) next();
+    while (peek().type === 'OP' && isListSep(peek().op)) {
+      if (peek().op === ';' && tokens[pos + 1]?.type === 'OP' && tokens[pos + 1]?.op === ';') {
+        throw new FauxnixParseError("fauxnix: syntax error near unexpected token `;;'");
+      }
+      next();
+    }
     while (peek().type !== 'EOF') {
       const kw = peekKw();
       if (kw && stop.has(kw)) break;
       const pipeline = parsePipeline();
       segments.push({ pipeline, op });
-      const t = peek();
-      if (t.type === 'OP' && (t.op === '&&' || t.op === '||' || isListSep(t.op))) {
-        op = t.op === '\n' ? ';' : (t.op as '&&' | '||' | ';');
-        next();
-        while (peek().type === 'OP' && isListSep(peek().op)) next();
-      } else {
-        break;
-      }
+      const nextOp = consumeListOp(stop);
+      if (nextOp === null) break;
+      op = nextOp;
     }
     if (segments.length === 0) {
       throw new FauxnixParseError('fauxnix: empty command');

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -877,6 +877,13 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('set --')).exitCode).toBe(0);
   });
 
+  it('env -i fails loudly instead of keeping inherited secrets', async () => {
+    const r = await run('env -i echo hi');
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/env -i\/--ignore-environment is not supported/);
+    expect(r.stdout.trim()).toBe('');
+  });
+
   it('${name:-word} and ${name:+word} follow bash empty/unset rules', async () => {
     expect((await run('unset X; echo ${X:-def}')).stdout.trim()).toBe('def');
     expect((await run('X=; echo ${X:-def}; unset X')).stdout.trim()).toBe('def');

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -178,6 +178,27 @@ describe('parser', () => {
     expect(() => parse('cat <<EOF')).toThrow(/heredoc/);
   });
 
+  it('rejects trailing && / || instead of dropping them', () => {
+    expect(() => parse('echo BEFORE &&')).toThrow(/unexpected end of file after `&&'/);
+    expect(() => parse('echo BEFORE ||')).toThrow(/unexpected end of file after `\\|\\|'/);
+    expect(() => parse('echo a &&\n')).toThrow(/unexpected end of file after `&&'/);
+    expect(() => parse('if true &&; then echo x; fi')).toThrow(/unexpected token `&&'/);
+    expect(parse('echo a && echo b').segments).toHaveLength(2);
+  });
+
+  it('rejects ;; instead of treating it as extra semicolons', () => {
+    expect(() => parse('echo A;; echo B')).toThrow(/unexpected token `;;'/);
+    expect(() => parse('echo A; ; echo B')).toThrow(/unexpected token `;;'/);
+    expect(parse('echo A; echo B').segments).toHaveLength(2);
+  });
+
+  it('env -i is a loud usage error, not a silent ignore', () => {
+    const script = translateCommandList(parse('env -i echo hi'))[0].script;
+    expect(script).toMatch(/env -i\/--ignore-environment is not supported/);
+    expect(script).toContain('$script:fx_exit = 2');
+    expect(script).not.toContain("fx-write");
+  });
+
   it('parses word-level $((...)) as Arith, not $( (expr) )', () => {
     const cmd = parse('echo $((1+1))').segments[0].pipeline.commands[0];
     expect(cmd.kind).toBe('SimpleCommand');


### PR DESCRIPTION
## Why

#131's remaining fail-loud syntax items, which you split out as a wave that can land **before** the v0.8 architecture work (#129/#130):

- `echo BEFORE &&` ran and exited 0 (bash: unexpected EOF)
- `echo A;; echo B` ran both sides (bash: unexpected `;;`)
- `env -i` / `--ignore-environment` was accepted and ignored, so inherited secrets stayed visible

## What

- Parser: trailing `&&` / `||` (including `&&;` / `&& then`) and `;;` are syntax errors. Valid `a && b` and `a; b` unchanged. `[[ a && b ]]` still uses inner `&&`, not list operators.
- `env -i` / `--ignore-environment` now writes a usage error and sets `$script:fx_exit = 2` (same honesty as `set -e`). Does not run the following command.
- README + MCP tool description mention `env -i`.

## Tests

- Unit: trailing `&&`/`||`, `;;`, `if true &&; then`, `env -i echo hi` (87 passed).
- Integration: `env -i echo hi` → exit 2, empty stdout; if/for still green.
- `npm run typecheck` clean.

One commit on current main (v0.7.1). Not merging.
