### PR TITLE
feat: compile find ! / -o / -a instead of ignoring them

### DIFF
--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,4 +1,4 @@
-import { Word, wordToString } from '../ast.js';
+import { FauxnixParseError, Word, wordToString } from '../ast.js';
 import { Handler, parseWords, psStr } from '../registry.js';
 import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
@@ -501,13 +501,235 @@ const df: Handler = (args) => {
 /* find                                                                */
 /* ------------------------------------------------------------------ */
 
+type FindNode =
+  | { kind: 'true' }
+  | { kind: 'and'; left: FindNode; right: FindNode }
+  | { kind: 'or'; left: FindNode; right: FindNode }
+  | { kind: 'not'; inner: FindNode }
+  | { kind: 'name'; pat: string; ci: boolean }
+  | { kind: 'type'; t: 'f' | 'd' | 'l' }
+  | { kind: 'size'; ps: string }
+  | { kind: 'mtime'; ps: string }
+  | { kind: 'delete' }
+  | { kind: 'print' };
+
+interface FindPlan {
+  ast: FindNode;
+  maxDepth: string | null;
+  minDepth: string | null;
+  hasDelete: boolean;
+  hasPrint: boolean;
+  hasSize: boolean;
+}
+
+function findFail(msg: string): never {
+  throw new FauxnixParseError(msg);
+}
+
+function canStartFindFactor(t: string): boolean {
+  return (
+    t === '!' ||
+    t === '-not' ||
+    t === '(' ||
+    t === '-name' ||
+    t === '-iname' ||
+    t === '-type' ||
+    t === '-size' ||
+    t === '-mtime' ||
+    t === '-delete' ||
+    t === '-print' ||
+    t === '-maxdepth' ||
+    t === '-mindepth'
+  );
+}
+
+/** GNU find expression: `!` tightest, juxtaposition/`-a` next, `-o` loosest. */
+function parseFindPreds(preds: string[]): FindPlan {
+  const plan: FindPlan = {
+    ast: { kind: 'true' },
+    maxDepth: null,
+    minDepth: null,
+    hasDelete: false,
+    hasPrint: false,
+    hasSize: false,
+  };
+  let i = 0;
+  const peek = (): string | null => (i < preds.length ? preds[i] : null);
+  const take = (): string => preds[i++];
+  const needArg = (opt: string): string => {
+    if (i >= preds.length) findFail("find: missing argument to '" + opt + "'");
+    return take();
+  };
+
+  const parsePrimary = (): FindNode => {
+    const t = take();
+    if (t === '-name' || t === '-iname') {
+      return { kind: 'name', pat: needArg(t), ci: t === '-iname' };
+    }
+    if (t === '-type') {
+      const v = needArg(t);
+      if (v !== 'f' && v !== 'd' && v !== 'l') findFail('find: Unknown argument to -type: ' + v);
+      return { kind: 'type', t: v };
+    }
+    if (t === '-size') {
+      const v = needArg(t);
+      const ps = sizeOf(v);
+      if (!ps) findFail("find: Invalid argument '" + v + "' to -size");
+      plan.hasSize = true;
+      return { kind: 'size', ps };
+    }
+    if (t === '-mtime') {
+      const v = needArg(t);
+      const ps = mtimeOf(v);
+      if (!ps) findFail("find: Invalid argument '" + v + "' to -mtime");
+      return { kind: 'mtime', ps };
+    }
+    if (t === '-delete') {
+      plan.hasDelete = true;
+      return { kind: 'delete' };
+    }
+    if (t === '-print') {
+      plan.hasPrint = true;
+      return { kind: 'print' };
+    }
+    if (t === '-maxdepth' || t === '-mindepth') {
+      const v = needArg(t);
+      if (!/^\d+$/.test(v)) {
+        findFail(
+          'find: expected a non-negative decimal integer argument to ' +
+            t +
+            ", but got '" +
+            v +
+            "'",
+        );
+      }
+      if (t === '-maxdepth' && plan.maxDepth === null) plan.maxDepth = v;
+      if (t === '-mindepth' && plan.minDepth === null) plan.minDepth = v;
+      return { kind: 'true' };
+    }
+    if (t.startsWith('-')) findFail("find: unknown predicate '" + t + "'");
+    findFail("find: paths must precede expression: '" + t + "'");
+  };
+
+  const parseFactor = (): FindNode => {
+    const t = peek();
+    if (t === null) findFail('find: expected an expression');
+    if (t === '-o' || t === '-or' || t === '-a' || t === '-and') {
+      findFail(
+        "find: invalid expression; you have used a binary operator '" +
+          t +
+          "' with nothing before it.",
+      );
+    }
+    if (t === '!' || t === '-not') {
+      take();
+      if (peek() === null) findFail("find: expected an expression after '" + t + "'");
+      if (peek() === ')') findFail("find: expected an expression between '" + t + "' and ')'");
+      return { kind: 'not', inner: parseFactor() };
+    }
+    if (t === '(') {
+      take();
+      if (peek() === ')') findFail('find: invalid expression; empty parentheses are not allowed.');
+      if (peek() === null) {
+        findFail("find: invalid expression; expected to find a ')' but didn't see one.");
+      }
+      const inner = parseOr();
+      if (peek() !== ')') {
+        findFail("find: invalid expression; expected to find a ')' but didn't see one.");
+      }
+      take();
+      return inner;
+    }
+    if (t === ')') findFail("find: invalid expression; you have too many ')'");
+    return parsePrimary();
+  };
+
+  const parseAnd = (): FindNode => {
+    let left = parseFactor();
+    while (true) {
+      const t = peek();
+      if (t === null || t === ')' || t === '-o' || t === '-or') break;
+      if (t === '-a' || t === '-and') {
+        take();
+        if (peek() === null || peek() === ')') {
+          findFail("find: expected an expression after '" + t + "'");
+        }
+        left = { kind: 'and', left, right: parseFactor() };
+        continue;
+      }
+      if (canStartFindFactor(t)) {
+        left = { kind: 'and', left, right: parseFactor() };
+        continue;
+      }
+      findFail("find: paths must precede expression: '" + t + "'");
+    }
+    return left;
+  };
+
+  const parseOr = (): FindNode => {
+    let left = parseAnd();
+    while (peek() === '-o' || peek() === '-or') {
+      const op = take();
+      if (peek() === null || peek() === ')') {
+        findFail("find: expected an expression after '" + op + "'");
+      }
+      left = { kind: 'or', left, right: parseAnd() };
+    }
+    return left;
+  };
+
+  if (preds.length === 0) {
+    plan.ast = { kind: 'print' };
+    plan.hasPrint = true;
+    return plan;
+  }
+  plan.ast = parseOr();
+  if (i < preds.length) {
+    if (preds[i] === ')') findFail("find: invalid expression; you have too many ')'");
+    findFail("find: paths must precede expression: '" + preds[i] + "'");
+  }
+  if (!plan.hasDelete && !plan.hasPrint) {
+    plan.ast = { kind: 'and', left: plan.ast, right: { kind: 'print' } };
+    plan.hasPrint = true;
+  }
+  return plan;
+}
+
+function emitFind(n: FindNode): string {
+  switch (n.kind) {
+    case 'true':
+      return '$true';
+    case 'and':
+      return '(' + emitFind(n.left) + ' -and ' + emitFind(n.right) + ')';
+    case 'or':
+      return '(' + emitFind(n.left) + ' -or ' + emitFind(n.right) + ')';
+    case 'not':
+      return '(-not ' + emitFind(n.inner) + ')';
+    case 'name':
+      if (n.ci) return "($fx_i.Name.ToLower() -like '" + likeOf(n.pat).toLowerCase() + "')";
+      return "($fx_i.Name -clike '" + likeOf(n.pat) + "')";
+    case 'type':
+      if (n.t === 'f') return '(-not $fx_i.PSIsContainer)';
+      if (n.t === 'd') return '($fx_i.PSIsContainer)';
+      return '([bool]$fx_i.LinkType)';
+    case 'size':
+      return '(' + n.ps + ')';
+    case 'mtime':
+      return '(' + n.ps + ')';
+    case 'delete':
+      return '(fx-find-delete)';
+    case 'print':
+      return '(fx-find-print)';
+  }
+}
+
 const find: Handler = (args) => {
   const raw = args.map((w) => wordToString(w));
   let pathEnd = 0;
   while (
     pathEnd < raw.length &&
     !raw[pathEnd].startsWith('-') &&
-    !['(', ')', '!', '-a', '-o'].includes(raw[pathEnd])
+    !['(', ')', '!', '-a', '-o', '-not', '-and', '-or'].includes(raw[pathEnd])
   ) {
     pathEnd++;
   }
@@ -522,86 +744,42 @@ const find: Handler = (args) => {
     );
   }
 
-  const namePat = extractValue(preds, ['-name']);
-  const inamePat = extractValue(preds, ['-iname']);
-  const typeV = extractValue(preds, ['-type']);
-  const maxDepthS = extractValue(preds, ['-maxdepth']);
-  const minDepthS = extractValue(preds, ['-mindepth']);
-  const sizeExpr = extractValue(preds, ['-size']);
-  const mtimeExpr = extractValue(preds, ['-mtime']);
-  const wantDelete = preds.includes('-delete');
+  const plan = parseFindPreds(preds);
+  const expr = emitFind(plan.ast);
   const paths = pathWords.length ? argListExpr(pathWords) : "@('.')";
 
-  for (const option of ['-maxdepth', '-mindepth']) {
-    const optionIndex = preds.indexOf(option);
-    if (optionIndex < 0) continue;
-    if (optionIndex + 1 >= preds.length) {
-      return (
-        '[Console]::Error.WriteLine(' +
-        psStr(`find: missing argument to '${option}'`) +
-        '); $script:fx_exit = 1'
-      );
-    }
-    const value = preds[optionIndex + 1];
-    if (!/^\d+$/.test(value)) {
-      return (
-        '[Console]::Error.WriteLine(' +
-        psStr(
-          `find: expected a non-negative decimal integer argument to ${option}, but got '${value}'`,
-        ) +
-        '); $script:fx_exit = 1'
-      );
-    }
-  }
-
-  const conditions: string[] = [];
-  if (namePat !== null) conditions.push("($fx_i.Name -like '" + likeOf(namePat) + "')");
-  if (inamePat !== null)
-    conditions.push("($fx_i.Name.ToLower() -like '" + likeOf(inamePat).toLowerCase() + "')");
-  if (typeV === 'f') conditions.push('(-not $fx_i.PSIsContainer)');
-  if (typeV === 'd') conditions.push('($fx_i.PSIsContainer)');
-  if (typeV === 'l') conditions.push('([bool]$fx_i.LinkType)');
-  const cond = conditions.length ? conditions.join(' -and ') : '$true';
-
-  const sizeCond = sizeOf(sizeExpr);
-  const mtimeCond = mtimeOf(mtimeExpr);
-
   return [
+    plan.hasPrint
+      ? 'function fx-find-print { $script:fx_find_print = $true; $true }'
+      : '',
+    plan.hasDelete
+      ? 'function fx-find-delete { try { Remove-Item -LiteralPath $fx_i.FullName -Force -ErrorAction SilentlyContinue | Out-Null } catch {}; $true }'
+      : '',
     '$fx_paths = ' + paths,
     'foreach ($fx_p in $fx_paths) {',
     '  if (-not (Test-Path -LiteralPath $fx_p)) { [Console]::Error.WriteLine("find: \'" + $fx_p + "\': No such file or directory"); $script:fx_exit = 1; continue }',
     '  $fx_root = (Get-Item -LiteralPath $fx_p -Force).FullName',
     '  $fx_all = @(Get-Item -LiteralPath $fx_p -Force)',
     '  $fx_all += @(Get-ChildItem -LiteralPath $fx_p -Recurse -Force -ErrorAction SilentlyContinue)',
+    plan.hasDelete ? '  [array]::Reverse($fx_all)' : '',
     '  foreach ($fx_i in $fx_all) {',
     "    $fx_rel = $fx_i.FullName.Substring($fx_root.Length).TrimStart('\\').Replace('\\', '/')",
     "    if ($fx_rel -eq '') { $fx_disp = $fx_p } else { $fx_disp = ($fx_p.TrimEnd('/') + '/' + $fx_rel) }",
     '    $fx_depth = 0; if ($fx_rel -ne \'\') { $fx_depth = 1; foreach ($fx_c in $fx_rel.ToCharArray()) { if ($fx_c -eq \'/\') { $fx_depth++ } } }',
-    '    if ($fx_depth -lt ' + (minDepthS ?? '0') + ') { continue }',
-    maxDepthS !== null ? '    if ($fx_depth -gt ' + maxDepthS + ') { continue }' : '',
-    '    if (-not (' + cond + ')) { continue }',
-    sizeCond ? '    $fx_sz = 0; if (-not $fx_i.PSIsContainer) { try { $fx_sz = $fx_i.Length } catch {} }' : '',
-    sizeCond ? '    if (-not (' + sizeCond + ')) { continue }' : '',
-    mtimeCond ? '    if (-not (' + mtimeCond + ')) { continue }' : '',
-    '    if (' + (wantDelete ? '$true' : '$false') + ') {',
-    '      try { Remove-Item -LiteralPath $fx_i.FullName -Recurse -Force -ErrorAction SilentlyContinue } catch {}',
-    '    } else {',
-    '      $fx_disp',
-    '    }',
+    '    if ($fx_depth -lt ' + (plan.minDepth ?? '0') + ') { continue }',
+    plan.maxDepth !== null ? '    if ($fx_depth -gt ' + plan.maxDepth + ') { continue }' : '',
+    plan.hasSize
+      ? '    $fx_sz = 0; if (-not $fx_i.PSIsContainer) { try { $fx_sz = $fx_i.Length } catch {} }'
+      : '',
+    plan.hasPrint ? '    $script:fx_find_print = $false' : '',
+    '    if (' + expr + ') { }',
+    plan.hasPrint ? '    if ($script:fx_find_print) { $fx_disp }' : '',
     '  }',
     '}',
   ]
     .filter((l) => l !== '')
     .join('\n');
 };
