### PR TITLE
feat: CommandSpec and fail-loud flags for cp/mv/rm/touch/tee

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ development:
 - **text filters**: `grep egrep sed awk sort uniq cut tr` — sed/awk scripts are parsed at
   translate time (unsupported constructs throw named errors, never silently misbehave)
 - **text I/O**: `echo printf cat head tail wc tee nl tac md5sum sha1sum sha256sum base64 seq yes xargs`
+
+`cp` / `mv` / `rm` / `touch` / `tee` carry a `CommandSpec`: unknown options fail with a GNU-style
+usage error instead of being ignored. `cp -n` / `mv -n` / `touch -c` / `tee --append` match GNU
+(no clobber / no-create / append). `fauxnix list --json` dumps the same capability metadata.
 - **shell/system**: `cd pwd export unset env printenv ps kill pkill pgrep sleep which type whoami
   id groups date uname hostname uptime free nproc clear true false test [ [[ : pushd popd dirs sudo
   timeout man history less more source . eval exit alias set`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { FauxnixSession } from './executor.js';
 import { parseCommand } from './parser.js';
 import { translateCommandList } from './translator.js';
-import { registeredNames } from './registry.js';
+import { listCommandsJson, registeredNames } from './registry.js';
 import { encodeCommand } from './encoding.js';
 import { startMcpServer } from './mcp.js';
 import { packageVersion } from './version.js';
@@ -16,6 +16,7 @@ Usage:
   fauxnix translate "cmd"            show the PowerShell translation only
   fauxnix mcp                        start the MCP stdio server (for agent harnesses)
   fauxnix list                       list translated commands
+  fauxnix list --json                same list as machine-readable capability metadata
   fauxnix check                      verify the local PowerShell environment
   fauxnix --version
 
@@ -36,6 +37,10 @@ export async function runCli(argv: string[]): Promise<void> {
   }
 
   if (verb === 'list') {
+    if (rest[0] === '--json') {
+      console.log(JSON.stringify(listCommandsJson(), null, 2));
+      return;
+    }
     const names = registeredNames();
     console.log(names.length + ' translated commands:');
     for (const n of names) console.log('  ' + n);

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,5 +1,12 @@
 import { Word, wordToString } from '../ast.js';
-import { Handler, parseWords, psStr } from '../registry.js';
+import {
+  CommandSpec,
+  Handler,
+  OptionSpec,
+  OptionSupport,
+  parseWords,
+  psStr,
+} from '../registry.js';
 import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
@@ -135,6 +142,7 @@ const cp: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args);
   const recurse = flags.has('r') || flags.has('R') || longs.has('--recursive');
   const verbose = flags.has('v') || longs.has('--verbose');
