### PR TITLE
feat: bounded MCP results, cancel, and serialized host lifecycle

### DIFF
--- a/docs/rfc-bounded-cancellable-execution.md
+++ b/docs/rfc-bounded-cancellable-execution.md
@@ -1,0 +1,99 @@
+# RFC: Bounded, cancellable, stream-preserving execution results
+
+Follow-up to the persistent PowerShell host ([#115](https://github.com/20000419/fauxnix/pull/115) / [docs/rfc-persistent-powershell-host.md](./rfc-persistent-powershell-host.md)).
+Tracks [#129](https://github.com/20000419/fauxnix/issues/129) as the v0.8 wire/result contract (paired with [#130](https://github.com/20000419/fauxnix/issues/130)).
+
+## Why the one-line host frame is now the bottleneck
+
+The resident `powershell.exe` delivered the latency win. The spawn-era convenience of “one JSON line per segment, flatten into one MCP text blob” now crosses several boundaries the suite did not exercise:
+
+1. **Native stderr is outside the frame.** `[Console]::SetError()` captures PowerShell/.NET writes; `git`/`npm`/`node` still write the OS stderr handle. Node appends those bytes to `stderrChunks` and never reads them.
+2. **One result is unbounded.** PowerShell buffers both streams, base64-encodes them, and sends one JSON line. An 11 MB MCP result exceeds the SDK’s 10 MiB read buffer and closes the connection. PS 5.1 `ConvertTo-Json` itself caps at ~2 MiB (`MaxJsonLength`).
+3. **Cancellation is not execution cancellation.** The MCP SDK provides `extra.signal`; the bash handler ignores it. Cancelling `sleep 3` returns to the client while the command keeps the session lock.
+4. **Lifecycle operations race.** Concurrent `fauxnix_session reset` can create multiple live hosts. Stdio EOF does not dispose the session.
+5. **The MCP result loses structure.** stdout/stderr/exit are flattened; `.trim()` drops whitespace-only output; infrastructure failures look like shell exits.
+
+These are one cluster: framing, limits, cancellation, and lifecycle need an explicit contract before a v1 interface freeze.
+
+## Constraints
+
+- Windows PowerShell 5.1 remains the execution baseline.
+- One persistent host per `FauxnixSession` remains the latency model.
+- Existing MCP clients must keep receiving readable `content[].text` during migration.
+- The stdio transport has a finite frame limit and is not an unbounded byte pipe.
+- Timeout/cancellation must terminate the owned process or explicitly report a weaker guarantee.
+- `ChildProcess.kill()` does **not** job-object the process tree (same as today’s timeout). Grandchildren may survive. Windows Job Object kill-on-close is a later step (roadmap B4), not this RFC’s first land.
+
+## Implementation split
+
+| PR | Ships | Does not ship |
+|---|---|---|
+| **A (this land)** | RFC; structured MCP results; `extra.signal` cancel by killing the host (same recovery as timeout); one lock for run/reset/dispose; dispose on stdin EOF / SIGINT / SIGTERM; stop `.trim()` of whitespace-only stdout; drain/clear native `stderrChunks` per request; ConvertTo-Json overflow becomes a loud frame error instead of a dead loop | v2 handshake, chunked frames, deterministic native-stderr marker |
+| **B (follow-up)** | `{v:2,type:ready,…}` handshake (still accept v1 `{ready:true}`); chunked stdout/stderr + `end`; `stdoutLimit`/`stderrLimit` + `truncated`; `FAUXNIX_ERR_END:<id>` marker on the OS stderr pipe so native bytes return exactly once | runspace `Stop()` in-flight cancel; Job Object tree kill; Linux/macOS |
+
+PR-A keeps speaking the v1 host frame:
+
+```json
+{"ready":true}
+{"id":"f…","scriptB64":"…","env":{"FAUXNIX_CWD":"…","FAUXNIX_PREV_EXIT":"0","FAUXNIX_STDIN_FILE":""}}
+{"id":"f…","stdoutB64":"…","stderrB64":"…","exitCode":0}
+```
+
+PR-B proposed frames (Node still reassembles into one `ExecResult`; MCP clients never see host chunks):
+
+```json
+{"v":2,"type":"ready","capabilities":{"cancel":false,"maxChunkBytes":65536,"stderrMarker":true}}
+{"v":2,"type":"run","id":"r1","scriptB64":"…","env":{},"stdoutLimit":8388608,"stderrLimit":1048576}
+{"v":2,"type":"stdout","id":"r1","seq":0,"dataB64":"…"}
+{"v":2,"type":"stderr","id":"r1","seq":0,"dataB64":"…"}
+{"v":2,"type":"end","id":"r1","exitCode":0,"timedOut":false,"cancelled":false,"truncated":false}
+```
+
+`capabilities.cancel: false` is honest until a nested runspace can read a cancel frame while `& $fx_sb` is running. Until then Node kills the host process, matching timeout recovery.
+
+## MCP result contract (PR-A)
+
+During migration, return both the current text content and versioned structured content:
+
+```json
+{
+  "schemaVersion": 1,
+  "stdout": "   ",
+  "stderr": "",
+  "exitCode": 0,
+  "timedOut": false,
+  "cancelled": false,
+  "truncated": false,
+  "sessionId": "a1b2c3d4"
+}
+```
+
+- Normal shell nonzero exits stay command results (`isError` unset). Host startup failure, malformed frames, translate/parse throws, and a dead transport are infrastructure (`isError: true`).
+- Whitespace-only stdout is byte-faithful in `structuredContent.stdout`. The text view may still strip a single trailing newline for display; it must not `.trim()`.
+- Cancel uses exit **130** (`128+SIGINT`). Timeout stays **124**.
+- Default budgets: 8 MiB stdout, 1 MiB stderr. Crossing a budget sets `truncated: true` and must not close the MCP connection.
+
+## Failure modes
+
+| Event | Behavior |
+|---|---|
+| `extra.signal` abort | Kill the host (same as timeout). Return `cancelled: true`, exit 130. Later list segments do not run. Next `run()` cold-starts a host. |
+| `ExecOptions.timeoutMs` | Unchanged: kill host, exit 124, session remains usable. |
+| Concurrent `reset` / `run` / `dispose` | One lifecycle lock. Exactly one live host after they settle. `reset()` mutates the existing `FauxnixSession` (does not allocate a second object). |
+| Stdio EOF / SIGINT / SIGTERM | Idempotent `dispose()`: stop host, unlink cwd/env/script/host temp files. |
+| Native stderr on the OS pipe | PR-A: concatenate whatever arrived on the pipe during the frame and **clear** `stderrChunks`. Not deterministic across two OS pipes (stated). PR-B: `FAUXNIX_ERR_END:<id>` marker. |
+| ConvertTo-Json > ~2 MiB | Loud stderr on that frame (`exit 1`), host loop stays alive. PR-B chunks so this path is unused for payload. |
+| `powershell.exe` missing | Unchanged 127 + sandbox message. Marked as infrastructure in MCP. |
+
+## Non-goals
+
+- Linux/macOS execution.
+- Turning fauxnix into a security sandbox.
+- Changing bash’s normal exit-code semantics.
+- Requiring every MCP client to consume streaming chunks.
+- Version bump / npm publish.
+- Job-object tree kill (B4) and per-frame runspace `Stop()` (B3).
+
+## Correctness that must stay green
+
+Session cwd, `FAUXNIX_SETVALS` / arrays, prefix `VAR=value` non-leak, `[[ ]]` + `BASH_REMATCH`, `if`/`for`, redirects including `2>&1` and failed `>` order, timeout 124, no-powershell 127, warm `echo hi` p50, PATHEXT restore.

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -6,18 +6,30 @@ import { Redirect } from './ast.js';
 import { SegmentPlan, normalizeLiteralPath, wrapScript } from './translator.js';
 import { decodeOutput, normalizeHostNewlines, resolveNativePref } from './encoding.js';
 import { normalizeStderr } from './errors.js';
-import { PowerShellHost, PS_MISSING_MESSAGE } from './ps-host.js';
+import {
+  DEFAULT_STDERR_LIMIT,
+  DEFAULT_STDOUT_LIMIT,
+  PowerShellHost,
+  PS_MISSING_MESSAGE,
+} from './ps-host.js';
 
 export interface ExecResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+  timedOut: boolean;
+  cancelled: boolean;
+  truncated: boolean;
+  spawnError?: 'ENOENT' | 'START';
 }
 
 export interface ExecOptions {
   timeoutMs?: number;
   /** Extra environment layered over the session (used by MCP per-call cwd). */
   cwd?: string;
+  signal?: AbortSignal;
+  stdoutLimit?: number;
+  stderrLimit?: number;
 }
 
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -179,6 +191,7 @@ function planRedirects(redirects: Redirect[]): SegmentRedirects {
 
 /** Session persists cwd and env across segments, like a real shell. */
 export class FauxnixSession {
+  id: string;
   cwd: string | null = null;
   env: Record<string, string> = {};
   /** Exit code of the previous segment — powers bash's `$?`. */
@@ -188,17 +201,28 @@ export class FauxnixSession {
   private scriptFile!: string;
   private hostFile!: string;
   private host: PowerShellHost | null = null;
-  private runLock: Promise<unknown> = Promise.resolve();
+  private lifecycleLock: Promise<unknown> = Promise.resolve();
 
   constructor() {
-    this.bindFiles(randomUUID().slice(0, 8));
+    this.id = randomUUID().slice(0, 8);
+    this.bindFiles(this.id);
   }
 
   private bindFiles(id: string): void {
+    this.id = id;
     this.cwdFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-cwd.txt');
     this.envFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-env.json');
     this.scriptFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-script.ps1');
     this.hostFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-host.ps1');
+  }
+
+  private withLock<T>(fn: () => Promise<T>): Promise<T> {
+    const done = this.lifecycleLock.then(fn, fn);
+    this.lifecycleLock = done.then(
+      () => undefined,
+      () => undefined,
+    );
+    return done;
   }
 
   private syncFromDisk(): void {
@@ -228,11 +252,25 @@ export class FauxnixSession {
   }
 
   /** Boot powershell.exe now so the first run() is not the 1.1s cold start. */
-  async prewarm(): Promise<void> {
-    await this.ensureHost().ready();
+  prewarm(): Promise<void> {
+    return this.withLock(async () => {
+      await this.ensureHost().ready();
+    });
   }
 
-  async dispose(): Promise<void> {
+  dispose(): Promise<void> {
+    return this.withLock(() => this.disposeUnlocked());
+  }
+
+  /** Kill the host and re-prewarm the same session object (no second FauxnixSession). */
+  reset(): Promise<void> {
+    return this.withLock(async () => {
+      await this.disposeUnlocked();
+      await this.ensureHost().ready();
+    });
+  }
+
+  private async disposeUnlocked(): Promise<void> {
     if (this.host) {
       await this.host.stop();
       this.host = null;
@@ -277,14 +315,9 @@ export class FauxnixSession {
   }
 
   run(plans: SegmentPlan[], opts: ExecOptions = {}): Promise<ExecResult> {
-    const done = this.runLock.then(() =>
+    return this.withLock(() =>
       runPlans(plans, this, opts, () => this.syncFromDisk(), () => this.ensureHost()),
     );
-    this.runLock = done.then(
-      () => undefined,
-      () => undefined,
-    );
-    return done;
   }
 }
 
@@ -297,11 +330,17 @@ async function runPlans(
 ): Promise<ExecResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const deadline = Date.now() + timeoutMs;
+  const stdoutLimit = opts.stdoutLimit ?? DEFAULT_STDOUT_LIMIT;
+  const stderrLimit = opts.stderrLimit ?? DEFAULT_STDERR_LIMIT;
   const timeoutMessage =
     '\nbash: command timed out after ' + Math.round(timeoutMs / 1000) + 's';
   let stdout = '';
   let stderr = '';
   let exitCode = 0;
+  let timedOut = false;
+  let cancelled = false;
+  let truncated = false;
+  let spawnError: ExecResult['spawnError'];
   // bash list semantics: `a && b ; c` runs c regardless of a; `a && b && c`
   // skips b AND c when a fails. chainOk models the value of the current
   // &&/|| chain; `;` segments always run and restart the chain.
@@ -317,9 +356,16 @@ async function runPlans(
   for (const plan of plans) {
     if (plan.op === '&&' && !chainOk) continue;
     if (plan.op === '||' && chainOk) continue;
+    if (opts.signal?.aborted) {
+      cancelled = true;
+      exitCode = 130;
+      session.prevExit = exitCode;
+      break;
+    }
     if (Date.now() >= deadline) {
       stderr += timeoutMessage;
       exitCode = 124;
+      timedOut = true;
       session.prevExit = exitCode;
       break;
     }
@@ -396,9 +442,16 @@ async function runPlans(
     }
 
     const remainingMs = deadline - Date.now();
+    if (opts.signal?.aborted) {
+      cancelled = true;
+      exitCode = 130;
+      session.prevExit = exitCode;
+      break;
+    }
     if (remainingMs <= 0) {
       stderr += timeoutMessage;
       exitCode = 124;
+      timedOut = true;
       session.prevExit = exitCode;
       break;
     }
@@ -412,14 +465,24 @@ async function runPlans(
         FAUXNIX_STDIN_FILE: red.stdinFile || '',
       },
       remainingMs,
+      opts.signal,
     );
 
-    if (inv.spawnError === 'ENOENT') {
+    if (inv.spawnError === 'ENOENT' || inv.spawnError === 'START') {
       stderr += inv.stderr.toString('utf8') || PS_MISSING_MESSAGE;
       exitCode = 127;
+      spawnError = inv.spawnError;
       session.prevExit = exitCode;
       chainOk = false;
       continue;
+    }
+
+    if (inv.cancelled) {
+      cancelled = true;
+      exitCode = 130;
+      session.prevExit = exitCode;
+      chainOk = false;
+      break;
     }
 
     afterSegment();
@@ -474,7 +537,9 @@ async function runPlans(
 
     stdout += segOut;
     stderr += segErr;
-    exitCode = inv.timedOut ? 124 : inv.exitCode;
+    if (inv.truncated) truncated = true;
+    exitCode = inv.timedOut ? 124 : inv.cancelled ? 130 : inv.exitCode;
+    if (inv.timedOut) timedOut = true;
     session.prevExit = exitCode;
     chainOk = exitCode === 0;
     // Only inherit cwd from a segment that actually ran and whose
@@ -487,5 +552,23 @@ async function runPlans(
     }
   }
 
-  return { stdout, stderr, exitCode };
+  const clippedOut = clipUtf8(stdout, stdoutLimit);
+  const clippedErr = clipUtf8(stderr, stderrLimit);
+  if (clippedOut.truncated || clippedErr.truncated) truncated = true;
+  return {
+    stdout: clippedOut.text,
+    stderr: clippedErr.text,
+    exitCode,
+    timedOut,
+    cancelled,
+    truncated,
+    spawnError,
+  };
+}
+
+function clipUtf8(text: string, limit: number): { text: string; truncated: boolean } {
+  if (Buffer.byteLength(text, 'utf8') <= limit) return { text, truncated: false };
+  let end = text.length;
+  while (end > 0 && Buffer.byteLength(text.slice(0, end), 'utf8') > limit) end--;
+  return { text: text.slice(0, end), truncated: true };
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import { FauxnixSession } from './executor.js';
+import { ExecResult, FauxnixSession } from './executor.js';
 import { parseCommand } from './parser.js';
 import { translateCommandList, wrapScript, translatePipelineBody } from './translator.js';
 import { registeredNames } from './registry.js';
@@ -42,16 +42,46 @@ Unknown commands (git, node, npm, python, cargo...) are passed through and execu
 Not supported: heredocs, while/until/case, background jobs. if/then/elif/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is started when the MCP session begins (and after reset), so the first bash tool call is already warm.
-Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).
+Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout, 130 cancelled). The tool also returns structuredContent (schemaVersion 1) with stdout/stderr/exitCode/timedOut/cancelled/truncated/sessionId.
 
 Platform requirement: the execution backend is native Windows PowerShell 5.1+. On hosts without PowerShell on PATH (e.g. Linux containers/sandboxes), the bash tool returns exit code 127 with an actionable error instead of running the command.`;
+
+export function formatBashText(
+  r: Pick<ExecResult, 'stdout' | 'stderr' | 'exitCode' | 'timedOut' | 'cancelled'>,
+): string {
+  const parts: string[] = [];
+  if (r.stdout.length) parts.push(r.stdout.replace(/\n$/, ''));
+  if (r.stderr.length) parts.push(r.stderr.replace(/\n$/, ''));
+  if (r.cancelled) parts.push('Cancelled');
+  else if (r.timedOut) parts.push('Exit code: 124');
+  else if (r.exitCode !== 0) parts.push('Exit code: ' + r.exitCode);
+  return parts.length ? parts.join('\n') : '(no output)';
+}
+
+export function bashToolResult(r: ExecResult, sessionId: string, infra: boolean) {
+  const structuredContent = {
+    schemaVersion: 1 as const,
+    stdout: r.stdout,
+    stderr: r.stderr,
+    exitCode: r.exitCode,
+    timedOut: r.timedOut,
+    cancelled: r.cancelled,
+    truncated: r.truncated,
+    sessionId,
+  };
+  return {
+    content: [{ type: 'text' as const, text: formatBashText(r) }],
+    structuredContent,
+    ...(infra ? { isError: true as const } : {}),
+  };
+}
 
 export async function startMcpServer(): Promise<void> {
   const server = new McpServer(
     { name: 'fauxnix', version: packageVersion },
     { capabilities: { tools: {} } },
   );
-  let session = new FauxnixSession();
+  const session = new FauxnixSession();
   await session.prewarm();
 
   server.tool(
@@ -68,19 +98,29 @@ export async function startMcpServer(): Promise<void> {
         .describe('Timeout in milliseconds (default 120000)'),
     },
     EXEC_ANNOTATIONS,
-    async ({ command, timeout_ms }) => {
+    async ({ command, timeout_ms }, extra) => {
       try {
         const plans = translateCommandList(parseCommand(command));
-        const result = await session.run(plans, { timeoutMs: timeout_ms });
-        const parts: string[] = [];
-        if (result.stdout.trim()) parts.push(result.stdout.replace(/\n$/, ''));
-        if (result.stderr.trim()) parts.push(result.stderr.replace(/\n$/, ''));
-        if (result.exitCode !== 0) parts.push('Exit code: ' + result.exitCode);
-        const text = parts.length ? parts.join('\n') : '(no output)';
-        return { content: [{ type: 'text', text }] };
+        const result = await session.run(plans, {
+          timeoutMs: timeout_ms,
+          signal: extra.signal,
+        });
+        const infra = result.spawnError === 'ENOENT' || result.spawnError === 'START';
+        return bashToolResult(result, session.id, infra);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
-        return { content: [{ type: 'text', text: msg }], isError: true };
+        return bashToolResult(
+          {
+            stdout: '',
+            stderr: msg,
+            exitCode: 2,
+            timedOut: false,
+            cancelled: false,
+            truncated: false,
+          },
+          session.id,
+          true,
+        );
       }
     },
   );
@@ -115,21 +155,46 @@ export async function startMcpServer(): Promise<void> {
     SESSION_ANNOTATIONS,
     async ({ action }) => {
       if (action === 'reset') {
-        await session.dispose();
-        session = new FauxnixSession();
-        await session.prewarm();
+        await session.reset();
         return { content: [{ type: 'text', text: 'fauxnix: session reset' }] };
       }
       const envKeys = Object.keys(session.env).sort();
       const text =
         'cwd: ' + (session.cwd ?? '(inherit from server start)') +
         '\nenv keys: ' + (envKeys.length ? envKeys.join(', ') : '(none tracked)') +
+        '\nsession: ' + session.id +
         '\ncommands registered: ' + registeredNames().length;
       return { content: [{ type: 'text', text }] };
     },
   );
 
   const transport = new StdioServerTransport();
+  let shuttingDown = false;
+  const shutdown = async () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    await session.dispose();
+    try {
+      await server.close();
+    } catch {
+      /* ignore */
+    }
+  };
+  process.stdin.on('end', () => {
+    void shutdown();
+  });
+  process.stdin.on('close', () => {
+    void shutdown();
+  });
+  process.on('SIGINT', () => {
+    void shutdown();
+  });
+  process.on('SIGTERM', () => {
+    void shutdown();
+  });
+  transport.onclose = () => {
+    void shutdown();
+  };
   await server.connect(transport);
 }
 

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -10,11 +10,16 @@ export const PS_MISSING_MESSAGE =
   'This host has no PowerShell on PATH (typical for Linux containers/sandboxes).\n' +
   'Run fauxnix on Windows, or install PowerShell and make powershell.exe reachable on PATH.\n';
 
+export const DEFAULT_STDOUT_LIMIT = 8_388_608;
+export const DEFAULT_STDERR_LIMIT = 1_048_576;
+
 export interface HostInvokeResult {
   stdout: Buffer;
   stderr: Buffer;
   exitCode: number;
   timedOut: boolean;
+  cancelled: boolean;
+  truncated: boolean;
   spawnError?: 'ENOENT' | 'START';
   spawnMessage?: string;
 }
@@ -85,13 +90,25 @@ export class PowerShellHost {
     return this.ensureStarted();
   }
 
-  async invoke(script: string, env: HostRequestEnv, timeoutMs: number): Promise<HostInvokeResult> {
-    const run = this.invokeLock.then(() => this.invokeSerial(script, env, timeoutMs));
+  async invoke(
+    script: string,
+    env: HostRequestEnv,
+    timeoutMs: number,
+    signal?: AbortSignal,
+  ): Promise<HostInvokeResult> {
+    const run = this.invokeLock.then(() => this.invokeSerial(script, env, timeoutMs, signal));
     this.invokeLock = run.then(
       () => undefined,
       () => undefined,
     );
     return run;
+  }
+
+  drainNativeStderr(): Buffer {
+    if (!this.stderrChunks.length) return Buffer.alloc(0);
+    const b = Buffer.concat(this.stderrChunks);
+    this.stderrChunks = [];
+    return b;
   }
 
   async stop(): Promise<void> {
@@ -119,13 +136,30 @@ export class PowerShellHost {
     });
   }
 
+  private cancelledResult(): HostInvokeResult {
+    return {
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      exitCode: 130,
+      timedOut: false,
+      cancelled: true,
+      truncated: false,
+    };
+  }
+
   private async invokeSerial(
     script: string,
     env: HostRequestEnv,
     timeoutMs: number,
+    signal?: AbortSignal,
   ): Promise<HostInvokeResult> {
+    if (signal?.aborted) {
+      await this.stop();
+      return this.cancelledResult();
+    }
+
     const started = await this.ensureStarted();
-    if (started) return started;
+    if (started) return { ...started, cancelled: false, truncated: false };
 
     const id = 'f' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
     const line = encodeHostRequest(id, script, env);
@@ -138,24 +172,44 @@ export class PowerShellHost {
         stderr: Buffer.from('fauxnix: powershell host exited unexpectedly\n', 'utf8'),
         exitCode: 1,
         timedOut: false,
+        cancelled: false,
+        truncated: false,
         spawnMessage: (e as Error).message,
       };
     }
 
+    let cancelled = false;
+    const onAbort = () => {
+      cancelled = true;
+      void this.stop();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
     try {
       const raw = await this.nextJsonLine(timeoutMs, id);
       const msg = decodeHostResponse(raw);
+      const native = this.drainNativeStderr();
       return {
         stdout: msg.stdout,
-        stderr: msg.stderr,
+        stderr: native.length ? Buffer.concat([msg.stderr, native]) : msg.stderr,
         exitCode: msg.exitCode,
         timedOut: false,
+        cancelled: false,
+        truncated: false,
       };
     } catch (e) {
       const timedOut = (e as { timedOut?: boolean }).timedOut === true;
       await this.stop();
+      this.drainNativeStderr();
+      if (cancelled || signal?.aborted) return this.cancelledResult();
       if (timedOut) {
-        return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), exitCode: 124, timedOut: true };
+        return {
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.alloc(0),
+          exitCode: 124,
+          timedOut: true,
+          cancelled: false,
+          truncated: false,
+        };
       }
       if (this.closeErr && (this.closeErr as NodeJS.ErrnoException).code === 'ENOENT') {
         return {
@@ -163,6 +217,8 @@ export class PowerShellHost {
           stderr: Buffer.from(PS_MISSING_MESSAGE, 'utf8'),
           exitCode: 127,
           timedOut: false,
+          cancelled: false,
+          truncated: false,
           spawnError: 'ENOENT',
         };
       }
@@ -177,7 +233,11 @@ export class PowerShellHost {
         ),
         exitCode: code === 0 ? 1 : code,
         timedOut: false,
+        cancelled: false,
+        truncated: false,
       };
+    } finally {
+      signal?.removeEventListener('abort', onAbort);
     }
   }
 
@@ -195,6 +255,8 @@ export class PowerShellHost {
           stderr: Buffer.from(PS_MISSING_MESSAGE, 'utf8'),
           exitCode: 127,
           timedOut: false,
+          cancelled: false,
+          truncated: false,
           spawnError: 'ENOENT',
         };
       }
@@ -206,6 +268,8 @@ export class PowerShellHost {
         ),
         exitCode: 127,
         timedOut: false,
+        cancelled: false,
+        truncated: false,
         spawnError: 'START',
         spawnMessage: err.message,
       };
@@ -234,14 +298,22 @@ export class PowerShellHost {
       windowsHide: true,
     });
     this.proc = child;
-    child.stdout!.on('data', (d: Buffer) => this.onStdout(d));
-    child.stderr!.on('data', (d: Buffer) => this.stderrChunks.push(d));
+    child.stdout!.on('data', (d: Buffer) => {
+      if (this.proc !== child) return;
+      this.onStdout(d);
+    });
+    child.stderr!.on('data', (d: Buffer) => {
+      if (this.proc !== child) return;
+      this.stderrChunks.push(d);
+    });
     child.on('error', (e) => {
+      if (this.proc !== child) return;
       this.closeErr = e;
       this.closed = true;
       this.failWaiters(e);
     });
     child.on('close', (c) => {
+      if (this.proc !== child) return;
       this.closeCode = c;
       this.closed = true;
       this.proc = null;

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1402,6 +1402,13 @@ while ($true) {
   $fx_code = 0
   try { $fx_code = [int]$script:fx_exit } catch { $fx_code = 1 }
   $fx_res = @{ id = $fx_id; stdoutB64 = $fx_outB64; stderrB64 = $fx_errB64; exitCode = $fx_code }
-  $fx_proto.WriteLine(($fx_res | ConvertTo-Json -Compress))
+  try {
+    $fx_json = $fx_res | ConvertTo-Json -Compress
+  } catch {
+    $fx_msg = 'fauxnix: host result exceeded ConvertTo-Json MaxJsonLength (~2MB)'
+    $fx_res = @{ id = $fx_id; stdoutB64 = ''; stderrB64 = [Convert]::ToBase64String($fx_utf8.GetBytes($fx_msg)); exitCode = 1 }
+    $fx_json = $fx_res | ConvertTo-Json -Compress
+  }
+  $fx_proto.WriteLine($fx_json)
 }
 `.trim();

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1106,4 +1106,59 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
       await extra.dispose();
     }
   }, 30000);
+
+  it('whitespace-only stdout is preserved', async () => {
+    const r = await run("printf '   '");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe('   ');
+    expect(r.cancelled).toBe(false);
+    expect(r.timedOut).toBe(false);
+  });
+
+  it('native stderr is returned once and does not leak into the next command', async () => {
+    const noisy = await run(`node -e "process.stderr.write('E'.repeat(4096)); process.exit(7)"`);
+    expect(noisy.exitCode).toBe(7);
+    expect(noisy.stderr).toContain('E'.repeat(64));
+    expect(noisy.stderr.split('E').length - 1).toBeGreaterThanOrEqual(4096);
+    const next = await run('echo hi');
+    expect(next.exitCode).toBe(0);
+    expect(next.stdout.trim()).toBe('hi');
+    expect(next.stderr).not.toContain('E'.repeat(64));
+  });
+
+  it('AbortSignal cancel unblocks the next request without running later segments', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const ac = new AbortController();
+      const pending = extra.run(
+        translateCommandList(parseCommand('sleep 5; echo should-not-run')),
+        { timeoutMs: 30_000, signal: ac.signal },
+      );
+      await new Promise((r) => setTimeout(r, 250));
+      ac.abort();
+      const cancelled = await pending;
+      expect(cancelled.cancelled).toBe(true);
+      expect(cancelled.exitCode).toBe(130);
+      expect(cancelled.stdout).not.toContain('should-not-run');
+      const next = await extra.run(translateCommandList(parseCommand('echo after-cancel')));
+      expect(next.exitCode).toBe(0);
+      expect(next.stdout.trim()).toBe('after-cancel');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('concurrent reset leaves one usable session', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      await Promise.all([extra.reset(), extra.reset(), extra.reset()]);
+      const r = await extra.run(translateCommandList(parseCommand('echo x')));
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe('x');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -15,6 +15,7 @@ import { lookup, parseWords, psStr } from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import { normalizeStderr } from '../src/errors.js';
 import { decodeHostResponse, encodeHostRequest } from '../src/ps-host.js';
+import { bashToolResult, formatBashText } from '../src/mcp.js';
 import '../src/commands/install-all.js';
 
 /* ---------------------------- parser ---------------------------- */
@@ -455,6 +456,7 @@ describe('translator', () => {
     expect(boot).toContain('function fx-csub');
     expect(boot).toContain('{"ready":true}');
     expect(boot).toContain('ConvertFrom-Json');
+    expect(boot).toContain('MaxJsonLength');
     expect(boot).not.toContain('exit $script:fx_exit');
   });
 
@@ -681,5 +683,48 @@ describe('tokenize', () => {
     const toks = tokenize('a > b 2> c');
     const ops = toks.filter((t) => t.type === 'OP').map((t) => t.op);
     expect(ops).toEqual(['>', '2>']);
+  });
+});
+
+describe('MCP structured results (#129)', () => {
+  it('keeps whitespace-only stdout instead of collapsing to (no output)', () => {
+    expect(
+      formatBashText({
+        stdout: '   ',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+        cancelled: false,
+      }),
+    ).toBe('   ');
+    expect(
+      formatBashText({
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+        cancelled: false,
+      }),
+    ).toBe('(no output)');
+  });
+
+  it('exposes schemaVersion 1 and does not mark shell exit 1 as a protocol error', () => {
+    const r = bashToolResult(
+      {
+        stdout: 'x',
+        stderr: '',
+        exitCode: 1,
+        timedOut: false,
+        cancelled: false,
+        truncated: false,
+      },
+      'abcd1234',
+      false,
+    );
+    expect(r.structuredContent.schemaVersion).toBe(1);
+    expect(r.structuredContent.sessionId).toBe('abcd1234');
+    expect(r.structuredContent.exitCode).toBe(1);
+    expect(r.content[0].text).toContain('Exit code: 1');
+    expect('isError' in r && r.isError).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Why

#129: the persistent host won on latency, then the spawn-era one-line frame and flattened MCP blob started failing in ways the suite never saw — dropped native stderr, ignored `extra.signal`, concurrent reset spawning extra hosts, `.trim()` eating whitespace-only stdout, and ConvertTo-Json/`ReadBuffer` ceilings.

Maintainer: ship an RFC like the persistent-host one, then land lifecycle/cancel/structured results on the **v1** frame before chunked v2.

## What (PR-A, v1 host frame)

- `docs/rfc-bounded-cancellable-execution.md` — contract, failure-mode table, A/B split.
- MCP `structuredContent` `schemaVersion: 1` (`stdout`/`stderr`/`exitCode`/`timedOut`/`cancelled`/`truncated`/`sessionId`). Shell nonzero stays a command result, not `isError`.
- `extra.signal` kills the host (same recovery as timeout), exit **130**, later list segments do not run. Next call cold-starts.
- One lifecycle lock for `run` / `reset` / `dispose`. `reset()` mutates the same `FauxnixSession`. Dispose on stdin EOF / SIGINT / SIGTERM.
- Native `stderrChunks` are concatenated into the result and cleared (best-effort; v2 marker is the follow-up).
- ConvertTo-Json overflow is a loud frame error; the RPC loop stays alive.

Chunked `{v:2,type:stdout|stderr|end}` frames and `FAUXNIX_ERR_END` stay the next #129 PR.

## Tests

- Unit: whitespace text view, structured schema, MaxJsonLength guard in the bootstrap.
- Integration: `printf '   '`, native node stderr returned once, AbortSignal cancel then `echo after-cancel`, concurrent `reset()`, existing timeout 124 still usable.