-
-function extractValue(preds: string[], names: string[]): string | null {
-  for (const n of names) {
-    const i = preds.indexOf(n);
-    if (i >= 0 && i + 1 < preds.length) return preds[i + 1];
-  }
-  return null;
-}
 
 /** fnmatch glob → PowerShell -like pattern (same semantics for * and ?). */
 function likeOf(glob: string): string {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -48,6 +48,11 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
       'grandchild\n',
       'utf8',
     );
+    mkdirSync(join(dir, 'find-bool', 'sub'), { recursive: true });
+    writeFileSync(join(dir, 'find-bool', 'keep.ts'), 'keep\n', 'utf8');
+    writeFileSync(join(dir, 'find-bool', 'drop.log'), 'drop\n', 'utf8');
+    writeFileSync(join(dir, 'find-bool', 'sub', 'a.ts'), 'a\n', 'utf8');
+    writeFileSync(join(dir, 'find-bool', 'sub', 'b.log'), 'b\n', 'utf8');
     session = new FauxnixSession();
     // seed the session cwd like a real shell login directory
     await session.run(translateCommandList(parseCommand('cd "' + dir + '"')));
@@ -679,18 +684,78 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     ]);
   });
 
-  it('find rejects missing and invalid depth arguments', async () => {
-    const missing = await run('find find-depth -maxdepth');
-    expect(missing.exitCode).toBe(1);
-    expect(missing.stderr).toContain("find: missing argument to '-maxdepth'");
-
+  it('find rejects missing and invalid depth arguments', () => {
+    expect(() => translateCommandList(parseCommand('find find-depth -maxdepth'))).toThrow(
+      "find: missing argument to '-maxdepth'",
+    );
     for (const value of ['nope', '-1']) {
-      const invalid = await run(`find find-depth -mindepth ${value}`);
-      expect(invalid.exitCode).toBe(1);
-      expect(invalid.stderr).toContain(
+      expect(() =>
+        translateCommandList(parseCommand(`find find-depth -mindepth ${value}`)),
+      ).toThrow(
         `find: expected a non-negative decimal integer argument to -mindepth, but got '${value}'`,
       );
     }
+  });
+
+  it('find ! / -o compose instead of ignoring operators', async () => {
+    const paths = async (cmd: string) => {
+      const r = await run(cmd);
+      expect(r.exitCode).toBe(0);
+      return r.stdout.split(/\r?\n/).filter(Boolean).sort();
+    };
+    expect(await paths("find find-bool -name '*.ts'")).toEqual([
+      'find-bool/keep.ts',
+      'find-bool/sub/a.ts',
+    ]);
+    const negated = await paths("find find-bool ! -name '*.ts'");
+    expect(negated).toContain('find-bool');
+    expect(negated).toContain('find-bool/drop.log');
+    expect(negated).toContain('find-bool/sub');
+    expect(negated).toContain('find-bool/sub/b.log');
+    expect(negated).not.toContain('find-bool/keep.ts');
+    expect(negated).not.toContain('find-bool/sub/a.ts');
+    expect(await paths("find find-bool -name '*.ts' -o -name '*.log'")).toEqual([
+      'find-bool/drop.log',
+      'find-bool/keep.ts',
+      'find-bool/sub/a.ts',
+      'find-bool/sub/b.log',
+    ]);
+    expect(await paths("find find-bool -name '*.ts' -name '*.log'")).toEqual([]);
+  });
+
+  it('find ! -name -delete removes the negated set, not the named set', async () => {
+    const root = join(dir, 'find-del-not');
+    mkdirSync(join(root, 'sub'), { recursive: true });
+    writeFileSync(join(root, 'keep.ts'), 'keep\n', 'utf8');
+    writeFileSync(join(root, 'drop.log'), 'drop\n', 'utf8');
+    writeFileSync(join(root, 'sub', 'a.ts'), 'a\n', 'utf8');
+    writeFileSync(join(root, 'sub', 'b.log'), 'b\n', 'utf8');
+    const r = await run("find find-del-not ! -name '*.ts' -delete");
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(join(root, 'keep.ts'))).toBe(true);
+    expect(existsSync(join(root, 'sub', 'a.ts'))).toBe(true);
+    expect(existsSync(join(root, 'drop.log'))).toBe(false);
+    expect(existsSync(join(root, 'sub', 'b.log'))).toBe(false);
+  });
+
+  it('find -name a -o -name b -delete follows GNU AND/OR precedence', async () => {
+    const root = join(dir, 'find-del-or');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'keep.ts'), 'keep\n', 'utf8');
+    writeFileSync(join(root, 'drop.log'), 'drop\n', 'utf8');
+    const footgun = await run("find find-del-or -name '*.log' -o -name '*.ts' -delete");
+    expect(footgun.exitCode).toBe(0);
+    expect(existsSync(join(root, 'drop.log'))).toBe(true);
+    expect(existsSync(join(root, 'keep.ts'))).toBe(false);
+
+    const groupedRoot = join(dir, 'find-del-group');
+    mkdirSync(groupedRoot, { recursive: true });
+    writeFileSync(join(groupedRoot, 'keep.ts'), 'keep\n', 'utf8');
+    writeFileSync(join(groupedRoot, 'drop.log'), 'drop\n', 'utf8');
+    const grouped = await run("find find-del-group \\( -name '*.log' -o -name '*.ts' \\) -delete");
+    expect(grouped.exitCode).toBe(0);
+    expect(existsSync(join(groupedRoot, 'keep.ts'))).toBe(false);
+    expect(existsSync(join(groupedRoot, 'drop.log'))).toBe(false);
   });
 
   it('stat -c format', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -683,3 +683,51 @@ describe('tokenize', () => {
     expect(ops).toEqual(['>', '2>']);
   });
 });
