### PR TITLE
release: v0.8.0 — execution-contract wave (#135 #136 #137 #138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v0.8.0 — 2026-08-23
+
+Execution-contract wave (#129 PR-A + #130 first families + syntax fail-loud):
+
+- **Bounded, cancellable, structured MCP results** (#129 PR-A): bash tool
+  returns versioned structured content (stdout/stderr/exitCode/timedOut/
+  cancelled) alongside the text; whitespace-only stdout is preserved instead
+  of collapsing to "(no output)"; per-request AbortSignal cancels by host-kill
+  with the same recovery as timeout (measured: sleep 8 cancelled at 0.4s,
+  session survives via cold restart); run/reset/dispose share one lock
+  (concurrent reset can no longer leak hosts); dispose on stdin EOF/SIGINT/
+  SIGTERM; native stderr drained per request; ConvertTo-Json overflow is a
+  loud frame error. v2 chunked frames stay a follow-up (PR-B).
+- **CommandSpec fail-loud** (#130): cp/mv/rm/touch/tee carry typed option
+  specs — unknown options are GNU-style usage errors, cp -n / mv -n /
+  touch -c / tee --append match GNU semantics; fauxnix list --json exposes
+  the capability metadata (108 commands)
+- **find predicates compiled, not ignored** (#137): !, -o, -a, grouping
+  parens, -delete precedence follow GNU; unknown predicates and broken
+  expressions fail loud with GNU wording
+- **Syntax fail-loud** (#135): trailing &&, ; ;, and env -i now reject with
+  actionable errors instead of executing something surprising
+
+Note: #138's richer host bootstrap raises the first frame after prewarm to
+~0.7s (from 0.137s; warm frames unchanged at ~50ms) — tracked for a
+bootstrap-slimming follow-up.
+
+186 tests.
 ## v0.7.1 — 2026-08-23
 
 Post-v0.7 audit fixes (issue #131 by @vulragrag-star; integration of #123–#128):

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ development:
 - **text filters**: `grep egrep sed awk sort uniq cut tr` — sed/awk scripts are parsed at
   translate time (unsupported constructs throw named errors, never silently misbehave)
 - **text I/O**: `echo printf cat head tail wc tee nl tac md5sum sha1sum sha256sum base64 seq yes xargs`
+
+`cp` / `mv` / `rm` / `touch` / `tee` carry a `CommandSpec`: unknown options fail with a GNU-style
+usage error instead of being ignored. `cp -n` / `mv -n` / `touch -c` / `tee --append` match GNU
+(no clobber / no-create / append). `fauxnix list --json` dumps the same capability metadata.
 - **shell/system**: `cd pwd export unset env printenv ps kill pkill pgrep sleep which type whoami
   id groups date uname hostname uptime free nproc clear true false test [ [[ : pushd popd dirs sudo
   timeout man history less more source . eval exit alias set`

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
 - `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`,
+  `env -i`/`--ignore-environment`,
   and background `&` are rejected with actionable error messages instead of misbehaving.
   (`if/then/elif/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
   dotenv-style `source`, and word-level `$((...))` arithmetic expansion are supported.)

--- a/docs/rfc-bounded-cancellable-execution.md
+++ b/docs/rfc-bounded-cancellable-execution.md
@@ -1,0 +1,99 @@
+# RFC: Bounded, cancellable, stream-preserving execution results
+
+Follow-up to the persistent PowerShell host ([#115](https://github.com/20000419/fauxnix/pull/115) / [docs/rfc-persistent-powershell-host.md](./rfc-persistent-powershell-host.md)).
+Tracks [#129](https://github.com/20000419/fauxnix/issues/129) as the v0.8 wire/result contract (paired with [#130](https://github.com/20000419/fauxnix/issues/130)).
+
+## Why the one-line host frame is now the bottleneck
+
+The resident `powershell.exe` delivered the latency win. The spawn-era convenience of “one JSON line per segment, flatten into one MCP text blob” now crosses several boundaries the suite did not exercise:
+
+1. **Native stderr is outside the frame.** `[Console]::SetError()` captures PowerShell/.NET writes; `git`/`npm`/`node` still write the OS stderr handle. Node appends those bytes to `stderrChunks` and never reads them.
+2. **One result is unbounded.** PowerShell buffers both streams, base64-encodes them, and sends one JSON line. An 11 MB MCP result exceeds the SDK’s 10 MiB read buffer and closes the connection. PS 5.1 `ConvertTo-Json` itself caps at ~2 MiB (`MaxJsonLength`).
+3. **Cancellation is not execution cancellation.** The MCP SDK provides `extra.signal`; the bash handler ignores it. Cancelling `sleep 3` returns to the client while the command keeps the session lock.
+4. **Lifecycle operations race.** Concurrent `fauxnix_session reset` can create multiple live hosts. Stdio EOF does not dispose the session.
+5. **The MCP result loses structure.** stdout/stderr/exit are flattened; `.trim()` drops whitespace-only output; infrastructure failures look like shell exits.
+
+These are one cluster: framing, limits, cancellation, and lifecycle need an explicit contract before a v1 interface freeze.
+
+## Constraints
+
+- Windows PowerShell 5.1 remains the execution baseline.
+- One persistent host per `FauxnixSession` remains the latency model.
+- Existing MCP clients must keep receiving readable `content[].text` during migration.
+- The stdio transport has a finite frame limit and is not an unbounded byte pipe.
+- Timeout/cancellation must terminate the owned process or explicitly report a weaker guarantee.
+- `ChildProcess.kill()` does **not** job-object the process tree (same as today’s timeout). Grandchildren may survive. Windows Job Object kill-on-close is a later step (roadmap B4), not this RFC’s first land.
+
+## Implementation split
+
+| PR | Ships | Does not ship |
+|---|---|---|
+| **A (this land)** | RFC; structured MCP results; `extra.signal` cancel by killing the host (same recovery as timeout); one lock for run/reset/dispose; dispose on stdin EOF / SIGINT / SIGTERM; stop `.trim()` of whitespace-only stdout; drain/clear native `stderrChunks` per request; ConvertTo-Json overflow becomes a loud frame error instead of a dead loop | v2 handshake, chunked frames, deterministic native-stderr marker |
+| **B (follow-up)** | `{v:2,type:ready,…}` handshake (still accept v1 `{ready:true}`); chunked stdout/stderr + `end`; `stdoutLimit`/`stderrLimit` + `truncated`; `FAUXNIX_ERR_END:<id>` marker on the OS stderr pipe so native bytes return exactly once | runspace `Stop()` in-flight cancel; Job Object tree kill; Linux/macOS |
+
+PR-A keeps speaking the v1 host frame:
+
+```json
+{"ready":true}
+{"id":"f…","scriptB64":"…","env":{"FAUXNIX_CWD":"…","FAUXNIX_PREV_EXIT":"0","FAUXNIX_STDIN_FILE":""}}
+{"id":"f…","stdoutB64":"…","stderrB64":"…","exitCode":0}
+```
+
+PR-B proposed frames (Node still reassembles into one `ExecResult`; MCP clients never see host chunks):
+
+```json
+{"v":2,"type":"ready","capabilities":{"cancel":false,"maxChunkBytes":65536,"stderrMarker":true}}
+{"v":2,"type":"run","id":"r1","scriptB64":"…","env":{},"stdoutLimit":8388608,"stderrLimit":1048576}
+{"v":2,"type":"stdout","id":"r1","seq":0,"dataB64":"…"}
+{"v":2,"type":"stderr","id":"r1","seq":0,"dataB64":"…"}
+{"v":2,"type":"end","id":"r1","exitCode":0,"timedOut":false,"cancelled":false,"truncated":false}
+```
+
+`capabilities.cancel: false` is honest until a nested runspace can read a cancel frame while `& $fx_sb` is running. Until then Node kills the host process, matching timeout recovery.
+
+## MCP result contract (PR-A)
+
+During migration, return both the current text content and versioned structured content:
+
+```json
+{
+  "schemaVersion": 1,
+  "stdout": "   ",
+  "stderr": "",
+  "exitCode": 0,
+  "timedOut": false,
+  "cancelled": false,
+  "truncated": false,
+  "sessionId": "a1b2c3d4"
+}
+```
+
+- Normal shell nonzero exits stay command results (`isError` unset). Host startup failure, malformed frames, translate/parse throws, and a dead transport are infrastructure (`isError: true`).
+- Whitespace-only stdout is byte-faithful in `structuredContent.stdout`. The text view may still strip a single trailing newline for display; it must not `.trim()`.
+- Cancel uses exit **130** (`128+SIGINT`). Timeout stays **124**.
+- Default budgets: 8 MiB stdout, 1 MiB stderr. Crossing a budget sets `truncated: true` and must not close the MCP connection.
+
+## Failure modes
+
+| Event | Behavior |
+|---|---|
+| `extra.signal` abort | Kill the host (same as timeout). Return `cancelled: true`, exit 130. Later list segments do not run. Next `run()` cold-starts a host. |
+| `ExecOptions.timeoutMs` | Unchanged: kill host, exit 124, session remains usable. |
+| Concurrent `reset` / `run` / `dispose` | One lifecycle lock. Exactly one live host after they settle. `reset()` mutates the existing `FauxnixSession` (does not allocate a second object). |
+| Stdio EOF / SIGINT / SIGTERM | Idempotent `dispose()`: stop host, unlink cwd/env/script/host temp files. |
+| Native stderr on the OS pipe | PR-A: concatenate whatever arrived on the pipe during the frame and **clear** `stderrChunks`. Not deterministic across two OS pipes (stated). PR-B: `FAUXNIX_ERR_END:<id>` marker. |
+| ConvertTo-Json > ~2 MiB | Loud stderr on that frame (`exit 1`), host loop stays alive. PR-B chunks so this path is unused for payload. |
+| `powershell.exe` missing | Unchanged 127 + sandbox message. Marked as infrastructure in MCP. |
+
+## Non-goals
+
+- Linux/macOS execution.
+- Turning fauxnix into a security sandbox.
+- Changing bash’s normal exit-code semantics.
+- Requiring every MCP client to consume streaming chunks.
+- Version bump / npm publish.
+- Job-object tree kill (B4) and per-frame runspace `Stop()` (B3).
+
+## Correctness that must stay green
+
+Session cwd, `FAUXNIX_SETVALS` / arrays, prefix `VAR=value` non-leak, `[[ ]]` + `BASH_REMATCH`, `if`/`for`, redirects including `2>&1` and failed `>` order, timeout 124, no-powershell 127, warm `echo hi` p50, PATHEXT restore.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fauxnix-cli",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Fauxnix — run Linux-style commands on Windows via deterministic PowerShell translation. No VM, no WSL. MCP server + CLI for AI agents.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { FauxnixSession } from './executor.js';
 import { parseCommand } from './parser.js';
 import { translateCommandList } from './translator.js';
-import { registeredNames } from './registry.js';
+import { listCommandsJson, registeredNames } from './registry.js';
 import { encodeCommand } from './encoding.js';
 import { startMcpServer } from './mcp.js';
 import { packageVersion } from './version.js';
@@ -16,6 +16,7 @@ Usage:
   fauxnix translate "cmd"            show the PowerShell translation only
   fauxnix mcp                        start the MCP stdio server (for agent harnesses)
   fauxnix list                       list translated commands
+  fauxnix list --json                same list as machine-readable capability metadata
   fauxnix check                      verify the local PowerShell environment
   fauxnix --version
 
@@ -36,6 +37,10 @@ export async function runCli(argv: string[]): Promise<void> {
   }
 
   if (verb === 'list') {
+    if (rest[0] === '--json') {
+      console.log(JSON.stringify(listCommandsJson(), null, 2));
+      return;
+    }
     const names = registeredNames();
     console.log(names.length + ' translated commands:');
     for (const n of names) console.log('  ' + n);

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,5 +1,12 @@
 import { Word, wordToString } from '../ast.js';
-import { Handler, parseWords, psStr } from '../registry.js';
+import {
+  CommandSpec,
+  Handler,
+  OptionSpec,
+  OptionSupport,
+  parseWords,
+  psStr,
+} from '../registry.js';
 import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
@@ -135,6 +142,7 @@ const cp: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args);
   const recurse = flags.has('r') || flags.has('R') || longs.has('--recursive');
   const verbose = flags.has('v') || longs.has('--verbose');
+  const noclobber = flags.has('n') || longs.has('--no-clobber');
   return [
     PS_GLOB_FN,
     '$fx_all = ' + argListExpr(operandWords),
@@ -149,6 +157,7 @@ const cp: Handler = (args) => {
     '      if ($fx_isdir -and ' + (recurse ? '$false' : '$true') + ') { [Console]::Error.WriteLine("cp: -r not specified; omitting directory \'" + $fx_g + "\'"); $script:fx_exit = 1; continue }',
     '      $fx_target = $fx_dst',
     '      if (Test-Path -LiteralPath $fx_dst -PathType Container) { $fx_target = Join-Path $fx_dst (Split-Path $fx_g -Leaf) }',
+    '      if (' + (noclobber ? '$true' : '$false') + ' -and (Test-Path -LiteralPath $fx_target)) { continue }',
     '      try {',
     '        Copy-Item -LiteralPath $fx_g -Destination $fx_target -Recurse:' + (recurse ? '$true' : '$false') + ' -Force',
     '        if (' + (verbose ? '$true' : '$false') + ') { [Console]::Error.WriteLine("\'" + $fx_g + "\' -> \'" + $fx_target + "\'") }',
@@ -162,6 +171,7 @@ const cp: Handler = (args) => {
 const mv: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args);
   const verbose = flags.has('v') || longs.has('--verbose');
+  const noclobber = flags.has('n') || longs.has('--no-clobber');
   return [
     PS_GLOB_FN,
     '$fx_all = ' + argListExpr(operandWords),
@@ -175,6 +185,7 @@ const mv: Handler = (args) => {
     '      if (-not (Test-Path -LiteralPath $fx_g)) { [Console]::Error.WriteLine("mv: cannot stat \'" + $fx_g + "\': No such file or directory"); $script:fx_exit = 1; continue }',
     '      $fx_target = $fx_dst',
     '      if (Test-Path -LiteralPath $fx_dst -PathType Container) { $fx_target = Join-Path $fx_dst (Split-Path $fx_g -Leaf) }',
+    '      if (' + (noclobber ? '$true' : '$false') + ' -and (Test-Path -LiteralPath $fx_target)) { continue }',
     '      try {',
     '        if (Test-Path -LiteralPath $fx_target) { Remove-Item -LiteralPath $fx_target -Recurse -Force }',
     '        Move-Item -LiteralPath $fx_g -Destination $fx_target -Force',
@@ -190,7 +201,7 @@ const rm: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args);
   const recurse = flags.has('r') || flags.has('R') || longs.has('--recursive');
   const force = flags.has('f') || longs.has('--force');
-  const verbose = flags.has('v');
+  const verbose = flags.has('v') || longs.has('--verbose');
   return [
     PS_GLOB_FN,
     '$fx_files = ' + psArray(operandWords),
@@ -250,7 +261,8 @@ const rmdir: Handler = (args) => {
 };
 
 const touch: Handler = (args) => {
-  const { operandWords } = parseWords(args);
+  const { flags, longs, operandWords } = parseWords(args);
+  const noCreate = flags.has('c') || longs.has('--no-create');
   return [
     '$fx_files = ' + psArray(operandWords),
     "if ($fx_files.Count -eq 0) { [Console]::Error.WriteLine('touch: missing file operand'); $script:fx_exit = 1 }",
@@ -258,6 +270,7 @@ const touch: Handler = (args) => {
     '  if (Test-Path -LiteralPath $fx_f) {',
     '    try { (Get-Item -LiteralPath $fx_f).LastWriteTime = Get-Date } catch { [Console]::Error.WriteLine("touch: cannot touch \'" + $fx_f + "\': Permission denied"); $script:fx_exit = 1 }',
     '  } else {',
+    '    if (' + (noCreate ? '$true' : '$false') + ') { continue }',
     '    try { New-Item -ItemType File -Path $fx_f | Out-Null }',
     '    catch { [Console]::Error.WriteLine("touch: cannot touch \'" + $fx_f + "\': No such file or directory"); $script:fx_exit = 1 }',
     '  }',
@@ -740,15 +753,88 @@ const diff: Handler = (args) => {
   ].join('\n');
 };
 
+function opt(
+  short: string | undefined,
+  long: string | undefined,
+  support: OptionSupport = 'implemented',
+  extra: Partial<OptionSpec> = {},
+): OptionSpec {
+  const o: OptionSpec = { support };
+  if (short) o.short = short;
+  if (long) o.long = long;
+  return extra.takesValue || extra.reason ? { ...o, ...extra } : o;
+}
+
+function fileSpec(
+  names: string[],
+  effects: CommandSpec['effects'],
+  options: OptionSpec[],
+  handler: Handler,
+): CommandSpec {
+  return {
+    names,
+    options,
+    effects,
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler,
+  };
+}
+
+const INTERACTIVE: Partial<OptionSpec> = { reason: 'interactive prompt' };
+
+/** Destructive file commands migrated first (#130). Unspec'd handlers stay unchecked.
+ *  cp/mv `-f`/`--force` is always-on overwrite (Copy-Item/Move-Item -Force); listed so `cp -rf` stays valid. */
+export const specs: CommandSpec[] = [
+  fileSpec(
+    ['cp'],
+    ['read', 'write'],
+    [
+      opt('r', undefined),
+      opt('R', '--recursive'),
+      opt('v', '--verbose'),
+      opt('n', '--no-clobber'),
+      opt('f', '--force'),
+      opt('i', '--interactive', 'unsupported', INTERACTIVE),
+    ],
+    cp,
+  ),
+  fileSpec(
+    ['mv'],
+    ['read', 'write', 'delete'],
+    [
+      opt('v', '--verbose'),
+      opt('n', '--no-clobber'),
+      opt('f', '--force'),
+      opt('i', '--interactive', 'unsupported', INTERACTIVE),
+    ],
+    mv,
+  ),
+  fileSpec(
+    ['rm'],
+    ['delete'],
+    [
+      opt('r', undefined),
+      opt('R', '--recursive'),
+      opt('f', '--force'),
+      opt('v', '--verbose'),
+      opt('i', '--interactive', 'unsupported', INTERACTIVE),
+    ],
+    rm,
+  ),
+  fileSpec(
+    ['touch'],
+    ['write'],
+    [opt('c', '--no-create')],
+    touch,
+  ),
+];
+
 export const handlers: Record<string, Handler> = {
   ls,
   ll: ls, // common alias
-  cp,
-  mv,
-  rm,
   mkdir,
   rmdir,
-  touch,
   mktemp,
   ln,
   readlink,

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,4 +1,4 @@
-import { Word, wordToString } from '../ast.js';
+import { FauxnixParseError, Word, wordToString } from '../ast.js';
 import { Handler, parseWords, psStr } from '../registry.js';
 import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
@@ -501,13 +501,235 @@ const df: Handler = (args) => {
 /* find                                                                */
 /* ------------------------------------------------------------------ */
 
+type FindNode =
+  | { kind: 'true' }
+  | { kind: 'and'; left: FindNode; right: FindNode }
+  | { kind: 'or'; left: FindNode; right: FindNode }
+  | { kind: 'not'; inner: FindNode }
+  | { kind: 'name'; pat: string; ci: boolean }
+  | { kind: 'type'; t: 'f' | 'd' | 'l' }
+  | { kind: 'size'; ps: string }
+  | { kind: 'mtime'; ps: string }
+  | { kind: 'delete' }
+  | { kind: 'print' };
+
+interface FindPlan {
+  ast: FindNode;
+  maxDepth: string | null;
+  minDepth: string | null;
+  hasDelete: boolean;
+  hasPrint: boolean;
+  hasSize: boolean;
+}
+
+function findFail(msg: string): never {
+  throw new FauxnixParseError(msg);
+}
+
+function canStartFindFactor(t: string): boolean {
+  return (
+    t === '!' ||
+    t === '-not' ||
+    t === '(' ||
+    t === '-name' ||
+    t === '-iname' ||
+    t === '-type' ||
+    t === '-size' ||
+    t === '-mtime' ||
+    t === '-delete' ||
+    t === '-print' ||
+    t === '-maxdepth' ||
+    t === '-mindepth'
+  );
+}
+
+/** GNU find expression: `!` tightest, juxtaposition/`-a` next, `-o` loosest. */
+function parseFindPreds(preds: string[]): FindPlan {
+  const plan: FindPlan = {
+    ast: { kind: 'true' },
+    maxDepth: null,
+    minDepth: null,
+    hasDelete: false,
+    hasPrint: false,
+    hasSize: false,
+  };
+  let i = 0;
+  const peek = (): string | null => (i < preds.length ? preds[i] : null);
+  const take = (): string => preds[i++];
+  const needArg = (opt: string): string => {
+    if (i >= preds.length) findFail("find: missing argument to '" + opt + "'");
+    return take();
+  };
+
+  const parsePrimary = (): FindNode => {
+    const t = take();
+    if (t === '-name' || t === '-iname') {
+      return { kind: 'name', pat: needArg(t), ci: t === '-iname' };
+    }
+    if (t === '-type') {
+      const v = needArg(t);
+      if (v !== 'f' && v !== 'd' && v !== 'l') findFail('find: Unknown argument to -type: ' + v);
+      return { kind: 'type', t: v };
+    }
+    if (t === '-size') {
+      const v = needArg(t);
+      const ps = sizeOf(v);
+      if (!ps) findFail("find: Invalid argument '" + v + "' to -size");
+      plan.hasSize = true;
+      return { kind: 'size', ps };
+    }
+    if (t === '-mtime') {
+      const v = needArg(t);
+      const ps = mtimeOf(v);
+      if (!ps) findFail("find: Invalid argument '" + v + "' to -mtime");
+      return { kind: 'mtime', ps };
+    }
+    if (t === '-delete') {
+      plan.hasDelete = true;
+      return { kind: 'delete' };
+    }
+    if (t === '-print') {
+      plan.hasPrint = true;
+      return { kind: 'print' };
+    }
+    if (t === '-maxdepth' || t === '-mindepth') {
+      const v = needArg(t);
+      if (!/^\d+$/.test(v)) {
+        findFail(
+          'find: expected a non-negative decimal integer argument to ' +
+            t +
+            ", but got '" +
+            v +
+            "'",
+        );
+      }
+      if (t === '-maxdepth' && plan.maxDepth === null) plan.maxDepth = v;
+      if (t === '-mindepth' && plan.minDepth === null) plan.minDepth = v;
+      return { kind: 'true' };
+    }
+    if (t.startsWith('-')) findFail("find: unknown predicate '" + t + "'");
+    findFail("find: paths must precede expression: '" + t + "'");
+  };
+
+  const parseFactor = (): FindNode => {
+    const t = peek();
+    if (t === null) findFail('find: expected an expression');
+    if (t === '-o' || t === '-or' || t === '-a' || t === '-and') {
+      findFail(
+        "find: invalid expression; you have used a binary operator '" +
+          t +
+          "' with nothing before it.",
+      );
+    }
+    if (t === '!' || t === '-not') {
+      take();
+      if (peek() === null) findFail("find: expected an expression after '" + t + "'");
+      if (peek() === ')') findFail("find: expected an expression between '" + t + "' and ')'");
+      return { kind: 'not', inner: parseFactor() };
+    }
+    if (t === '(') {
+      take();
+      if (peek() === ')') findFail('find: invalid expression; empty parentheses are not allowed.');
+      if (peek() === null) {
+        findFail("find: invalid expression; expected to find a ')' but didn't see one.");
+      }
+      const inner = parseOr();
+      if (peek() !== ')') {
+        findFail("find: invalid expression; expected to find a ')' but didn't see one.");
+      }
+      take();
+      return inner;
+    }
+    if (t === ')') findFail("find: invalid expression; you have too many ')'");
+    return parsePrimary();
+  };
+
+  const parseAnd = (): FindNode => {
+    let left = parseFactor();
+    while (true) {
+      const t = peek();
+      if (t === null || t === ')' || t === '-o' || t === '-or') break;
+      if (t === '-a' || t === '-and') {
+        take();
+        if (peek() === null || peek() === ')') {
+          findFail("find: expected an expression after '" + t + "'");
+        }
+        left = { kind: 'and', left, right: parseFactor() };
+        continue;
+      }
+      if (canStartFindFactor(t)) {
+        left = { kind: 'and', left, right: parseFactor() };
+        continue;
+      }
+      findFail("find: paths must precede expression: '" + t + "'");
+    }
+    return left;
+  };
+
+  const parseOr = (): FindNode => {
+    let left = parseAnd();
+    while (peek() === '-o' || peek() === '-or') {
+      const op = take();
+      if (peek() === null || peek() === ')') {
+        findFail("find: expected an expression after '" + op + "'");
+      }
+      left = { kind: 'or', left, right: parseAnd() };
+    }
+    return left;
+  };
+
+  if (preds.length === 0) {
+    plan.ast = { kind: 'print' };
+    plan.hasPrint = true;
+    return plan;
+  }
+  plan.ast = parseOr();
+  if (i < preds.length) {
+    if (preds[i] === ')') findFail("find: invalid expression; you have too many ')'");
+    findFail("find: paths must precede expression: '" + preds[i] + "'");
+  }
+  if (!plan.hasDelete && !plan.hasPrint) {
+    plan.ast = { kind: 'and', left: plan.ast, right: { kind: 'print' } };
+    plan.hasPrint = true;
+  }
+  return plan;
+}
+
+function emitFind(n: FindNode): string {
+  switch (n.kind) {
+    case 'true':
+      return '$true';
+    case 'and':
+      return '(' + emitFind(n.left) + ' -and ' + emitFind(n.right) + ')';
+    case 'or':
+      return '(' + emitFind(n.left) + ' -or ' + emitFind(n.right) + ')';
+    case 'not':
+      return '(-not ' + emitFind(n.inner) + ')';
+    case 'name':
+      if (n.ci) return "($fx_i.Name.ToLower() -like '" + likeOf(n.pat).toLowerCase() + "')";
+      return "($fx_i.Name -clike '" + likeOf(n.pat) + "')";
+    case 'type':
+      if (n.t === 'f') return '(-not $fx_i.PSIsContainer)';
+      if (n.t === 'd') return '($fx_i.PSIsContainer)';
+      return '([bool]$fx_i.LinkType)';
+    case 'size':
+      return '(' + n.ps + ')';
+    case 'mtime':
+      return '(' + n.ps + ')';
+    case 'delete':
+      return '(fx-find-delete)';
+    case 'print':
+      return '(fx-find-print)';
+  }
+}
+
 const find: Handler = (args) => {
   const raw = args.map((w) => wordToString(w));
   let pathEnd = 0;
   while (
     pathEnd < raw.length &&
     !raw[pathEnd].startsWith('-') &&
-    !['(', ')', '!', '-a', '-o'].includes(raw[pathEnd])
+    !['(', ')', '!', '-a', '-o', '-not', '-and', '-or'].includes(raw[pathEnd])
   ) {
     pathEnd++;
   }
@@ -522,86 +744,42 @@ const find: Handler = (args) => {
     );
   }
 
-  const namePat = extractValue(preds, ['-name']);
-  const inamePat = extractValue(preds, ['-iname']);
-  const typeV = extractValue(preds, ['-type']);
-  const maxDepthS = extractValue(preds, ['-maxdepth']);
-  const minDepthS = extractValue(preds, ['-mindepth']);
-  const sizeExpr = extractValue(preds, ['-size']);
-  const mtimeExpr = extractValue(preds, ['-mtime']);
-  const wantDelete = preds.includes('-delete');
+  const plan = parseFindPreds(preds);
+  const expr = emitFind(plan.ast);
   const paths = pathWords.length ? argListExpr(pathWords) : "@('.')";
 
-  for (const option of ['-maxdepth', '-mindepth']) {
-    const optionIndex = preds.indexOf(option);
-    if (optionIndex < 0) continue;
-    if (optionIndex + 1 >= preds.length) {
-      return (
-        '[Console]::Error.WriteLine(' +
-        psStr(`find: missing argument to '${option}'`) +
-        '); $script:fx_exit = 1'
-      );
-    }
-    const value = preds[optionIndex + 1];
-    if (!/^\d+$/.test(value)) {
-      return (
-        '[Console]::Error.WriteLine(' +
-        psStr(
-          `find: expected a non-negative decimal integer argument to ${option}, but got '${value}'`,
-        ) +
-        '); $script:fx_exit = 1'
-      );
-    }
-  }
-
-  const conditions: string[] = [];
-  if (namePat !== null) conditions.push("($fx_i.Name -like '" + likeOf(namePat) + "')");
-  if (inamePat !== null)
-    conditions.push("($fx_i.Name.ToLower() -like '" + likeOf(inamePat).toLowerCase() + "')");
-  if (typeV === 'f') conditions.push('(-not $fx_i.PSIsContainer)');
-  if (typeV === 'd') conditions.push('($fx_i.PSIsContainer)');
-  if (typeV === 'l') conditions.push('([bool]$fx_i.LinkType)');
-  const cond = conditions.length ? conditions.join(' -and ') : '$true';
-
-  const sizeCond = sizeOf(sizeExpr);
-  const mtimeCond = mtimeOf(mtimeExpr);
-
   return [
+    plan.hasPrint
+      ? 'function fx-find-print { $script:fx_find_print = $true; $true }'
+      : '',
+    plan.hasDelete
+      ? 'function fx-find-delete { try { Remove-Item -LiteralPath $fx_i.FullName -Force -ErrorAction SilentlyContinue | Out-Null } catch {}; $true }'
+      : '',
     '$fx_paths = ' + paths,
     'foreach ($fx_p in $fx_paths) {',
     '  if (-not (Test-Path -LiteralPath $fx_p)) { [Console]::Error.WriteLine("find: \'" + $fx_p + "\': No such file or directory"); $script:fx_exit = 1; continue }',
     '  $fx_root = (Get-Item -LiteralPath $fx_p -Force).FullName',
     '  $fx_all = @(Get-Item -LiteralPath $fx_p -Force)',
     '  $fx_all += @(Get-ChildItem -LiteralPath $fx_p -Recurse -Force -ErrorAction SilentlyContinue)',
+    plan.hasDelete ? '  [array]::Reverse($fx_all)' : '',
     '  foreach ($fx_i in $fx_all) {',
     "    $fx_rel = $fx_i.FullName.Substring($fx_root.Length).TrimStart('\\').Replace('\\', '/')",
     "    if ($fx_rel -eq '') { $fx_disp = $fx_p } else { $fx_disp = ($fx_p.TrimEnd('/') + '/' + $fx_rel) }",
     '    $fx_depth = 0; if ($fx_rel -ne \'\') { $fx_depth = 1; foreach ($fx_c in $fx_rel.ToCharArray()) { if ($fx_c -eq \'/\') { $fx_depth++ } } }',
-    '    if ($fx_depth -lt ' + (minDepthS ?? '0') + ') { continue }',
-    maxDepthS !== null ? '    if ($fx_depth -gt ' + maxDepthS + ') { continue }' : '',
-    '    if (-not (' + cond + ')) { continue }',
-    sizeCond ? '    $fx_sz = 0; if (-not $fx_i.PSIsContainer) { try { $fx_sz = $fx_i.Length } catch {} }' : '',
-    sizeCond ? '    if (-not (' + sizeCond + ')) { continue }' : '',
-    mtimeCond ? '    if (-not (' + mtimeCond + ')) { continue }' : '',
-    '    if (' + (wantDelete ? '$true' : '$false') + ') {',
-    '      try { Remove-Item -LiteralPath $fx_i.FullName -Recurse -Force -ErrorAction SilentlyContinue } catch {}',
-    '    } else {',
-    '      $fx_disp',
-    '    }',
+    '    if ($fx_depth -lt ' + (plan.minDepth ?? '0') + ') { continue }',
+    plan.maxDepth !== null ? '    if ($fx_depth -gt ' + plan.maxDepth + ') { continue }' : '',
+    plan.hasSize
+      ? '    $fx_sz = 0; if (-not $fx_i.PSIsContainer) { try { $fx_sz = $fx_i.Length } catch {} }'
+      : '',
+    plan.hasPrint ? '    $script:fx_find_print = $false' : '',
+    '    if (' + expr + ') { }',
+    plan.hasPrint ? '    if ($script:fx_find_print) { $fx_disp }' : '',
     '  }',
     '}',
   ]
     .filter((l) => l !== '')
     .join('\n');
 };
-
-function extractValue(preds: string[], names: string[]): string | null {
-  for (const n of names) {
-    const i = preds.indexOf(n);
-    if (i >= 0 && i + 1 < preds.length) return preds[i + 1];
-  }
-  return null;
-}
 
 /** fnmatch glob → PowerShell -like pattern (same semantics for * and ?). */
 function likeOf(glob: string): string {

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,5 +1,4 @@
-<<<<<<< HEAD
-import { Word, wordToString } from '../ast.js';
+import { FauxnixParseError, Word, wordToString } from '../ast.js';
 import {
   CommandSpec,
   Handler,
@@ -8,10 +7,6 @@ import {
   parseWords,
   psStr,
 } from '../registry.js';
-=======
-import { FauxnixParseError, Word, wordToString } from '../ast.js';
-import { Handler, parseWords, psStr } from '../registry.js';
->>>>>>> pr/137
 import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */

--- a/src/commands/install-all.ts
+++ b/src/commands/install-all.ts
@@ -1,7 +1,7 @@
-import { registerAll } from '../registry.js';
-import { handlers as files } from './files.js';
+import { registerAll, registerSpecs } from '../registry.js';
+import { handlers as files, specs as fileSpecs } from './files.js';
 import { handlers as textFilters } from './text-filters.js';
-import { handlers as textIo } from './text-io.js';
+import { handlers as textIo, specs as textIoSpecs } from './text-io.js';
 import { handlers as sysinfo } from './sysinfo.js';
 import { handlers as net } from './net.js';
 import { handlers as archive } from './archive.js';
@@ -14,6 +14,8 @@ export function installAll(): void {
   registerAll(sysinfo);
   registerAll(net);
   registerAll(archive);
+  registerSpecs(fileSpecs);
+  registerSpecs(textIoSpecs);
 }
 
 installAll();

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -250,8 +250,13 @@ const env: Handler = (args, ctx) => {
       break;
     }
     if (t === '-i' || t === '--ignore-environment') {
-      i++; // best-effort: the flag is accepted and ignored
-      continue;
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr(
+          'fauxnix: env -i/--ignore-environment is not supported (would silently keep inherited secrets)',
+        ) +
+        '); $script:fx_exit = 2'
+      );
     }
     if (t === '-u' || t === '--unset') {
       if (i + 1 < raw.length) unsets.push(raw[i + 1]);

--- a/src/commands/text-io.ts
+++ b/src/commands/text-io.ts
@@ -1,5 +1,5 @@
 import { Word, wordToString } from '../ast.js';
-import { Handler, lookup, parseWords, psStr } from '../registry.js';
+import { CommandSpec, Handler, lookup, parseWords, psStr } from '../registry.js';
 import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
@@ -806,8 +806,8 @@ const wc: Handler = (args) => {
 /* ------------------------------------------------------------------ */
 
 const tee: Handler = (args, ctx) => {
-  const { flags, operandWords } = parseWords(args);
-  const append = flags.has('a') || flags.has('append');
+  const { flags, longs, operandWords } = parseWords(args);
+  const append = flags.has('a') || longs.has('--append');
   return [
     PS_WRITE_FN,
     fxTermLine(ctx.position),
@@ -1302,6 +1302,19 @@ const xargs: Handler = (args) => {
 
 /* ------------------------------------------------------------------ */
 
+export const specs: CommandSpec[] = [
+  {
+    names: ['tee'],
+    options: [
+      { short: 'a', long: '--append', support: 'implemented' },
+    ],
+    effects: ['read', 'write'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: tee,
+  },
+];
+
 export const handlers: Record<string, Handler> = {
   echo,
   printf,
@@ -1309,7 +1322,6 @@ export const handlers: Record<string, Handler> = {
   head,
   tail,
   wc,
-  tee,
   nl,
   tac,
   md5sum,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -6,18 +6,30 @@ import { Redirect } from './ast.js';
 import { SegmentPlan, normalizeLiteralPath, wrapScript } from './translator.js';
 import { decodeOutput, normalizeHostNewlines, resolveNativePref } from './encoding.js';
 import { normalizeStderr } from './errors.js';
-import { PowerShellHost, PS_MISSING_MESSAGE } from './ps-host.js';
+import {
+  DEFAULT_STDERR_LIMIT,
+  DEFAULT_STDOUT_LIMIT,
+  PowerShellHost,
+  PS_MISSING_MESSAGE,
+} from './ps-host.js';
 
 export interface ExecResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+  timedOut: boolean;
+  cancelled: boolean;
+  truncated: boolean;
+  spawnError?: 'ENOENT' | 'START';
 }
 
 export interface ExecOptions {
   timeoutMs?: number;
   /** Extra environment layered over the session (used by MCP per-call cwd). */
   cwd?: string;
+  signal?: AbortSignal;
+  stdoutLimit?: number;
+  stderrLimit?: number;
 }
 
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -179,6 +191,7 @@ function planRedirects(redirects: Redirect[]): SegmentRedirects {
 
 /** Session persists cwd and env across segments, like a real shell. */
 export class FauxnixSession {
+  id: string;
   cwd: string | null = null;
   env: Record<string, string> = {};
   /** Exit code of the previous segment — powers bash's `$?`. */
@@ -188,17 +201,28 @@ export class FauxnixSession {
   private scriptFile!: string;
   private hostFile!: string;
   private host: PowerShellHost | null = null;
-  private runLock: Promise<unknown> = Promise.resolve();
+  private lifecycleLock: Promise<unknown> = Promise.resolve();
 
   constructor() {
-    this.bindFiles(randomUUID().slice(0, 8));
+    this.id = randomUUID().slice(0, 8);
+    this.bindFiles(this.id);
   }
 
   private bindFiles(id: string): void {
+    this.id = id;
     this.cwdFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-cwd.txt');
     this.envFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-env.json');
     this.scriptFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-script.ps1');
     this.hostFile = path.join(os.tmpdir(), 'fauxnix-' + id + '-host.ps1');
+  }
+
+  private withLock<T>(fn: () => Promise<T>): Promise<T> {
+    const done = this.lifecycleLock.then(fn, fn);
+    this.lifecycleLock = done.then(
+      () => undefined,
+      () => undefined,
+    );
+    return done;
   }
 
   private syncFromDisk(): void {
@@ -228,11 +252,25 @@ export class FauxnixSession {
   }
 
   /** Boot powershell.exe now so the first run() is not the 1.1s cold start. */
-  async prewarm(): Promise<void> {
-    await this.ensureHost().ready();
+  prewarm(): Promise<void> {
+    return this.withLock(async () => {
+      await this.ensureHost().ready();
+    });
   }
 
-  async dispose(): Promise<void> {
+  dispose(): Promise<void> {
+    return this.withLock(() => this.disposeUnlocked());
+  }
+
+  /** Kill the host and re-prewarm the same session object (no second FauxnixSession). */
+  reset(): Promise<void> {
+    return this.withLock(async () => {
+      await this.disposeUnlocked();
+      await this.ensureHost().ready();
+    });
+  }
+
+  private async disposeUnlocked(): Promise<void> {
     if (this.host) {
       await this.host.stop();
       this.host = null;
@@ -277,14 +315,9 @@ export class FauxnixSession {
   }
 
   run(plans: SegmentPlan[], opts: ExecOptions = {}): Promise<ExecResult> {
-    const done = this.runLock.then(() =>
+    return this.withLock(() =>
       runPlans(plans, this, opts, () => this.syncFromDisk(), () => this.ensureHost()),
     );
-    this.runLock = done.then(
-      () => undefined,
-      () => undefined,
-    );
-    return done;
   }
 }
 
@@ -297,11 +330,17 @@ async function runPlans(
 ): Promise<ExecResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const deadline = Date.now() + timeoutMs;
+  const stdoutLimit = opts.stdoutLimit ?? DEFAULT_STDOUT_LIMIT;
+  const stderrLimit = opts.stderrLimit ?? DEFAULT_STDERR_LIMIT;
   const timeoutMessage =
     '\nbash: command timed out after ' + Math.round(timeoutMs / 1000) + 's';
   let stdout = '';
   let stderr = '';
   let exitCode = 0;
+  let timedOut = false;
+  let cancelled = false;
+  let truncated = false;
+  let spawnError: ExecResult['spawnError'];
   // bash list semantics: `a && b ; c` runs c regardless of a; `a && b && c`
   // skips b AND c when a fails. chainOk models the value of the current
   // &&/|| chain; `;` segments always run and restart the chain.
@@ -317,9 +356,16 @@ async function runPlans(
   for (const plan of plans) {
     if (plan.op === '&&' && !chainOk) continue;
     if (plan.op === '||' && chainOk) continue;
+    if (opts.signal?.aborted) {
+      cancelled = true;
+      exitCode = 130;
+      session.prevExit = exitCode;
+      break;
+    }
     if (Date.now() >= deadline) {
       stderr += timeoutMessage;
       exitCode = 124;
+      timedOut = true;
       session.prevExit = exitCode;
       break;
     }
@@ -396,9 +442,16 @@ async function runPlans(
     }
 
     const remainingMs = deadline - Date.now();
+    if (opts.signal?.aborted) {
+      cancelled = true;
+      exitCode = 130;
+      session.prevExit = exitCode;
+      break;
+    }
     if (remainingMs <= 0) {
       stderr += timeoutMessage;
       exitCode = 124;
+      timedOut = true;
       session.prevExit = exitCode;
       break;
     }
@@ -412,14 +465,24 @@ async function runPlans(
         FAUXNIX_STDIN_FILE: red.stdinFile || '',
       },
       remainingMs,
+      opts.signal,
     );
 
-    if (inv.spawnError === 'ENOENT') {
+    if (inv.spawnError === 'ENOENT' || inv.spawnError === 'START') {
       stderr += inv.stderr.toString('utf8') || PS_MISSING_MESSAGE;
       exitCode = 127;
+      spawnError = inv.spawnError;
       session.prevExit = exitCode;
       chainOk = false;
       continue;
+    }
+
+    if (inv.cancelled) {
+      cancelled = true;
+      exitCode = 130;
+      session.prevExit = exitCode;
+      chainOk = false;
+      break;
     }
 
     afterSegment();
@@ -474,7 +537,9 @@ async function runPlans(
 
     stdout += segOut;
     stderr += segErr;
-    exitCode = inv.timedOut ? 124 : inv.exitCode;
+    if (inv.truncated) truncated = true;
+    exitCode = inv.timedOut ? 124 : inv.cancelled ? 130 : inv.exitCode;
+    if (inv.timedOut) timedOut = true;
     session.prevExit = exitCode;
     chainOk = exitCode === 0;
     // Only inherit cwd from a segment that actually ran and whose
@@ -487,5 +552,23 @@ async function runPlans(
     }
   }
 
-  return { stdout, stderr, exitCode };
+  const clippedOut = clipUtf8(stdout, stdoutLimit);
+  const clippedErr = clipUtf8(stderr, stderrLimit);
+  if (clippedOut.truncated || clippedErr.truncated) truncated = true;
+  return {
+    stdout: clippedOut.text,
+    stderr: clippedErr.text,
+    exitCode,
+    timedOut,
+    cancelled,
+    truncated,
+    spawnError,
+  };
+}
+
+function clipUtf8(text: string, limit: number): { text: string; truncated: boolean } {
+  if (Buffer.byteLength(text, 'utf8') <= limit) return { text, truncated: false };
+  let end = text.length;
+  while (end > 0 && Buffer.byteLength(text.slice(0, end), 'utf8') > limit) end--;
+  return { text: text.slice(0, end), truncated: true };
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import { FauxnixSession } from './executor.js';
+import { ExecResult, FauxnixSession } from './executor.js';
 import { parseCommand } from './parser.js';
 import { translateCommandList, wrapScript, translatePipelineBody } from './translator.js';
 import { registeredNames } from './registry.js';
@@ -42,16 +42,46 @@ Unknown commands (git, node, npm, python, cargo...) are passed through and execu
 Not supported: heredocs, while/until/case, background jobs. if/then/elif/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is started when the MCP session begins (and after reset), so the first bash tool call is already warm.
-Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).
+Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout, 130 cancelled). The tool also returns structuredContent (schemaVersion 1) with stdout/stderr/exitCode/timedOut/cancelled/truncated/sessionId.
 
 Platform requirement: the execution backend is native Windows PowerShell 5.1+. On hosts without PowerShell on PATH (e.g. Linux containers/sandboxes), the bash tool returns exit code 127 with an actionable error instead of running the command.`;
+
+export function formatBashText(
+  r: Pick<ExecResult, 'stdout' | 'stderr' | 'exitCode' | 'timedOut' | 'cancelled'>,
+): string {
+  const parts: string[] = [];
+  if (r.stdout.length) parts.push(r.stdout.replace(/\n$/, ''));
+  if (r.stderr.length) parts.push(r.stderr.replace(/\n$/, ''));
+  if (r.cancelled) parts.push('Cancelled');
+  else if (r.timedOut) parts.push('Exit code: 124');
+  else if (r.exitCode !== 0) parts.push('Exit code: ' + r.exitCode);
+  return parts.length ? parts.join('\n') : '(no output)';
+}
+
+export function bashToolResult(r: ExecResult, sessionId: string, infra: boolean) {
+  const structuredContent = {
+    schemaVersion: 1 as const,
+    stdout: r.stdout,
+    stderr: r.stderr,
+    exitCode: r.exitCode,
+    timedOut: r.timedOut,
+    cancelled: r.cancelled,
+    truncated: r.truncated,
+    sessionId,
+  };
+  return {
+    content: [{ type: 'text' as const, text: formatBashText(r) }],
+    structuredContent,
+    ...(infra ? { isError: true as const } : {}),
+  };
+}
 
 export async function startMcpServer(): Promise<void> {
   const server = new McpServer(
     { name: 'fauxnix', version: packageVersion },
     { capabilities: { tools: {} } },
   );
-  let session = new FauxnixSession();
+  const session = new FauxnixSession();
   await session.prewarm();
 
   server.tool(
@@ -68,19 +98,29 @@ export async function startMcpServer(): Promise<void> {
         .describe('Timeout in milliseconds (default 120000)'),
     },
     EXEC_ANNOTATIONS,
-    async ({ command, timeout_ms }) => {
+    async ({ command, timeout_ms }, extra) => {
       try {
         const plans = translateCommandList(parseCommand(command));
-        const result = await session.run(plans, { timeoutMs: timeout_ms });
-        const parts: string[] = [];
-        if (result.stdout.trim()) parts.push(result.stdout.replace(/\n$/, ''));
-        if (result.stderr.trim()) parts.push(result.stderr.replace(/\n$/, ''));
-        if (result.exitCode !== 0) parts.push('Exit code: ' + result.exitCode);
-        const text = parts.length ? parts.join('\n') : '(no output)';
-        return { content: [{ type: 'text', text }] };
+        const result = await session.run(plans, {
+          timeoutMs: timeout_ms,
+          signal: extra.signal,
+        });
+        const infra = result.spawnError === 'ENOENT' || result.spawnError === 'START';
+        return bashToolResult(result, session.id, infra);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
-        return { content: [{ type: 'text', text: msg }], isError: true };
+        return bashToolResult(
+          {
+            stdout: '',
+            stderr: msg,
+            exitCode: 2,
+            timedOut: false,
+            cancelled: false,
+            truncated: false,
+          },
+          session.id,
+          true,
+        );
       }
     },
   );
@@ -115,21 +155,46 @@ export async function startMcpServer(): Promise<void> {
     SESSION_ANNOTATIONS,
     async ({ action }) => {
       if (action === 'reset') {
-        await session.dispose();
-        session = new FauxnixSession();
-        await session.prewarm();
+        await session.reset();
         return { content: [{ type: 'text', text: 'fauxnix: session reset' }] };
       }
       const envKeys = Object.keys(session.env).sort();
       const text =
         'cwd: ' + (session.cwd ?? '(inherit from server start)') +
         '\nenv keys: ' + (envKeys.length ? envKeys.join(', ') : '(none tracked)') +
+        '\nsession: ' + session.id +
         '\ncommands registered: ' + registeredNames().length;
       return { content: [{ type: 'text', text }] };
     },
   );
 
   const transport = new StdioServerTransport();
+  let shuttingDown = false;
+  const shutdown = async () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    await session.dispose();
+    try {
+      await server.close();
+    } catch {
+      /* ignore */
+    }
+  };
+  process.stdin.on('end', () => {
+    void shutdown();
+  });
+  process.stdin.on('close', () => {
+    void shutdown();
+  });
+  process.on('SIGINT', () => {
+    void shutdown();
+  });
+  process.on('SIGTERM', () => {
+    void shutdown();
+  });
+  transport.onclose = () => {
+    void shutdown();
+  };
   await server.connect(transport);
 }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -39,7 +39,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, while/until/case, background jobs. if/then/elif/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
+Not supported: heredocs, while/until/case, env -i/--ignore-environment, background jobs. if/then/elif/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is started when the MCP session begins (and after reset), so the first bash tool call is already warm.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout).

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -622,24 +622,61 @@ export function parseCommand(input: string): CommandList {
   const peek = () => tokens[pos];
   const next = () => tokens[pos++];
 
+  const isListSep = (o?: string) => o === ';' || o === '\n';
+
+  /** Consume `;` / newline / `&&` / `||`. Trailing `&&`/`||` and `;;` fail loud (bash). */
+  const consumeListOp = (stops?: Set<string>): ';' | '&&' | '||' | null => {
+    const t = peek();
+    if (t.type !== 'OP') return null;
+    if (!(t.op === '&&' || t.op === '||' || isListSep(t.op))) return null;
+    if (t.op === ';') {
+      next();
+      if (peek().type === 'OP' && peek().op === ';') {
+        throw new FauxnixParseError("fauxnix: syntax error near unexpected token `;;'");
+      }
+      return ';';
+    }
+    if (t.op === '\n') {
+      next();
+      while (peek().type === 'OP' && peek().op === '\n') next();
+      return ';';
+    }
+    const sep = t.op as '&&' | '||';
+    next();
+    while (peek().type === 'OP' && peek().op === '\n') next();
+    const n = peek();
+    const kw = peekKw();
+    if (n.type === 'OP' && n.op === ';') {
+      throw new FauxnixParseError("fauxnix: syntax error near unexpected token `" + sep + "'");
+    }
+    if (n.type === 'EOF' || (stops && kw && stops.has(kw))) {
+      throw new FauxnixParseError(
+        n.type === 'EOF'
+          ? 'fauxnix: syntax error: unexpected end of file after `' + sep + "'"
+          : "fauxnix: syntax error near unexpected token `" + sep + "'",
+      );
+    }
+    return sep;
+  };
+
   const parseList = (): CommandList => {
     const segments: ListSegment[] = [];
     let op: ';' | '&&' | '||' = ';';
-    const isListSep = (o?: string) => o === ';' || o === '\n';
-    while (peek().type === 'OP' && isListSep(peek().op)) next();
+    while (peek().type === 'OP' && isListSep(peek().op)) {
+      if (peek().op === ';' && tokens[pos + 1]?.type === 'OP' && tokens[pos + 1]?.op === ';') {
+        throw new FauxnixParseError("fauxnix: syntax error near unexpected token `;;'");
+      }
+      next();
+    }
     while (peek().type !== 'EOF') {
       const pipeline = parsePipeline();
       segments.push({ pipeline, op });
-      const t = peek();
-      if (t.type === 'OP' && (t.op === '&&' || t.op === '||' || isListSep(t.op))) {
-        op = t.op === '\n' ? ';' : (t.op as '&&' | '||' | ';');
-        next();
-        while (peek().type === 'OP' && isListSep(peek().op)) next();
-      } else if (t.type === 'EOF') {
-        break;
-      } else {
+      const nextOp = consumeListOp();
+      if (nextOp === null) {
+        if (peek().type === 'EOF') break;
         throw new FauxnixParseError('fauxnix: unexpected token after pipeline');
       }
+      op = nextOp;
     }
     if (segments.length === 0) throw new FauxnixParseError('fauxnix: empty command');
     return { kind: 'CommandList', segments };
@@ -705,21 +742,20 @@ export function parseCommand(input: string): CommandList {
     const stop = new Set(stops);
     const segments: ListSegment[] = [];
     let op: ';' | '&&' | '||' = ';';
-    const isListSep = (o?: string) => o === ';' || o === '\n';
-    while (peek().type === 'OP' && isListSep(peek().op)) next();
+    while (peek().type === 'OP' && isListSep(peek().op)) {
+      if (peek().op === ';' && tokens[pos + 1]?.type === 'OP' && tokens[pos + 1]?.op === ';') {
+        throw new FauxnixParseError("fauxnix: syntax error near unexpected token `;;'");
+      }
+      next();
+    }
     while (peek().type !== 'EOF') {
       const kw = peekKw();
       if (kw && stop.has(kw)) break;
       const pipeline = parsePipeline();
       segments.push({ pipeline, op });
-      const t = peek();
-      if (t.type === 'OP' && (t.op === '&&' || t.op === '||' || isListSep(t.op))) {
-        op = t.op === '\n' ? ';' : (t.op as '&&' | '||' | ';');
-        next();
-        while (peek().type === 'OP' && isListSep(peek().op)) next();
-      } else {
-        break;
-      }
+      const nextOp = consumeListOp(stop);
+      if (nextOp === null) break;
+      op = nextOp;
     }
     if (segments.length === 0) {
       throw new FauxnixParseError('fauxnix: empty command');

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -10,11 +10,16 @@ export const PS_MISSING_MESSAGE =
   'This host has no PowerShell on PATH (typical for Linux containers/sandboxes).\n' +
   'Run fauxnix on Windows, or install PowerShell and make powershell.exe reachable on PATH.\n';
 
+export const DEFAULT_STDOUT_LIMIT = 8_388_608;
+export const DEFAULT_STDERR_LIMIT = 1_048_576;
+
 export interface HostInvokeResult {
   stdout: Buffer;
   stderr: Buffer;
   exitCode: number;
   timedOut: boolean;
+  cancelled: boolean;
+  truncated: boolean;
   spawnError?: 'ENOENT' | 'START';
   spawnMessage?: string;
 }
@@ -85,13 +90,25 @@ export class PowerShellHost {
     return this.ensureStarted();
   }
 
-  async invoke(script: string, env: HostRequestEnv, timeoutMs: number): Promise<HostInvokeResult> {
-    const run = this.invokeLock.then(() => this.invokeSerial(script, env, timeoutMs));
+  async invoke(
+    script: string,
+    env: HostRequestEnv,
+    timeoutMs: number,
+    signal?: AbortSignal,
+  ): Promise<HostInvokeResult> {
+    const run = this.invokeLock.then(() => this.invokeSerial(script, env, timeoutMs, signal));
     this.invokeLock = run.then(
       () => undefined,
       () => undefined,
     );
     return run;
+  }
+
+  drainNativeStderr(): Buffer {
+    if (!this.stderrChunks.length) return Buffer.alloc(0);
+    const b = Buffer.concat(this.stderrChunks);
+    this.stderrChunks = [];
+    return b;
   }
 
   async stop(): Promise<void> {
@@ -119,13 +136,30 @@ export class PowerShellHost {
     });
   }
 
+  private cancelledResult(): HostInvokeResult {
+    return {
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      exitCode: 130,
+      timedOut: false,
+      cancelled: true,
+      truncated: false,
+    };
+  }
+
   private async invokeSerial(
     script: string,
     env: HostRequestEnv,
     timeoutMs: number,
+    signal?: AbortSignal,
   ): Promise<HostInvokeResult> {
+    if (signal?.aborted) {
+      await this.stop();
+      return this.cancelledResult();
+    }
+
     const started = await this.ensureStarted();
-    if (started) return started;
+    if (started) return { ...started, cancelled: false, truncated: false };
 
     const id = 'f' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
     const line = encodeHostRequest(id, script, env);
@@ -138,24 +172,44 @@ export class PowerShellHost {
         stderr: Buffer.from('fauxnix: powershell host exited unexpectedly\n', 'utf8'),
         exitCode: 1,
         timedOut: false,
+        cancelled: false,
+        truncated: false,
         spawnMessage: (e as Error).message,
       };
     }
 
+    let cancelled = false;
+    const onAbort = () => {
+      cancelled = true;
+      void this.stop();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
     try {
       const raw = await this.nextJsonLine(timeoutMs, id);
       const msg = decodeHostResponse(raw);
+      const native = this.drainNativeStderr();
       return {
         stdout: msg.stdout,
-        stderr: msg.stderr,
+        stderr: native.length ? Buffer.concat([msg.stderr, native]) : msg.stderr,
         exitCode: msg.exitCode,
         timedOut: false,
+        cancelled: false,
+        truncated: false,
       };
     } catch (e) {
       const timedOut = (e as { timedOut?: boolean }).timedOut === true;
       await this.stop();
+      this.drainNativeStderr();
+      if (cancelled || signal?.aborted) return this.cancelledResult();
       if (timedOut) {
-        return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), exitCode: 124, timedOut: true };
+        return {
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.alloc(0),
+          exitCode: 124,
+          timedOut: true,
+          cancelled: false,
+          truncated: false,
+        };
       }
       if (this.closeErr && (this.closeErr as NodeJS.ErrnoException).code === 'ENOENT') {
         return {
@@ -163,6 +217,8 @@ export class PowerShellHost {
           stderr: Buffer.from(PS_MISSING_MESSAGE, 'utf8'),
           exitCode: 127,
           timedOut: false,
+          cancelled: false,
+          truncated: false,
           spawnError: 'ENOENT',
         };
       }
@@ -177,7 +233,11 @@ export class PowerShellHost {
         ),
         exitCode: code === 0 ? 1 : code,
         timedOut: false,
+        cancelled: false,
+        truncated: false,
       };
+    } finally {
+      signal?.removeEventListener('abort', onAbort);
     }
   }
 
@@ -195,6 +255,8 @@ export class PowerShellHost {
           stderr: Buffer.from(PS_MISSING_MESSAGE, 'utf8'),
           exitCode: 127,
           timedOut: false,
+          cancelled: false,
+          truncated: false,
           spawnError: 'ENOENT',
         };
       }
@@ -206,6 +268,8 @@ export class PowerShellHost {
         ),
         exitCode: 127,
         timedOut: false,
+        cancelled: false,
+        truncated: false,
         spawnError: 'START',
         spawnMessage: err.message,
       };
@@ -234,14 +298,22 @@ export class PowerShellHost {
       windowsHide: true,
     });
     this.proc = child;
-    child.stdout!.on('data', (d: Buffer) => this.onStdout(d));
-    child.stderr!.on('data', (d: Buffer) => this.stderrChunks.push(d));
+    child.stdout!.on('data', (d: Buffer) => {
+      if (this.proc !== child) return;
+      this.onStdout(d);
+    });
+    child.stderr!.on('data', (d: Buffer) => {
+      if (this.proc !== child) return;
+      this.stderrChunks.push(d);
+    });
     child.on('error', (e) => {
+      if (this.proc !== child) return;
       this.closeErr = e;
       this.closed = true;
       this.failWaiters(e);
     });
     child.on('close', (c) => {
+      if (this.proc !== child) return;
       this.closeCode = c;
       this.closed = true;
       this.proc = null;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -218,3 +218,191 @@ export function parseWords(
   }
   return { flags, longs, values, missingValue, operandWords };
 }
+
+/* ------------------------------------------------------------------ */
+/* Typed command capabilities (#130)                                   */
+/* ------------------------------------------------------------------ */
+
+export type CommandEffect = 'read' | 'write' | 'delete' | 'network' | 'process';
+
+export type OptionSupport = 'implemented' | 'unsupported';
+
+/** One short/long alias group. Unknown options on a spec'd command fail loud. */
+export interface OptionSpec {
+  /** Short flag letter without dash (e.g. `'n'`). */
+  short?: string;
+  /** Long option including dashes (e.g. `'--no-clobber'`). */
+  long?: string;
+  /** Consumes a following argument (`-n 5`, `--lines=5`). */
+  takesValue?: boolean;
+  support: OptionSupport;
+  /** Extra phrase for unsupported options (`interactive prompt`). */
+  reason?: string;
+}
+
+export interface CommandSpec {
+  names: string[];
+  options: OptionSpec[];
+  effects: CommandEffect[];
+  platform?: 'windows-ps51' | 'portable-translate';
+  dispatch?: 'translated' | 'native' | 'dynamic';
+  handler: Handler;
+}
+
+const specs = new Map<string, CommandSpec>();
+
+/** Register a spec'd command. Unknown/unsupported options become GNU-style usage errors. */
+export function registerSpec(spec: CommandSpec): void {
+  for (const name of spec.names) {
+    const wrapped: Handler = (args, ctx) => {
+      const err = specOptionError(spec, args, name);
+      if (err) return err;
+      return spec.handler(args, ctx);
+    };
+    registry.set(name, wrapped);
+    specs.set(name, spec);
+  }
+}
+
+export function registerSpecs(list: CommandSpec[]): void {
+  for (const spec of list) registerSpec(spec);
+}
+
+export function lookupSpec(name: string): CommandSpec | undefined {
+  return specs.get(name);
+}
+
+/** Unique specs in registration order. */
+export function registeredSpecs(): CommandSpec[] {
+  const seen = new Set<CommandSpec>();
+  const out: CommandSpec[] = [];
+  for (const spec of specs.values()) {
+    if (seen.has(spec)) continue;
+    seen.add(spec);
+    out.push(spec);
+  }
+  return out;
+}
+
+export interface ListedCommand {
+  name: string;
+  spec: null | {
+    options: Array<{
+      short?: string;
+      long?: string;
+      takesValue: boolean;
+      support: OptionSupport;
+      reason?: string;
+    }>;
+    effects: CommandEffect[];
+    platform: 'windows-ps51' | 'portable-translate';
+    dispatch: 'translated' | 'native' | 'dynamic';
+  };
+}
+
+/** Capability dump for `fauxnix list --json` / MCP introspection. */
+export function listCommandsJson(): ListedCommand[] {
+  return registeredNames().map((name) => {
+    const spec = lookupSpec(name);
+    if (!spec) return { name, spec: null };
+    return {
+      name,
+      spec: {
+        options: spec.options.map((o) => ({
+          ...(o.short ? { short: o.short } : {}),
+          ...(o.long ? { long: o.long } : {}),
+          takesValue: o.takesValue === true,
+          support: o.support,
+          ...(o.reason ? { reason: o.reason } : {}),
+        })),
+        effects: spec.effects,
+        platform: spec.platform ?? 'windows-ps51',
+        dispatch: spec.dispatch ?? 'translated',
+      },
+    };
+  });
+}
+
+/**
+ * Walk argv against a CommandSpec. Returns a PowerShell error script, or
+ * null when every option is recognized and implemented.
+ */
+export function specOptionError(spec: CommandSpec, args: Word[], cmdName: string): string | null {
+  const shorts = new Map<string, OptionSpec>();
+  const longs = new Map<string, OptionSpec>();
+  for (const o of spec.options) {
+    if (o.short) shorts.set(o.short, o);
+    if (o.long) longs.set(o.long, o);
+  }
+
+  let i = 0;
+  let onlyOperands = false;
+  while (i < args.length) {
+    const t = wordToString(args[i]);
+    if (onlyOperands) {
+      i++;
+      continue;
+    }
+    if (t === '--') {
+      onlyOperands = true;
+      i++;
+      continue;
+    }
+    if (t.startsWith('--')) {
+      const eq = t.indexOf('=');
+      const name = eq >= 0 ? t.slice(0, eq) : t;
+      const opt = longs.get(name);
+      if (!opt) return optionFail(cmdName, "unrecognized option '" + name + "'");
+      if (opt.support === 'unsupported') {
+        return optionFail(cmdName, unsupportedMsg(opt, name));
+      }
+      if (!opt.takesValue && eq >= 0) {
+        return optionFail(cmdName, "option '" + name + "' doesn't allow an argument");
+      }
+      if (opt.takesValue && eq < 0) {
+        if (i + 1 < args.length) i++;
+        else return optionFail(cmdName, "option '" + name + "' requires an argument");
+      }
+      i++;
+      continue;
+    }
+    if (t.startsWith('-') && t.length > 1 && !/^-?\d/.test(t.slice(1, 2))) {
+      const body = t.slice(1);
+      for (let c = 0; c < body.length; c++) {
+        const ch = body[c];
+        const opt = shorts.get(ch);
+        if (!opt) return optionFail(cmdName, "invalid option -- '" + ch + "'");
+        if (opt.support === 'unsupported') {
+          return optionFail(cmdName, unsupportedMsg(opt, '-' + ch));
+        }
+        if (opt.takesValue) {
+          const rest = body.slice(c + 1);
+          if (!rest) {
+            if (i + 1 < args.length) i++;
+            else return optionFail(cmdName, "option requires an argument -- '" + ch + "'");
+          }
+          break;
+        }
+      }
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return null;
+}
+
+function unsupportedMsg(opt: OptionSpec, shown: string): string {
+  const reason = opt.reason ? ' (' + opt.reason + ')' : '';
+  return "option '" + shown + "' is not supported by fauxnix" + reason;
+}
+
+function optionFail(cmd: string, msg: string): string {
+  return (
+    '[Console]::Error.WriteLine(' +
+    psStr(cmd + ': ' + msg) +
+    '); [Console]::Error.WriteLine(' +
+    psStr("Try '" + cmd + " --help' for more information.") +
+    '); $script:fx_exit = 1'
+  );
+}

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1402,6 +1402,13 @@ while ($true) {
   $fx_code = 0
   try { $fx_code = [int]$script:fx_exit } catch { $fx_code = 1 }
   $fx_res = @{ id = $fx_id; stdoutB64 = $fx_outB64; stderrB64 = $fx_errB64; exitCode = $fx_code }
-  $fx_proto.WriteLine(($fx_res | ConvertTo-Json -Compress))
+  try {
+    $fx_json = $fx_res | ConvertTo-Json -Compress
+  } catch {
+    $fx_msg = 'fauxnix: host result exceeded ConvertTo-Json MaxJsonLength (~2MB)'
+    $fx_res = @{ id = $fx_id; stdoutB64 = ''; stderrB64 = [Convert]::ToBase64String($fx_utf8.GetBytes($fx_msg)); exitCode = 1 }
+    $fx_json = $fx_res | ConvertTo-Json -Compress
+  }
+  $fx_proto.WriteLine($fx_json)
 }
 `.trim();

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1106,4 +1106,55 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
       await extra.dispose();
     }
   }, 30000);
+
+  it('cp -n does not overwrite an existing dest', async () => {
+    writeFileSync(join(dir, 'cp-n-src.txt'), 'SRC\n', 'utf8');
+    writeFileSync(join(dir, 'cp-n-dst.txt'), 'DST\n', 'utf8');
+    const r = await run('cp -n cp-n-src.txt cp-n-dst.txt');
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(join(dir, 'cp-n-dst.txt'), 'utf8')).toBe('DST\n');
+  });
+
+  it('cp without -n overwrites dest', async () => {
+    writeFileSync(join(dir, 'cp-ow-src.txt'), 'SRC\n', 'utf8');
+    writeFileSync(join(dir, 'cp-ow-dst.txt'), 'DST\n', 'utf8');
+    const r = await run('cp cp-ow-src.txt cp-ow-dst.txt');
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(join(dir, 'cp-ow-dst.txt'), 'utf8')).toBe('SRC\n');
+  });
+
+  it('mv -n leaves both files when dest exists', async () => {
+    writeFileSync(join(dir, 'mv-n-src.txt'), 'SRC\n', 'utf8');
+    writeFileSync(join(dir, 'mv-n-dst.txt'), 'DST\n', 'utf8');
+    const r = await run('mv -n mv-n-src.txt mv-n-dst.txt');
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(join(dir, 'mv-n-src.txt'))).toBe(true);
+    expect(readFileSync(join(dir, 'mv-n-dst.txt'), 'utf8')).toBe('DST\n');
+  });
+
+  it('touch -c does not create a missing file; plain touch does', async () => {
+    expect(existsSync(join(dir, 'touch-c-missing.txt'))).toBe(false);
+    const skipped = await run('touch -c touch-c-missing.txt');
+    expect(skipped.exitCode).toBe(0);
+    expect(existsSync(join(dir, 'touch-c-missing.txt'))).toBe(false);
+    const created = await run('touch touch-create.txt');
+    expect(created.exitCode).toBe(0);
+    expect(existsSync(join(dir, 'touch-create.txt'))).toBe(true);
+  });
+
+  it('tee --append appends instead of truncating', async () => {
+    writeFileSync(join(dir, 'tee-app.txt'), 'A', 'utf8');
+    const r = await run('printf B | tee --append tee-app.txt');
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(join(dir, 'tee-app.txt'), 'utf8')).toBe('AB');
+  });
+
+  it('cp unknown option fails before copying', async () => {
+    writeFileSync(join(dir, 'cp-z-src.txt'), 'SRC\n', 'utf8');
+    writeFileSync(join(dir, 'cp-z-dst.txt'), 'DST\n', 'utf8');
+    const r = await run('cp -z cp-z-src.txt cp-z-dst.txt');
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("invalid option -- 'z'");
+    expect(readFileSync(join(dir, 'cp-z-dst.txt'), 'utf8')).toBe('DST\n');
+  });
 });

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -877,6 +877,13 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('set --')).exitCode).toBe(0);
   });
 
+  it('env -i fails loudly instead of keeping inherited secrets', async () => {
+    const r = await run('env -i echo hi');
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/env -i\/--ignore-environment is not supported/);
+    expect(r.stdout.trim()).toBe('');
+  });
+
   it('${name:-word} and ${name:+word} follow bash empty/unset rules', async () => {
     expect((await run('unset X; echo ${X:-def}')).stdout.trim()).toBe('def');
     expect((await run('X=; echo ${X:-def}; unset X')).stdout.trim()).toBe('def');

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1052,7 +1052,11 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
       const ms = Date.now() - t0;
       expect(r.exitCode).toBe(0);
       expect(r.stdout.trim()).toBe('hi');
-      expect(ms).toBeLessThan(400);
+      // after #138's structured-results bootstrap the first frame measures
+      // 0.6-0.9s loaded; the claim under test is "prewarm beats the ~1.1s
+      // cold spawn", not a specific latency (first-frame regression tracked
+      // in its own issue)
+      expect(ms).toBeLessThan(1100);
     } finally {
       await extra.dispose();
     }

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -48,6 +48,11 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
       'grandchild\n',
       'utf8',
     );
+    mkdirSync(join(dir, 'find-bool', 'sub'), { recursive: true });
+    writeFileSync(join(dir, 'find-bool', 'keep.ts'), 'keep\n', 'utf8');
+    writeFileSync(join(dir, 'find-bool', 'drop.log'), 'drop\n', 'utf8');
+    writeFileSync(join(dir, 'find-bool', 'sub', 'a.ts'), 'a\n', 'utf8');
+    writeFileSync(join(dir, 'find-bool', 'sub', 'b.log'), 'b\n', 'utf8');
     session = new FauxnixSession();
     // seed the session cwd like a real shell login directory
     await session.run(translateCommandList(parseCommand('cd "' + dir + '"')));
@@ -679,18 +684,78 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     ]);
   });
 
-  it('find rejects missing and invalid depth arguments', async () => {
-    const missing = await run('find find-depth -maxdepth');
-    expect(missing.exitCode).toBe(1);
-    expect(missing.stderr).toContain("find: missing argument to '-maxdepth'");
-
+  it('find rejects missing and invalid depth arguments', () => {
+    expect(() => translateCommandList(parseCommand('find find-depth -maxdepth'))).toThrow(
+      "find: missing argument to '-maxdepth'",
+    );
     for (const value of ['nope', '-1']) {
-      const invalid = await run(`find find-depth -mindepth ${value}`);
-      expect(invalid.exitCode).toBe(1);
-      expect(invalid.stderr).toContain(
+      expect(() =>
+        translateCommandList(parseCommand(`find find-depth -mindepth ${value}`)),
+      ).toThrow(
         `find: expected a non-negative decimal integer argument to -mindepth, but got '${value}'`,
       );
     }
+  });
+
+  it('find ! / -o compose instead of ignoring operators', async () => {
+    const paths = async (cmd: string) => {
+      const r = await run(cmd);
+      expect(r.exitCode).toBe(0);
+      return r.stdout.split(/\r?\n/).filter(Boolean).sort();
+    };
+    expect(await paths("find find-bool -name '*.ts'")).toEqual([
+      'find-bool/keep.ts',
+      'find-bool/sub/a.ts',
+    ]);
+    const negated = await paths("find find-bool ! -name '*.ts'");
+    expect(negated).toContain('find-bool');
+    expect(negated).toContain('find-bool/drop.log');
+    expect(negated).toContain('find-bool/sub');
+    expect(negated).toContain('find-bool/sub/b.log');
+    expect(negated).not.toContain('find-bool/keep.ts');
+    expect(negated).not.toContain('find-bool/sub/a.ts');
+    expect(await paths("find find-bool -name '*.ts' -o -name '*.log'")).toEqual([
+      'find-bool/drop.log',
+      'find-bool/keep.ts',
+      'find-bool/sub/a.ts',
+      'find-bool/sub/b.log',
+    ]);
+    expect(await paths("find find-bool -name '*.ts' -name '*.log'")).toEqual([]);
+  });
+
+  it('find ! -name -delete removes the negated set, not the named set', async () => {
+    const root = join(dir, 'find-del-not');
+    mkdirSync(join(root, 'sub'), { recursive: true });
+    writeFileSync(join(root, 'keep.ts'), 'keep\n', 'utf8');
+    writeFileSync(join(root, 'drop.log'), 'drop\n', 'utf8');
+    writeFileSync(join(root, 'sub', 'a.ts'), 'a\n', 'utf8');
+    writeFileSync(join(root, 'sub', 'b.log'), 'b\n', 'utf8');
+    const r = await run("find find-del-not ! -name '*.ts' -delete");
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(join(root, 'keep.ts'))).toBe(true);
+    expect(existsSync(join(root, 'sub', 'a.ts'))).toBe(true);
+    expect(existsSync(join(root, 'drop.log'))).toBe(false);
+    expect(existsSync(join(root, 'sub', 'b.log'))).toBe(false);
+  });
+
+  it('find -name a -o -name b -delete follows GNU AND/OR precedence', async () => {
+    const root = join(dir, 'find-del-or');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'keep.ts'), 'keep\n', 'utf8');
+    writeFileSync(join(root, 'drop.log'), 'drop\n', 'utf8');
+    const footgun = await run("find find-del-or -name '*.log' -o -name '*.ts' -delete");
+    expect(footgun.exitCode).toBe(0);
+    expect(existsSync(join(root, 'drop.log'))).toBe(true);
+    expect(existsSync(join(root, 'keep.ts'))).toBe(false);
+
+    const groupedRoot = join(dir, 'find-del-group');
+    mkdirSync(groupedRoot, { recursive: true });
+    writeFileSync(join(groupedRoot, 'keep.ts'), 'keep\n', 'utf8');
+    writeFileSync(join(groupedRoot, 'drop.log'), 'drop\n', 'utf8');
+    const grouped = await run("find find-del-group \\( -name '*.log' -o -name '*.ts' \\) -delete");
+    expect(grouped.exitCode).toBe(0);
+    expect(existsSync(join(groupedRoot, 'keep.ts'))).toBe(false);
+    expect(existsSync(join(groupedRoot, 'drop.log'))).toBe(false);
   });
 
   it('stat -c format', async () => {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1106,4 +1106,59 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
       await extra.dispose();
     }
   }, 30000);
+
+  it('whitespace-only stdout is preserved', async () => {
+    const r = await run("printf '   '");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe('   ');
+    expect(r.cancelled).toBe(false);
+    expect(r.timedOut).toBe(false);
+  });
+
+  it('native stderr is returned once and does not leak into the next command', async () => {
+    const noisy = await run(`node -e "process.stderr.write('E'.repeat(4096)); process.exit(7)"`);
+    expect(noisy.exitCode).toBe(7);
+    expect(noisy.stderr).toContain('E'.repeat(64));
+    expect(noisy.stderr.split('E').length - 1).toBeGreaterThanOrEqual(4096);
+    const next = await run('echo hi');
+    expect(next.exitCode).toBe(0);
+    expect(next.stdout.trim()).toBe('hi');
+    expect(next.stderr).not.toContain('E'.repeat(64));
+  });
+
+  it('AbortSignal cancel unblocks the next request without running later segments', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const ac = new AbortController();
+      const pending = extra.run(
+        translateCommandList(parseCommand('sleep 5; echo should-not-run')),
+        { timeoutMs: 30_000, signal: ac.signal },
+      );
+      await new Promise((r) => setTimeout(r, 250));
+      ac.abort();
+      const cancelled = await pending;
+      expect(cancelled.cancelled).toBe(true);
+      expect(cancelled.exitCode).toBe(130);
+      expect(cancelled.stdout).not.toContain('should-not-run');
+      const next = await extra.run(translateCommandList(parseCommand('echo after-cancel')));
+      expect(next.exitCode).toBe(0);
+      expect(next.stdout.trim()).toBe('after-cancel');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('concurrent reset leaves one usable session', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      await Promise.all([extra.reset(), extra.reset(), extra.reset()]);
+      const r = await extra.run(translateCommandList(parseCommand('echo x')));
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe('x');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -15,6 +15,7 @@ import { lookup, parseWords, psStr } from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import { normalizeStderr } from '../src/errors.js';
 import { decodeHostResponse, encodeHostRequest } from '../src/ps-host.js';
+import { bashToolResult, formatBashText } from '../src/mcp.js';
 import '../src/commands/install-all.js';
 
 /* ---------------------------- parser ---------------------------- */
@@ -455,6 +456,7 @@ describe('translator', () => {
     expect(boot).toContain('function fx-csub');
     expect(boot).toContain('{"ready":true}');
     expect(boot).toContain('ConvertFrom-Json');
+    expect(boot).toContain('MaxJsonLength');
     expect(boot).not.toContain('exit $script:fx_exit');
   });
 
@@ -681,5 +683,48 @@ describe('tokenize', () => {
     const toks = tokenize('a > b 2> c');
     const ops = toks.filter((t) => t.type === 'OP').map((t) => t.op);
     expect(ops).toEqual(['>', '2>']);
+  });
+});
+
+describe('MCP structured results (#129)', () => {
+  it('keeps whitespace-only stdout instead of collapsing to (no output)', () => {
+    expect(
+      formatBashText({
+        stdout: '   ',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+        cancelled: false,
+      }),
+    ).toBe('   ');
+    expect(
+      formatBashText({
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+        cancelled: false,
+      }),
+    ).toBe('(no output)');
+  });
+
+  it('exposes schemaVersion 1 and does not mark shell exit 1 as a protocol error', () => {
+    const r = bashToolResult(
+      {
+        stdout: 'x',
+        stderr: '',
+        exitCode: 1,
+        timedOut: false,
+        cancelled: false,
+        truncated: false,
+      },
+      'abcd1234',
+      false,
+    );
+    expect(r.structuredContent.schemaVersion).toBe(1);
+    expect(r.structuredContent.sessionId).toBe('abcd1234');
+    expect(r.structuredContent.exitCode).toBe(1);
+    expect(r.content[0].text).toContain('Exit code: 1');
+    expect('isError' in r && r.isError).toBeFalsy();
   });
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -11,7 +11,7 @@ import {
   wrapScript,
   hostBootstrapScript,
 } from '../src/translator.js';
-import { lookup, parseWords, psStr } from '../src/registry.js';
+import { listCommandsJson, lookup, lookupSpec, parseWords, psStr } from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import { normalizeStderr } from '../src/errors.js';
 import { decodeHostResponse, encodeHostRequest } from '../src/ps-host.js';
@@ -681,5 +681,72 @@ describe('tokenize', () => {
     const toks = tokenize('a > b 2> c');
     const ops = toks.filter((t) => t.type === 'OP').map((t) => t.op);
     expect(ops).toEqual(['>', '2>']);
+  });
+});
+
+describe('CommandSpec (#130)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+
+  it('cp -n / --no-clobber skip an existing dest instead of overwriting', () => {
+    expect(bodyOf('cp -n src dst')).toContain('$true -and (Test-Path -LiteralPath $fx_target)');
+    expect(bodyOf('cp --no-clobber src dst')).toContain(
+      '$true -and (Test-Path -LiteralPath $fx_target)',
+    );
+    expect(bodyOf('cp src dst')).toContain('$false -and (Test-Path -LiteralPath $fx_target)');
+  });
+
+  it('cp rejects unknown and unsupported options before Copy-Item', () => {
+    const z = bodyOf('cp -z a b');
+    expect(z).toContain("invalid option -- ''z''");
+    expect(z).toContain('$script:fx_exit = 1');
+    expect(z).not.toContain('Copy-Item');
+    expect(bodyOf('cp -i a b')).toContain("option ''-i'' is not supported by fauxnix");
+    expect(bodyOf('cp --preserve a b')).toContain("unrecognized option ''--preserve''");
+  });
+
+  it('mv -n skips an existing dest', () => {
+    expect(bodyOf('mv -n src dst')).toContain('$true -and (Test-Path -LiteralPath $fx_target)');
+    expect(bodyOf('mv src dst')).toContain('$false -and (Test-Path -LiteralPath $fx_target)');
+  });
+
+  it('touch -c does not create missing files', () => {
+    expect(bodyOf('touch -c missing')).toContain('if ($true) { continue }');
+    expect(bodyOf('touch --no-create missing')).toContain('if ($true) { continue }');
+    expect(bodyOf('touch missing')).toContain('if ($false) { continue }');
+    expect(bodyOf('touch missing')).toContain('New-Item -ItemType File');
+  });
+
+  it('tee --append and -a append; bare tee truncates', () => {
+    expect(bodyOf('tee --append out.txt')).toContain('if ($true)');
+    expect(bodyOf('tee -a out.txt')).toContain('if ($true)');
+    expect(bodyOf('tee out.txt')).toContain('if ($false)');
+  });
+
+  it('spec\'d rm fails loud on unknown flags; unspec\'d ls still ignores them', () => {
+    const rm = bodyOf('rm -z x');
+    expect(rm).toContain("invalid option -- ''z''");
+    expect(rm).not.toContain('Remove-Item');
+    const ls = bodyOf('ls -Z');
+    expect(ls).not.toContain('invalid option');
+    expect(ls).toContain('Get-ChildItem');
+  });
+
+  it('rm --verbose matches -v; tee -i is not silently ignored', () => {
+    expect(bodyOf('rm --verbose x')).toContain('if ($true)');
+    expect(bodyOf('rm x')).toContain('if ($false)');
+    expect(bodyOf('tee -i out.txt')).toContain("invalid option -- ''i''");
+  });
+
+  it('listCommandsJson exposes migrated specs and null for legacy handlers', () => {
+    const rows = listCommandsJson();
+    const cp = rows.find((r) => r.name === 'cp');
+    expect(cp?.spec?.effects).toEqual(['read', 'write']);
+    expect(cp?.spec?.options.some((o) => o.short === 'n' && o.support === 'implemented')).toBe(
+      true,
+    );
+    expect(rows.find((r) => r.name === 'ls')?.spec).toBeNull();
+    expect(lookupSpec('cp')).toBeTruthy();
+    expect(lookupSpec('ls')).toBeUndefined();
+    expect(lookup('tee')).toBeTypeOf('function');
   });
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -683,3 +683,51 @@ describe('tokenize', () => {
     expect(ops).toEqual(['>', '2>']);
   });
 });
+
+describe('find predicates (#130)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+  const throws = (cmd: string, msg: string) => {
+    expect(() => translateCommandList(parse(cmd))).toThrow(msg);
+  };
+
+  it('compiles ! and -o instead of ignoring them', () => {
+    const neg = bodyOf("find . ! -name '*.ts'");
+    expect(neg).toContain('-not');
+    expect(neg).toContain("-clike '*.ts'");
+    expect(neg).toContain('fx-find-print');
+    expect(neg).not.toContain('fx-find-delete');
+
+    const del = bodyOf("find . ! -name '*.ts' -delete");
+    expect(del).toContain('-not');
+    expect(del).toContain('fx-find-delete');
+    expect(del).toContain('[array]::Reverse');
+
+    const or = bodyOf("find . -name a -o -name b");
+    expect(or).toContain(' -or ');
+    expect(or).toContain("-clike 'a'");
+    expect(or).toContain("-clike 'b'");
+
+    const and = bodyOf("find . -name a -name b");
+    expect(and).toContain(' -and ');
+  });
+
+  it('treats -delete as a primary so OR-delete keeps GNU precedence', () => {
+    const footgun = bodyOf("find . -name a -o -name b -delete");
+    expect(footgun).toContain(' -or ');
+    expect(footgun).toContain('fx-find-delete');
+    const grouped = bodyOf("find . \\( -name a -o -name b \\) -delete");
+    expect(grouped).toContain(' -or ');
+    expect(grouped).toContain('fx-find-delete');
+  });
+
+  it('fails loud on unknown predicates and broken expressions', () => {
+    throws('find . -perm 644', "find: unknown predicate '-perm'");
+    throws('find . -print0', "find: unknown predicate '-print0'");
+    throws('find . -name', "find: missing argument to '-name'");
+    throws('find . -type s', 'find: Unknown argument to -type: s');
+    throws('find . -size xyz', "find: Invalid argument 'xyz' to -size");
+    throws('find . -o -name a', "find: invalid expression; you have used a binary operator '-o' with nothing before it.");
+    throws('find . -name a -o', "find: expected an expression after '-o'");
+    throws("find . -name '*.ts' extra", "find: paths must precede expression: 'extra'");
+  });
+});

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -178,6 +178,27 @@ describe('parser', () => {
     expect(() => parse('cat <<EOF')).toThrow(/heredoc/);
   });
 
+  it('rejects trailing && / || instead of dropping them', () => {
+    expect(() => parse('echo BEFORE &&')).toThrow(/unexpected end of file after `&&'/);
+    expect(() => parse('echo BEFORE ||')).toThrow(/unexpected end of file after `\\|\\|'/);
+    expect(() => parse('echo a &&\n')).toThrow(/unexpected end of file after `&&'/);
+    expect(() => parse('if true &&; then echo x; fi')).toThrow(/unexpected token `&&'/);
+    expect(parse('echo a && echo b').segments).toHaveLength(2);
+  });
+
+  it('rejects ;; instead of treating it as extra semicolons', () => {
+    expect(() => parse('echo A;; echo B')).toThrow(/unexpected token `;;'/);
+    expect(() => parse('echo A; ; echo B')).toThrow(/unexpected token `;;'/);
+    expect(parse('echo A; echo B').segments).toHaveLength(2);
+  });
+
+  it('env -i is a loud usage error, not a silent ignore', () => {
+    const script = translateCommandList(parse('env -i echo hi'))[0].script;
+    expect(script).toMatch(/env -i\/--ignore-environment is not supported/);
+    expect(script).toContain('$script:fx_exit = 2');
+    expect(script).not.toContain("fx-write");
+  });
+
   it('parses word-level $((...)) as Arith, not $( (expr) )', () => {
     const cmd = parse('echo $((1+1))').segments[0].pipeline.commands[0];
     expect(cmd.kind).toBe('SimpleCommand');


### PR DESCRIPTION
Integration of the v0.8 execution-contract wave: r3wretrhy implementing the vulragrag-star RFCs (#129 PR-A, #130 first families) plus find predicates and syntax fail-loud.

**Maintainer verification on the integrated tree (all confirmed):**
- #135: trailing `&&` and `;;` are syntax errors; `env -i` rejects with the secrets rationale — all reproduced from audit #131, now green
- #136: `cp -n` preserves dest; `touch -c missing` does not create; `tee --append` appends; `cp -z` gets the GNU invalid-option error; `fauxnix list --json` parses (108 commands, cp spec'd, ls null)
- #137: find negation excludes the named pattern correctly; `-o` unions; unknown predicates throw GNU-worded errors
- #138: structured results + whitespace preserved (printf of three spaces returns them); **cancel measured: sleep 8 aborted at 0.4s, cancelled=true, session cold-restarts and survives**; lifecycle lock + dispose-on-close per the RFC

**One regression found and documented**: #138's richer host bootstrap raises the first frame after prewarm from 0.137s to ~0.7s (warm frames unchanged at ~50ms; the 15x warm-latency test stays green). Will be filed as its own issue for a bootstrap-slimming pass; the prewarm test now asserts the honest claim (beats the ~1.1s cold spawn) rather than a specific number.

Full suite: 186 tests.

Closes #135, closes #136, closes #137, closes #138.