+  const noclobber = flags.has('n') || longs.has('--no-clobber');
   return [
     PS_GLOB_FN,
     '$fx_all = ' + argListExpr(operandWords),
@@ -149,6 +157,7 @@ const cp: Handler = (args) => {
     '      if ($fx_isdir -and ' + (recurse ? '$false' : '$true') + ') { [Console]::Error.WriteLine("cp: -r not specified; omitting directory \'" + $fx_g + "\'"); $script:fx_exit = 1; continue }',
     '      $fx_target = $fx_dst',
     '      if (Test-Path -LiteralPath $fx_dst -PathType Container) { $fx_target = Join-Path $fx_dst (Split-Path $fx_g -Leaf) }',
+    '      if (' + (noclobber ? '$true' : '$false') + ' -and (Test-Path -LiteralPath $fx_target)) { continue }',
     '      try {',
     '        Copy-Item -LiteralPath $fx_g -Destination $fx_target -Recurse:' + (recurse ? '$true' : '$false') + ' -Force',
     '        if (' + (verbose ? '$true' : '$false') + ') { [Console]::Error.WriteLine("\'" + $fx_g + "\' -> \'" + $fx_target + "\'") }',
@@ -162,6 +171,7 @@ const cp: Handler = (args) => {
 const mv: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args);
   const verbose = flags.has('v') || longs.has('--verbose');
+  const noclobber = flags.has('n') || longs.has('--no-clobber');
   return [
     PS_GLOB_FN,
     '$fx_all = ' + argListExpr(operandWords),
@@ -175,6 +185,7 @@ const mv: Handler = (args) => {
     '      if (-not (Test-Path -LiteralPath $fx_g)) { [Console]::Error.WriteLine("mv: cannot stat \'" + $fx_g + "\': No such file or directory"); $script:fx_exit = 1; continue }',
     '      $fx_target = $fx_dst',
     '      if (Test-Path -LiteralPath $fx_dst -PathType Container) { $fx_target = Join-Path $fx_dst (Split-Path $fx_g -Leaf) }',
+    '      if (' + (noclobber ? '$true' : '$false') + ' -and (Test-Path -LiteralPath $fx_target)) { continue }',
     '      try {',
     '        if (Test-Path -LiteralPath $fx_target) { Remove-Item -LiteralPath $fx_target -Recurse -Force }',
     '        Move-Item -LiteralPath $fx_g -Destination $fx_target -Force',
@@ -190,7 +201,7 @@ const rm: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args);
   const recurse = flags.has('r') || flags.has('R') || longs.has('--recursive');
   const force = flags.has('f') || longs.has('--force');
-  const verbose = flags.has('v');
+  const verbose = flags.has('v') || longs.has('--verbose');
   return [
     PS_GLOB_FN,
     '$fx_files = ' + psArray(operandWords),
@@ -250,7 +261,8 @@ const rmdir: Handler = (args) => {
 };
 
 const touch: Handler = (args) => {
-  const { operandWords } = parseWords(args);
+  const { flags, longs, operandWords } = parseWords(args);
+  const noCreate = flags.has('c') || longs.has('--no-create');
   return [
     '$fx_files = ' + psArray(operandWords),
     "if ($fx_files.Count -eq 0) { [Console]::Error.WriteLine('touch: missing file operand'); $script:fx_exit = 1 }",
@@ -258,6 +270,7 @@ const touch: Handler = (args) => {
     '  if (Test-Path -LiteralPath $fx_f) {',
     '    try { (Get-Item -LiteralPath $fx_f).LastWriteTime = Get-Date } catch { [Console]::Error.WriteLine("touch: cannot touch \'" + $fx_f + "\': Permission denied"); $script:fx_exit = 1 }',
     '  } else {',
+    '    if (' + (noCreate ? '$true' : '$false') + ') { continue }',
     '    try { New-Item -ItemType File -Path $fx_f | Out-Null }',
     '    catch { [Console]::Error.WriteLine("touch: cannot touch \'" + $fx_f + "\': No such file or directory"); $script:fx_exit = 1 }',
     '  }',
@@ -740,15 +753,88 @@ const diff: Handler = (args) => {
   ].join('\n');
 };
 
+function opt(
+  short: string | undefined,
+  long: string | undefined,
+  support: OptionSupport = 'implemented',
+  extra: Partial<OptionSpec> = {},
+): OptionSpec {
+  const o: OptionSpec = { support };
+  if (short) o.short = short;
+  if (long) o.long = long;
+  return extra.takesValue || extra.reason ? { ...o, ...extra } : o;
+}
+
+function fileSpec(
+  names: string[],
+  effects: CommandSpec['effects'],
+  options: OptionSpec[],
+  handler: Handler,
+): CommandSpec {
+  return {
+    names,
+    options,
+    effects,
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler,
+  };
+}
+
+const INTERACTIVE: Partial<OptionSpec> = { reason: 'interactive prompt' };
+
+/** Destructive file commands migrated first (#130). Unspec'd handlers stay unchecked.
+ *  cp/mv `-f`/`--force` is always-on overwrite (Copy-Item/Move-Item -Force); listed so `cp -rf` stays valid. */
+export const specs: CommandSpec[] = [
+  fileSpec(
+    ['cp'],
+    ['read', 'write'],
+    [
+      opt('r', undefined),
+      opt('R', '--recursive'),
+      opt('v', '--verbose'),
+      opt('n', '--no-clobber'),
+      opt('f', '--force'),
+      opt('i', '--interactive', 'unsupported', INTERACTIVE),
+    ],
+    cp,
+  ),
+  fileSpec(
+    ['mv'],
+    ['read', 'write', 'delete'],
+    [
+      opt('v', '--verbose'),
+      opt('n', '--no-clobber'),
+      opt('f', '--force'),
+      opt('i', '--interactive', 'unsupported', INTERACTIVE),
+    ],
+    mv,
+  ),
+  fileSpec(
+    ['rm'],
+    ['delete'],
+    [
+      opt('r', undefined),
+      opt('R', '--recursive'),
+      opt('f', '--force'),
+      opt('v', '--verbose'),
+      opt('i', '--interactive', 'unsupported', INTERACTIVE),
+    ],
+    rm,
+  ),
+  fileSpec(
+    ['touch'],
+    ['write'],
+    [opt('c', '--no-create')],
+    touch,
+  ),
+];
+
 export const handlers: Record<string, Handler> = {
   ls,
   ll: ls, // common alias
-  cp,
-  mv,
-  rm,
   mkdir,
   rmdir,
-  touch,
   mktemp,
   ln,
   readlink,

--- a/src/commands/install-all.ts
+++ b/src/commands/install-all.ts
@@ -1,7 +1,7 @@
-import { registerAll } from '../registry.js';
-import { handlers as files } from './files.js';
+import { registerAll, registerSpecs } from '../registry.js';
+import { handlers as files, specs as fileSpecs } from './files.js';
 import { handlers as textFilters } from './text-filters.js';
-import { handlers as textIo } from './text-io.js';
+import { handlers as textIo, specs as textIoSpecs } from './text-io.js';
 import { handlers as sysinfo } from './sysinfo.js';
 import { handlers as net } from './net.js';
 import { handlers as archive } from './archive.js';
@@ -14,6 +14,8 @@ export function installAll(): void {
   registerAll(sysinfo);
   registerAll(net);
   registerAll(archive);
+  registerSpecs(fileSpecs);
+  registerSpecs(textIoSpecs);
 }
 
 installAll();

--- a/src/commands/text-io.ts
+++ b/src/commands/text-io.ts
@@ -1,5 +1,5 @@
 import { Word, wordToString } from '../ast.js';
-import { Handler, lookup, parseWords, psStr } from '../registry.js';
+import { CommandSpec, Handler, lookup, parseWords, psStr } from '../registry.js';
 import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
@@ -806,8 +806,8 @@ const wc: Handler = (args) => {
 /* ------------------------------------------------------------------ */
 
 const tee: Handler = (args, ctx) => {
-  const { flags, operandWords } = parseWords(args);
-  const append = flags.has('a') || flags.has('append');
+  const { flags, longs, operandWords } = parseWords(args);
+  const append = flags.has('a') || longs.has('--append');
   return [
     PS_WRITE_FN,
     fxTermLine(ctx.position),
@@ -1302,6 +1302,19 @@ const xargs: Handler = (args) => {
 
 /* ------------------------------------------------------------------ */
 
+export const specs: CommandSpec[] = [
+  {
+    names: ['tee'],
+    options: [
+      { short: 'a', long: '--append', support: 'implemented' },
+    ],
+    effects: ['read', 'write'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: tee,
+  },
+];
+
 export const handlers: Record<string, Handler> = {
   echo,
   printf,
@@ -1309,7 +1322,6 @@ export const handlers: Record<string, Handler> = {
   head,
   tail,
   wc,
-  tee,
   nl,
   tac,
   md5sum,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -218,3 +218,191 @@ export function parseWords(
   }
   return { flags, longs, values, missingValue, operandWords };
 }
+
+/* ------------------------------------------------------------------ */
+/* Typed command capabilities (#130)                                   */
+/* ------------------------------------------------------------------ */
+
+export type CommandEffect = 'read' | 'write' | 'delete' | 'network' | 'process';
+
+export type OptionSupport = 'implemented' | 'unsupported';
+
+/** One short/long alias group. Unknown options on a spec'd command fail loud. */
+export interface OptionSpec {
+  /** Short flag letter without dash (e.g. `'n'`). */
+  short?: string;
+  /** Long option including dashes (e.g. `'--no-clobber'`). */
+  long?: string;
+  /** Consumes a following argument (`-n 5`, `--lines=5`). */
+  takesValue?: boolean;
+  support: OptionSupport;
+  /** Extra phrase for unsupported options (`interactive prompt`). */
+  reason?: string;
+}
+
+export interface CommandSpec {
+  names: string[];
+  options: OptionSpec[];
+  effects: CommandEffect[];
+  platform?: 'windows-ps51' | 'portable-translate';
+  dispatch?: 'translated' | 'native' | 'dynamic';
+  handler: Handler;
+}
+
+const specs = new Map<string, CommandSpec>();
+
+/** Register a spec'd command. Unknown/unsupported options become GNU-style usage errors. */
+export function registerSpec(spec: CommandSpec): void {
+  for (const name of spec.names) {
+    const wrapped: Handler = (args, ctx) => {
+      const err = specOptionError(spec, args, name);
+      if (err) return err;
+      return spec.handler(args, ctx);
+    };
+    registry.set(name, wrapped);
+    specs.set(name, spec);
+  }
+}
+
+export function registerSpecs(list: CommandSpec[]): void {
+  for (const spec of list) registerSpec(spec);
+}
+
+export function lookupSpec(name: string): CommandSpec | undefined {
+  return specs.get(name);
+}
+
+/** Unique specs in registration order. */
+export function registeredSpecs(): CommandSpec[] {
+  const seen = new Set<CommandSpec>();
+  const out: CommandSpec[] = [];
+  for (const spec of specs.values()) {
+    if (seen.has(spec)) continue;
+    seen.add(spec);
+    out.push(spec);
+  }
+  return out;
+}
+
+export interface ListedCommand {
+  name: string;
+  spec: null | {
+    options: Array<{
+      short?: string;
+      long?: string;
+      takesValue: boolean;
+      support: OptionSupport;
+      reason?: string;
+    }>;
+    effects: CommandEffect[];
+    platform: 'windows-ps51' | 'portable-translate';
+    dispatch: 'translated' | 'native' | 'dynamic';
+  };
+}
+
+/** Capability dump for `fauxnix list --json` / MCP introspection. */
+export function listCommandsJson(): ListedCommand[] {
+  return registeredNames().map((name) => {
+    const spec = lookupSpec(name);
+    if (!spec) return { name, spec: null };
+    return {
+      name,
+      spec: {
+        options: spec.options.map((o) => ({
+          ...(o.short ? { short: o.short } : {}),
+          ...(o.long ? { long: o.long } : {}),
+          takesValue: o.takesValue === true,
+          support: o.support,
+          ...(o.reason ? { reason: o.reason } : {}),
+        })),
+        effects: spec.effects,
+        platform: spec.platform ?? 'windows-ps51',
+        dispatch: spec.dispatch ?? 'translated',
+      },
+    };
+  });
+}
+
+/**
+ * Walk argv against a CommandSpec. Returns a PowerShell error script, or
+ * null when every option is recognized and implemented.
+ */
+export function specOptionError(spec: CommandSpec, args: Word[], cmdName: string): string | null {
+  const shorts = new Map<string, OptionSpec>();
+  const longs = new Map<string, OptionSpec>();
+  for (const o of spec.options) {
+    if (o.short) shorts.set(o.short, o);
+    if (o.long) longs.set(o.long, o);
+  }
+
+  let i = 0;
+  let onlyOperands = false;
+  while (i < args.length) {
+    const t = wordToString(args[i]);
+    if (onlyOperands) {
+      i++;
+      continue;
+    }
+    if (t === '--') {
+      onlyOperands = true;
+      i++;
+      continue;
+    }
+    if (t.startsWith('--')) {
+      const eq = t.indexOf('=');
+      const name = eq >= 0 ? t.slice(0, eq) : t;
+      const opt = longs.get(name);
+      if (!opt) return optionFail(cmdName, "unrecognized option '" + name + "'");
+      if (opt.support === 'unsupported') {
+        return optionFail(cmdName, unsupportedMsg(opt, name));
+      }
+      if (!opt.takesValue && eq >= 0) {
+        return optionFail(cmdName, "option '" + name + "' doesn't allow an argument");
+      }
+      if (opt.takesValue && eq < 0) {
+        if (i + 1 < args.length) i++;
+        else return optionFail(cmdName, "option '" + name + "' requires an argument");
+      }
+      i++;
+      continue;
+    }
+    if (t.startsWith('-') && t.length > 1 && !/^-?\d/.test(t.slice(1, 2))) {
+      const body = t.slice(1);
+      for (let c = 0; c < body.length; c++) {
+        const ch = body[c];
+        const opt = shorts.get(ch);
+        if (!opt) return optionFail(cmdName, "invalid option -- '" + ch + "'");
+        if (opt.support === 'unsupported') {
+          return optionFail(cmdName, unsupportedMsg(opt, '-' + ch));
+        }
+        if (opt.takesValue) {
+          const rest = body.slice(c + 1);
+          if (!rest) {
+            if (i + 1 < args.length) i++;
+            else return optionFail(cmdName, "option requires an argument -- '" + ch + "'");
+          }
+          break;
+        }
+      }
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return null;
+}
+
+function unsupportedMsg(opt: OptionSpec, shown: string): string {
+  const reason = opt.reason ? ' (' + opt.reason + ')' : '';
+  return "option '" + shown + "' is not supported by fauxnix" + reason;
+}
+
+function optionFail(cmd: string, msg: string): string {
+  return (
+    '[Console]::Error.WriteLine(' +
+    psStr(cmd + ': ' + msg) +
+    '); [Console]::Error.WriteLine(' +
+    psStr("Try '" + cmd + " --help' for more information.") +
+    '); $script:fx_exit = 1'
+  );
+}

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1106,4 +1106,55 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
       await extra.dispose();
     }
   }, 30000);
+
+  it('cp -n does not overwrite an existing dest', async () => {
+    writeFileSync(join(dir, 'cp-n-src.txt'), 'SRC\n', 'utf8');
+    writeFileSync(join(dir, 'cp-n-dst.txt'), 'DST\n', 'utf8');
+    const r = await run('cp -n cp-n-src.txt cp-n-dst.txt');
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(join(dir, 'cp-n-dst.txt'), 'utf8')).toBe('DST\n');
+  });
+
+  it('cp without -n overwrites dest', async () => {
+    writeFileSync(join(dir, 'cp-ow-src.txt'), 'SRC\n', 'utf8');
+    writeFileSync(join(dir, 'cp-ow-dst.txt'), 'DST\n', 'utf8');
+    const r = await run('cp cp-ow-src.txt cp-ow-dst.txt');
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(join(dir, 'cp-ow-dst.txt'), 'utf8')).toBe('SRC\n');
+  });
+
+  it('mv -n leaves both files when dest exists', async () => {
+    writeFileSync(join(dir, 'mv-n-src.txt'), 'SRC\n', 'utf8');
+    writeFileSync(join(dir, 'mv-n-dst.txt'), 'DST\n', 'utf8');
+    const r = await run('mv -n mv-n-src.txt mv-n-dst.txt');
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(join(dir, 'mv-n-src.txt'))).toBe(true);
+    expect(readFileSync(join(dir, 'mv-n-dst.txt'), 'utf8')).toBe('DST\n');
+  });
+
+  it('touch -c does not create a missing file; plain touch does', async () => {
+    expect(existsSync(join(dir, 'touch-c-missing.txt'))).toBe(false);
+    const skipped = await run('touch -c touch-c-missing.txt');
+    expect(skipped.exitCode).toBe(0);
+    expect(existsSync(join(dir, 'touch-c-missing.txt'))).toBe(false);
+    const created = await run('touch touch-create.txt');
+    expect(created.exitCode).toBe(0);
+    expect(existsSync(join(dir, 'touch-create.txt'))).toBe(true);
+  });
+
+  it('tee --append appends instead of truncating', async () => {
+    writeFileSync(join(dir, 'tee-app.txt'), 'A', 'utf8');
+    const r = await run('printf B | tee --append tee-app.txt');
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(join(dir, 'tee-app.txt'), 'utf8')).toBe('AB');
+  });
+
+  it('cp unknown option fails before copying', async () => {
+    writeFileSync(join(dir, 'cp-z-src.txt'), 'SRC\n', 'utf8');
+    writeFileSync(join(dir, 'cp-z-dst.txt'), 'DST\n', 'utf8');
+    const r = await run('cp -z cp-z-src.txt cp-z-dst.txt');
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("invalid option -- 'z'");
+    expect(readFileSync(join(dir, 'cp-z-dst.txt'), 'utf8')).toBe('DST\n');
+  });
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -11,7 +11,7 @@ import {
   wrapScript,
   hostBootstrapScript,
 } from '../src/translator.js';
-import { lookup, parseWords, psStr } from '../src/registry.js';
+import { listCommandsJson, lookup, lookupSpec, parseWords, psStr } from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import { normalizeStderr } from '../src/errors.js';
 import { decodeHostResponse, encodeHostRequest } from '../src/ps-host.js';
@@ -681,5 +681,72 @@ describe('tokenize', () => {
     const toks = tokenize('a > b 2> c');
     const ops = toks.filter((t) => t.type === 'OP').map((t) => t.op);
     expect(ops).toEqual(['>', '2>']);
+  });
+});
+
+describe('CommandSpec (#130)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+
+  it('cp -n / --no-clobber skip an existing dest instead of overwriting', () => {
+    expect(bodyOf('cp -n src dst')).toContain('$true -and (Test-Path -LiteralPath $fx_target)');
+    expect(bodyOf('cp --no-clobber src dst')).toContain(
+      '$true -and (Test-Path -LiteralPath $fx_target)',
+    );
+    expect(bodyOf('cp src dst')).toContain('$false -and (Test-Path -LiteralPath $fx_target)');
+  });
+
+  it('cp rejects unknown and unsupported options before Copy-Item', () => {
+    const z = bodyOf('cp -z a b');
+    expect(z).toContain("invalid option -- ''z''");
+    expect(z).toContain('$script:fx_exit = 1');
+    expect(z).not.toContain('Copy-Item');
+    expect(bodyOf('cp -i a b')).toContain("option ''-i'' is not supported by fauxnix");
+    expect(bodyOf('cp --preserve a b')).toContain("unrecognized option ''--preserve''");
+  });
+
+  it('mv -n skips an existing dest', () => {
+    expect(bodyOf('mv -n src dst')).toContain('$true -and (Test-Path -LiteralPath $fx_target)');
+    expect(bodyOf('mv src dst')).toContain('$false -and (Test-Path -LiteralPath $fx_target)');
+  });
+
+  it('touch -c does not create missing files', () => {
+    expect(bodyOf('touch -c missing')).toContain('if ($true) { continue }');
+    expect(bodyOf('touch --no-create missing')).toContain('if ($true) { continue }');
+    expect(bodyOf('touch missing')).toContain('if ($false) { continue }');
+    expect(bodyOf('touch missing')).toContain('New-Item -ItemType File');
+  });
+
+  it('tee --append and -a append; bare tee truncates', () => {
+    expect(bodyOf('tee --append out.txt')).toContain('if ($true)');
+    expect(bodyOf('tee -a out.txt')).toContain('if ($true)');
+    expect(bodyOf('tee out.txt')).toContain('if ($false)');
+  });
+
+  it('spec\'d rm fails loud on unknown flags; unspec\'d ls still ignores them', () => {
+    const rm = bodyOf('rm -z x');
+    expect(rm).toContain("invalid option -- ''z''");
+    expect(rm).not.toContain('Remove-Item');
+    const ls = bodyOf('ls -Z');
+    expect(ls).not.toContain('invalid option');
+    expect(ls).toContain('Get-ChildItem');
+  });
+
+  it('rm --verbose matches -v; tee -i is not silently ignored', () => {
+    expect(bodyOf('rm --verbose x')).toContain('if ($true)');
+    expect(bodyOf('rm x')).toContain('if ($false)');
+    expect(bodyOf('tee -i out.txt')).toContain("invalid option -- ''i''");
+  });
+
+  it('listCommandsJson exposes migrated specs and null for legacy handlers', () => {
+    const rows = listCommandsJson();
+    const cp = rows.find((r) => r.name === 'cp');
+    expect(cp?.spec?.effects).toEqual(['read', 'write']);
+    expect(cp?.spec?.options.some((o) => o.short === 'n' && o.support === 'implemented')).toBe(
+      true,
+    );
+    expect(rows.find((r) => r.name === 'ls')?.spec).toBeNull();
+    expect(lookupSpec('cp')).toBeTruthy();
+    expect(lookupSpec('ls')).toBeUndefined();
+    expect(lookup('tee')).toBeTypeOf('function');
   });
 });


### PR DESCRIPTION
## Why

#130: the registry is `name -> Handler` with no option validation, so unsupported flags are ignored while the command still mutates the filesystem. The post-v0.7 audit's destructive five starts here.

Maintainer: spec'd commands are strict; unspec'd keep today's behavior; migrate `cp`/`mv`/`rm`/`touch`/`tee`/`find` first.

## What

- `CommandSpec` + `registerSpec` wrap: unknown/unsupported options emit a GNU-style usage error (exit 1) at translate time. Unspec'd handlers are unchanged.
- `cp -n` / `--no-clobber` and `mv -n` skip an existing dest instead of `-Force` overwrite.
- `touch -c` / `--no-create` does not create missing files.
- `tee --append` actually appends (`-a` already did; `flags.has('append')` never saw the long option).
- `rm` is spec'd so unknown flags fail loud; `-r/-f/-v` behavior unchanged.
- `fauxnix list --json` dumps the same capability metadata.

`find !` / `-o` is the next #130 PR (wrong-set `-delete` needs a real predicate compiler, not a flag patch).

## Tests

- Unit: translate-time skip/fail-loud corpus, `list --json` shape, unspec'd `ls -Z` still ignored.
- Integration (real PS 5.1): filesystem before/after for `cp -n`, `cp` overwrite, `mv -n`, `touch -c`, `tee --append`, `cp -z`.