+
+describe('find predicates (#130)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+  const throws = (cmd: string, msg: string) => {
+    expect(() => translateCommandList(parse(cmd))).toThrow(msg);
+  };
+
+  it('compiles ! and -o instead of ignoring them', () => {
+    const neg = bodyOf("find . ! -name '*.ts'");
+    expect(neg).toContain('-not');
+    expect(neg).toContain("-clike '*.ts'");
+    expect(neg).toContain('fx-find-print');
+    expect(neg).not.toContain('fx-find-delete');
+
+    const del = bodyOf("find . ! -name '*.ts' -delete");
+    expect(del).toContain('-not');
+    expect(del).toContain('fx-find-delete');
+    expect(del).toContain('[array]::Reverse');
+
+    const or = bodyOf("find . -name a -o -name b");
+    expect(or).toContain(' -or ');
+    expect(or).toContain("-clike 'a'");
+    expect(or).toContain("-clike 'b'");
+
+    const and = bodyOf("find . -name a -name b");
+    expect(and).toContain(' -and ');
+  });
+
+  it('treats -delete as a primary so OR-delete keeps GNU precedence', () => {
+    const footgun = bodyOf("find . -name a -o -name b -delete");
+    expect(footgun).toContain(' -or ');
+    expect(footgun).toContain('fx-find-delete');
+    const grouped = bodyOf("find . \\( -name a -o -name b \\) -delete");
+    expect(grouped).toContain(' -or ');
+    expect(grouped).toContain('fx-find-delete');
+  });
+
+  it('fails loud on unknown predicates and broken expressions', () => {
+    throws('find . -perm 644', "find: unknown predicate '-perm'");
+    throws('find . -print0', "find: unknown predicate '-print0'");
+    throws('find . -name', "find: missing argument to '-name'");
+    throws('find . -type s', 'find: Unknown argument to -type: s');
+    throws('find . -size xyz', "find: Invalid argument 'xyz' to -size");
+    throws('find . -o -name a', "find: invalid expression; you have used a binary operator '-o' with nothing before it.");
+    throws('find . -name a -o', "find: expected an expression after '-o'");
+    throws("find . -name '*.ts' extra", "find: paths must precede expression: 'extra'");
+  });
+});


### PR DESCRIPTION
## Why

#130: `find` listed `!` / `-o` / `-a` / `(` in the path-end stop set, then compiled AND-only filters from the first `-name`. `find . ! -name '*.ts' -delete` therefore deleted the **named** set.

Maintainer: `!` and `-o` need real semantics, not just validation. Do not put `find` on `CommandSpec` yet — `specOptionError` would treat `-name` as bundled shorts.

## What

- Recursive-descent GNU expression: `!`/`-not`, juxtaposition/`-a`/`-and`, `-o`/`-or`, parentheses.
- Unknown predicates / missing values / broken operators fail at translate time (`FauxnixParseError`).
- `-delete` is a primary (GNU AND/OR footgun preserved). No `Remove-Item -Recurse` (that would still kill `*.ts` via a matching parent dir). Reverse the walk so children go first.
- Implicit `-print` wraps the whole user expression when no action is present.
- `-maxdepth`/`-mindepth` stay global pre-filters (first-wins).

Stacked independently of #136 (`CommandSpec` / `cp -n`). Merge either order.

## Tests

- Unit: emitted `-not`/`-or`/`-and`, `-delete` helper only when used, unknown-predicate throws.
- Integration: listing `!` / `-o` / AND; `! -name -delete` keeps `*.ts`; ungrouped OR-delete only deletes the last term; grouped `\( a -o b \) -delete` deletes both.
