### PR TITLE
feat: grep -m, head --lines, du --max-depth, and spec docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ development:
   translate time (unsupported constructs throw named errors, never silently misbehave)
 - **text I/O**: `echo printf cat head tail wc tee nl tac md5sum sha1sum sha256sum base64 seq yes xargs`
 
-`cp` / `mv` / `rm` / `touch` / `tee` carry a `CommandSpec`: unknown options fail with a GNU-style
-usage error instead of being ignored. `cp -n` / `mv -n` / `touch -c` / `tee --append` match GNU
-(no clobber / no-create / append). `fauxnix list --json` dumps the same capability metadata.
+`cp` / `mv` / `rm` / `touch` / `tee` / `grep` / `head` / `du` carry a `CommandSpec`: unknown
+options fail with a GNU-style usage error instead of being ignored. Implemented GNU holes:
+`cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` / `head --lines` / `du --max-depth`.
+`fauxnix list --json` and `docs/command-specs.md` dump the same metadata.
 - **shell/system**: `cd pwd export unset env printenv ps kill pkill pgrep sleep which type whoami
   id groups date uname hostname uptime free nproc clear true false test [ [[ : pushd popd dirs sudo
   timeout man history less more source . eval exit alias set`

--- a/docs/command-specs.md
+++ b/docs/command-specs.md
@@ -1,0 +1,110 @@
+# Command specs
+
+Generated from `CommandSpec`. Unlisted commands still use unchecked `parseWords` (unknown flags ignored). Spec'd commands fail loud on unknown or unsupported options.
+
+## `cp`
+
+Effects: `read`, `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-r` | flag | implemented |
+| `-R`, `--recursive` | flag | implemented |
+| `-v`, `--verbose` | flag | implemented |
+| `-n`, `--no-clobber` | flag | implemented |
+| `-f`, `--force` | flag | implemented |
+| `-i`, `--interactive` | flag | unsupported (interactive prompt) |
+
+## `mv`
+
+Effects: `read`, `write`, `delete`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-v`, `--verbose` | flag | implemented |
+| `-n`, `--no-clobber` | flag | implemented |
+| `-f`, `--force` | flag | implemented |
+| `-i`, `--interactive` | flag | unsupported (interactive prompt) |
+
+## `rm`
+
+Effects: `delete`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-r` | flag | implemented |
+| `-R`, `--recursive` | flag | implemented |
+| `-f`, `--force` | flag | implemented |
+| `-v`, `--verbose` | flag | implemented |
+| `-i`, `--interactive` | flag | unsupported (interactive prompt) |
+
+## `touch`
+
+Effects: `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-c`, `--no-create` | flag | implemented |
+
+## `du`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-s`, `--summarize` | flag | implemented |
+| `-h`, `--human-readable` | flag | implemented |
+| `-d`, `--max-depth` | required | implemented |
+
+## `tee`
+
+Effects: `read`, `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-a`, `--append` | flag | implemented |
+
+## `head`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-n`, `--lines` | required | implemented |
+| `-c`, `--bytes` | required | implemented |
+| `-q`, `--quiet` | flag | implemented |
+| `--silent` | flag | implemented |
+| `-v`, `--verbose` | flag | implemented |
+
+## `grep`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-i` | flag | implemented |
+| `-v` | flag | implemented |
+| `-n` | flag | implemented |
+| `-c` | flag | implemented |
+| `-l` | flag | implemented |
+| `-r` | flag | implemented |
+| `-R` | flag | implemented |
+| `-E` | flag | implemented |
+| `-F` | flag | implemented |
+| `-w` | flag | implemented |
+| `-q` | flag | implemented |
+| `-o` | flag | implemented |
+| `-h` | flag | implemented |
+| `-H` | flag | implemented |
+| `-A` | required | implemented |
+| `-B` | required | implemented |
+| `-C` | required | implemented |
+| `-m`, `--max-count` | required | implemented |
+| `-e`, `--regexp` | required | implemented |
+| `--include` | required | implemented |
+| `--exclude` | required | implemented |
+| `--exclude-dir` | required | implemented |
+
+## Unspec'd commands
+
+`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `basename`, `cat`, `cd`, `chmod`, `chown`, `clear`, `command`, `curl`, `cut`, `date`, `df`, `diff`, `dig`, `dirname`, `dirs`, `echo`, `egrep`, `env`, `eval`, `exit`, `export`, `false`, `file`, `find`, `free`, `groups`, `gunzip`, `gzip`, `history`, `host`, `hostname`, `id`, `ifconfig`, `ip`, `kill`, `less`, `ll`, `ln`, `ls`, `man`, `md5sum`, `mkdir`, `mktemp`, `more`, `netstat`, `nl`, `nproc`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `printenv`, `printf`, `ps`, `pushd`, `pwd`, `read`, `readlink`, `realpath`, `rmdir`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `sleep`, `sort`, `source`, `ss`, `stat`, `sudo`, `tac`, `tail`, `tar`, `test`, `timeout`, `tr`, `true`, `type`, `uname`, `uniq`, `unset`, `unzip`, `uptime`, `wc`, `wget`, `which`, `whoami`, `xargs`, `yes`, `zcat`, `zip`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { FauxnixSession } from './executor.js';
 import { parseCommand } from './parser.js';
 import { translateCommandList } from './translator.js';
-import { listCommandsJson, registeredNames } from './registry.js';
+import { listCommandsJson, registeredNames, specsMarkdown } from './registry.js';
 import { encodeCommand } from './encoding.js';
 import { startMcpServer } from './mcp.js';
 import { packageVersion } from './version.js';
@@ -17,6 +17,7 @@ Usage:
   fauxnix mcp                        start the MCP stdio server (for agent harnesses)
   fauxnix list                       list translated commands
   fauxnix list --json                same list as machine-readable capability metadata
+  fauxnix list --markdown            CommandSpec tables (same text as docs/command-specs.md)
   fauxnix check                      verify the local PowerShell environment
   fauxnix --version
 
@@ -39,6 +40,10 @@ export async function runCli(argv: string[]): Promise<void> {
   if (verb === 'list') {
     if (rest[0] === '--json') {
       console.log(JSON.stringify(listCommandsJson(), null, 2));
+      return;
+    }
+    if (rest[0] === '--markdown') {
+      console.log(specsMarkdown());
       return;
     }
     const names = registeredNames();

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -459,10 +459,41 @@ const file: Handler = (args) => {
 /* ------------------------------------------------------------------ */
 
 const du: Handler = (args) => {
-  const { flags, longs, operandWords } = parseWords(args, [], ['--max-depth']);
+  const { flags, longs, values, missingValue, operandWords } = parseWords(
+    args,
+    ['d'],
+    ['--max-depth'],
+  );
   const sum = flags.has('s') || longs.has('--summarize');
   const human = flags.has('h') || longs.has('--human-readable');
+  if (missingValue.includes('-d') || missingValue.includes('--max-depth')) {
+    return (
+      '[Console]::Error.WriteLine(' +
+      psStr("du: option requires an argument -- 'max-depth'") +
+      '); $script:fx_exit = 1'
+    );
+  }
+  const maxDepthRaw = values.get('-d') ?? values.get('--max-depth');
+  let maxDepth: number | null = null;
+  if (maxDepthRaw !== undefined) {
+    if (!/^\d+$/.test(maxDepthRaw)) {
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr("du: invalid maximum depth '" + maxDepthRaw + "'") +
+        '); $script:fx_exit = 1'
+      );
+    }
+    maxDepth = parseInt(maxDepthRaw, 10);
+  }
+  if (sum && maxDepth !== null && maxDepth !== 0) {
+    return (
+      '[Console]::Error.WriteLine(' +
+      psStr('du: summarizing conflicts with --max-depth=' + String(maxDepth)) +
+      '); $script:fx_exit = 1'
+    );
+  }
   const targets = operandWords.length ? argListExpr(operandWords) : "@('.')";
+  const onlyRoot = sum || maxDepth === 0;
   return [
     PS_HSIZE_FN,
     'function fx-size($p) {',
@@ -473,7 +504,7 @@ const du: Handler = (args) => {
     '$fx_ts = ' + targets,
     'foreach ($fx_t in $fx_ts) {',
     '  if (-not (Test-Path -LiteralPath $fx_t)) { [Console]::Error.WriteLine("du: cannot access \'" + $fx_t + "\': No such file or directory"); $script:fx_exit = 1; continue }',
-    '  if (' + (sum ? '$true' : '$false') + ') {',
+    '  if (' + (onlyRoot ? '$true' : '$false') + ') {',
     '    $fx_kb = fx-size $fx_t',
     '    if (' + (human ? '$true' : '$false') + ') { "{0}`t{1}" -f (fx-hsize ($fx_kb * 1KB)), $fx_t } else { "{0}`t{1}" -f $fx_kb, $fx_t }',
     '  } else {',
@@ -481,6 +512,11 @@ const du: Handler = (args) => {
     '    foreach ($fx_d in @(Get-ChildItem -LiteralPath $fx_t -Recurse -Force -Directory -ErrorAction SilentlyContinue)) {',
     '      $fx_kb = fx-size $fx_d.FullName',
     "      $fx_rel = './' + $fx_d.FullName.Substring($fx_root.Length).TrimStart('\\').Replace('\\', '/')",
+    maxDepth !== null && maxDepth > 0
+      ? "      $fx_ddepth = @($fx_rel.ToCharArray() | Where-Object { $_ -eq '/' }).Count; if ($fx_ddepth -gt " +
+        maxDepth +
+        ') { continue }'
+      : '',
     '      if (' + (human ? '$true' : '$false') + ') { "{0}`t{1}" -f (fx-hsize ($fx_kb * 1KB)), $fx_rel } else { "{0}`t{1}" -f $fx_kb, $fx_rel }',
     '    }',
     '    $fx_kb = fx-size $fx_t',
@@ -1006,6 +1042,16 @@ export const specs: CommandSpec[] = [
     [opt('c', '--no-create')],
     touch,
   ),
+  fileSpec(
+    ['du'],
+    ['read'],
+    [
+      opt('s', '--summarize'),
+      opt('h', '--human-readable'),
+      opt('d', '--max-depth', 'implemented', { takesValue: true }),
+    ],
+    du,
+  ),
 ];
 
 export const handlers: Record<string, Handler> = {
@@ -1021,7 +1067,6 @@ export const handlers: Record<string, Handler> = {
   dirname,
   stat,
   file,
-  du,
   df,
   find,
   chmod,

--- a/src/commands/install-all.ts
+++ b/src/commands/install-all.ts
@@ -1,6 +1,6 @@
 import { registerAll, registerSpecs } from '../registry.js';
 import { handlers as files, specs as fileSpecs } from './files.js';
-import { handlers as textFilters } from './text-filters.js';
+import { handlers as textFilters, specs as textFilterSpecs } from './text-filters.js';
 import { handlers as textIo, specs as textIoSpecs } from './text-io.js';
 import { handlers as sysinfo } from './sysinfo.js';
 import { handlers as net } from './net.js';
@@ -16,6 +16,7 @@ export function installAll(): void {
   registerAll(archive);
   registerSpecs(fileSpecs);
   registerSpecs(textIoSpecs);
+  registerSpecs(textFilterSpecs);
 }
 
 installAll();

--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { FauxnixParseError, Word, wordToString } from '../ast.js';
-import { Handler, parseWords, psStr } from '../registry.js';
+import { CommandSpec, Handler, parseWords, psStr } from '../registry.js';
 import { argListExpr, exprOfWord, literalOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
@@ -285,16 +285,30 @@ const grep: Handler = (args) => {
 
   const { flags, operandWords, values, missingValue } = parseWords(
     args,
-    ['A', 'B', 'C'],
-    filterOptionNames,
+    ['A', 'B', 'C', 'm', 'e'],
+    [...filterOptionNames, '--max-count', '--regexp'],
   );
-  const missingFilterOption = missingValue.find((o) => filterOptionNames.includes(o));
+  const missingFilterOption = missingValue.find((o) =>
+    [...filterOptionNames, '-m', '--max-count', '-e', '--regexp'].includes(o),
+  );
   if (missingFilterOption) {
     return (
       '[Console]::Error.WriteLine(' +
       psStr("grep: option '" + missingFilterOption + "' requires an argument") +
       '); $script:fx_exit = 2'
     );
+  }
+  const maxCountRaw = values.get('-m') ?? values.get('--max-count');
+  let maxCount: number | null = null;
+  if (maxCountRaw !== undefined) {
+    if (!/^\d+$/.test(maxCountRaw)) {
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr("grep: invalid max count '" + maxCountRaw + "'") +
+        '); $script:fx_exit = 2'
+      );
+    }
+    maxCount = parseInt(maxCountRaw, 10);
   }
   const ci = flags.has('i');
   const inv = flags.has('v');
@@ -317,13 +331,15 @@ const grep: Handler = (args) => {
   const ctxA = Math.max(toInt(values.get('-A')), toInt(values.get('-C')));
   const ctxB = Math.max(toInt(values.get('-B')), toInt(values.get('-C')));
 
-  if (operandWords.length === 0) {
+  const ePat = values.get('-e') ?? values.get('--regexp');
+  if (ePat === undefined && operandWords.length === 0) {
     return (
       "[Console]::Error.WriteLine('usage: grep [OPTION]... PATTERN [FILE]...'); $script:fx_exit = 2"
     );
   }
-  const patternWord = operandWords[0];
-  const fileWords = operandWords.slice(1);
+  const patternWord: Word =
+    ePat !== undefined ? [{ kind: 'Text', text: ePat }] : operandWords[0];
+  const fileWords = ePat !== undefined ? operandWords : operandWords.slice(1);
   const patLit = literalOfWord(patternWord);
   let patExpr: string;
   if (fixed || patLit === null) {
@@ -490,10 +506,16 @@ const grep: Handler = (args) => {
 
   // --- per-source scan body ----------------------------------------------
   const scan: string[] = [];
+  if (maxCount !== null) scan.push('$fx_mleft = ' + maxCount);
   if (cntMode) {
     scan.push('$fx_c = 0');
     scan.push('for ($fx_i = 0; $fx_i -lt $fx_ls.Count; $fx_i++) {');
-    scan.push('  if (fx-gmatch $fx_ls[$fx_i]) { $fx_c++ }');
+    if (maxCount !== null) scan.push('  if ($fx_mleft -le 0) { break }');
+    scan.push(
+      '  if (fx-gmatch $fx_ls[$fx_i]) { $fx_c++' +
+        (maxCount !== null ? '; $fx_mleft--; if ($fx_mleft -le 0) { break }' : '') +
+        ' }',
+    );
     scan.push('}');
     scan.push('if ($fx_c -gt 0) { $fx_any = $true }');
     scan.push(
@@ -502,19 +524,23 @@ const grep: Handler = (args) => {
   } else if (listMode) {
     scan.push('$fx_hit1 = $false');
     scan.push('for ($fx_i = 0; $fx_i -lt $fx_ls.Count; $fx_i++) {');
+    if (maxCount !== null) scan.push('  if ($fx_mleft -le 0) { break }');
     scan.push('  if (fx-gmatch $fx_ls[$fx_i]) { $fx_hit1 = $true; break }');
     scan.push('}');
     scan.push('if ($fx_hit1) { $fx_any = $true; $fx_disp }');
   } else if (quiet) {
     scan.push('for ($fx_i = 0; $fx_i -lt $fx_ls.Count; $fx_i++) {');
+    if (maxCount !== null) scan.push('  if ($fx_mleft -le 0) { break }');
     scan.push('  if (fx-gmatch $fx_ls[$fx_i]) { $fx_any = $true; break }');
     scan.push('}');
   } else {
     scan.push('$fx_hits = @()');
     scan.push('for ($fx_i = 0; $fx_i -lt $fx_ls.Count; $fx_i++) {');
+    if (maxCount !== null) scan.push('  if ($fx_mleft -le 0) { break }');
     scan.push('  $fx_l = $fx_ls[$fx_i]');
     scan.push('  if (fx-gmatch $fx_l) {');
     scan.push('    $fx_any = $true');
+    if (maxCount !== null) scan.push('    $fx_mleft--');
     if (onlyMatch && !inv) {
       if (fixed) {
         if (ci) {
@@ -552,6 +578,7 @@ const grep: Handler = (args) => {
     } else if (!onlyMatch) {
       scan.push('    $fx_hits += $fx_i');
     }
+    if (maxCount !== null) scan.push('    if ($fx_mleft -le 0) { break }');
     scan.push('  }');
     scan.push('}');
     if (!onlyMatch) {
@@ -2646,8 +2673,42 @@ const tr: Handler = (args) => {
 
 /* ------------------------------------------------------------------ */
 
+export const specs: CommandSpec[] = [
+  {
+    names: ['grep'],
+    options: [
+      { short: 'i', support: 'implemented' },
+      { short: 'v', support: 'implemented' },
+      { short: 'n', support: 'implemented' },
+      { short: 'c', support: 'implemented' },
+      { short: 'l', support: 'implemented' },
+      { short: 'r', support: 'implemented' },
+      { short: 'R', support: 'implemented' },
+      { short: 'E', support: 'implemented' },
+      { short: 'F', support: 'implemented' },
+      { short: 'w', support: 'implemented' },
+      { short: 'q', support: 'implemented' },
+      { short: 'o', support: 'implemented' },
+      { short: 'h', support: 'implemented' },
+      { short: 'H', support: 'implemented' },
+      { short: 'A', takesValue: true, support: 'implemented' },
+      { short: 'B', takesValue: true, support: 'implemented' },
+      { short: 'C', takesValue: true, support: 'implemented' },
+      { short: 'm', long: '--max-count', takesValue: true, support: 'implemented' },
+      { short: 'e', long: '--regexp', takesValue: true, support: 'implemented' },
+      { long: '--include', takesValue: true, support: 'implemented' },
+      { long: '--exclude', takesValue: true, support: 'implemented' },
+      { long: '--exclude-dir', takesValue: true, support: 'implemented' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    usageExit: 2,
+    handler: grep,
+  },
+];
+
 export const handlers: Record<string, Handler> = {
-  grep,
   egrep: (args, ctx) => grep([[{ kind: 'Text', text: '-E' }], ...args], ctx), // egrep = grep -E
   sed,
   awk,

--- a/src/commands/text-io.ts
+++ b/src/commands/text-io.ts
@@ -455,6 +455,34 @@ const head: Handler = (args, ctx) => {
         continue;
       }
       if (t.startsWith('--')) {
+        const eq = t.indexOf('=');
+        const name = eq >= 0 ? t.slice(0, eq) : t;
+        const inline = eq >= 0 ? t.slice(eq + 1) : null;
+        if (name === '--lines' || name === '--bytes') {
+          let val = inline;
+          if (val === null) {
+            if (i + 1 >= args.length) {
+              return psErrExpr(psStr('head: option requires an argument -- ' + name.slice(2)));
+            }
+            val = wordToString(args[i + 1]);
+            i += 2;
+          } else {
+            i++;
+          }
+          if (name === '--bytes') nBytes = val;
+          else nLines = val;
+          continue;
+        }
+        if (name === '--quiet' || name === '--silent') {
+          quiet = true;
+          i++;
+          continue;
+        }
+        if (name === '--verbose') {
+          verbose = true;
+          i++;
+          continue;
+        }
         i++;
         continue;
       }
@@ -494,6 +522,11 @@ const head: Handler = (args, ctx) => {
   }
   const bytesMode = nBytes !== null;
   const countLit = bytesMode ? nBytes! : nLines !== null ? nLines : '10';
+  if (!/^[+-]?\d+$/.test(countLit)) {
+    return psErrExpr(
+      psStr("head: invalid number of " + (bytesMode ? 'bytes' : 'lines') + ": '" + countLit + "'"),
+    );
+  }
 
   const lines: string[] = [
     PS_GLOB_FN,
@@ -587,6 +620,35 @@ const tail: Handler = (args, ctx) => {
         continue;
       }
       if (t.startsWith('--')) {
+        const eq = t.indexOf('=');
+        const name = eq >= 0 ? t.slice(0, eq) : t;
+        const inline = eq >= 0 ? t.slice(eq + 1) : null;
+        if (name === '--lines' || name === '--bytes') {
+          let val = inline;
+          if (val === null) {
+            if (i + 1 >= args.length) {
+              return psErrExpr(psStr('tail: option requires an argument -- ' + name.slice(2)));
+            }
+            val = wordToString(args[i + 1]);
+            i += 2;
+          } else {
+            i++;
+          }
+          if (name === '--bytes') nBytes = val;
+          else if (val.startsWith('+')) fromLine = val.slice(1);
+          else nLines = val.replace(/^-/, '');
+          continue;
+        }
+        if (name === '--quiet' || name === '--silent') {
+          quiet = true;
+          i++;
+          continue;
+        }
+        if (name === '--verbose') {
+          verbose = true;
+          i++;
+          continue;
+        }
         i++;
         continue;
       }
@@ -1313,13 +1375,26 @@ export const specs: CommandSpec[] = [
     dispatch: 'translated',
     handler: tee,
   },
+  {
+    names: ['head'],
+    options: [
+      { short: 'n', long: '--lines', takesValue: true, support: 'implemented' },
+      { short: 'c', long: '--bytes', takesValue: true, support: 'implemented' },
+      { short: 'q', long: '--quiet', support: 'implemented' },
+      { long: '--silent', support: 'implemented' },
+      { short: 'v', long: '--verbose', support: 'implemented' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: head,
+  },
 ];
 
 export const handlers: Record<string, Handler> = {
   echo,
   printf,
   cat,
-  head,
   tail,
   wc,
   nl,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -246,6 +246,8 @@ export interface CommandSpec {
   effects: CommandEffect[];
   platform?: 'windows-ps51' | 'portable-translate';
   dispatch?: 'translated' | 'native' | 'dynamic';
+  /** GNU usage/syntax exit (grep uses 2; cp/mv/rm use 1). */
+  usageExit?: number;
   handler: Handler;
 }
 
@@ -282,6 +284,43 @@ export function registeredSpecs(): CommandSpec[] {
     out.push(spec);
   }
   return out;
+}
+
+/** Markdown dump of every CommandSpec — source for docs/command-specs.md. */
+export function specsMarkdown(): string {
+  const lines = [
+    '# Command specs',
+    '',
+    'Generated from `CommandSpec`. Unlisted commands still use unchecked `parseWords` (unknown flags ignored). Spec\'d commands fail loud on unknown or unsupported options.',
+    '',
+  ];
+  for (const spec of registeredSpecs()) {
+    lines.push('## `' + spec.names.join('` / `') + '`');
+    lines.push('');
+    lines.push('Effects: ' + spec.effects.map((e) => '`' + e + '`').join(', '));
+    lines.push('');
+    if (!spec.options.length) {
+      lines.push('No options declared.');
+    } else {
+      lines.push('| Option | Value | Support |');
+      lines.push('| --- | --- | --- |');
+      for (const o of spec.options) {
+        const names = [o.short ? '`-' + o.short + '`' : '', o.long ? '`' + o.long + '`' : '']
+          .filter((s) => s !== '')
+          .join(', ');
+        const val = o.takesValue ? 'required' : 'flag';
+        const extra = o.reason ? ' (' + o.reason + ')' : '';
+        lines.push('| ' + names + ' | ' + val + ' | ' + o.support + extra + ' |');
+      }
+    }
+    lines.push('');
+  }
+  const unspec = registeredNames().filter((n) => !lookupSpec(n));
+  lines.push('## Unspec\'d commands');
+  lines.push('');
+  lines.push(unspec.map((n) => '`' + n + '`').join(', '));
+  lines.push('');
+  return lines.join('\n');
 }
 
 export interface ListedCommand {
@@ -328,6 +367,8 @@ export function listCommandsJson(): ListedCommand[] {
  * null when every option is recognized and implemented.
  */
 export function specOptionError(spec: CommandSpec, args: Word[], cmdName: string): string | null {
+  const usageExit = spec.usageExit ?? 1;
+  const fail = (msg: string) => optionFail(cmdName, msg, usageExit);
   const shorts = new Map<string, OptionSpec>();
   const longs = new Map<string, OptionSpec>();
   for (const o of spec.options) {
@@ -352,16 +393,16 @@ export function specOptionError(spec: CommandSpec, args: Word[], cmdName: string
       const eq = t.indexOf('=');
       const name = eq >= 0 ? t.slice(0, eq) : t;
       const opt = longs.get(name);
-      if (!opt) return optionFail(cmdName, "unrecognized option '" + name + "'");
+      if (!opt) return fail("unrecognized option '" + name + "'");
       if (opt.support === 'unsupported') {
-        return optionFail(cmdName, unsupportedMsg(opt, name));
+        return fail(unsupportedMsg(opt, name));
       }
       if (!opt.takesValue && eq >= 0) {
-        return optionFail(cmdName, "option '" + name + "' doesn't allow an argument");
+        return fail("option '" + name + "' doesn't allow an argument");
       }
       if (opt.takesValue && eq < 0) {
         if (i + 1 < args.length) i++;
-        else return optionFail(cmdName, "option '" + name + "' requires an argument");
+        else return fail("option '" + name + "' requires an argument");
       }
       i++;
       continue;
@@ -371,15 +412,15 @@ export function specOptionError(spec: CommandSpec, args: Word[], cmdName: string
       for (let c = 0; c < body.length; c++) {
         const ch = body[c];
         const opt = shorts.get(ch);
-        if (!opt) return optionFail(cmdName, "invalid option -- '" + ch + "'");
+        if (!opt) return fail("invalid option -- '" + ch + "'");
         if (opt.support === 'unsupported') {
-          return optionFail(cmdName, unsupportedMsg(opt, '-' + ch));
+          return fail(unsupportedMsg(opt, '-' + ch));
         }
         if (opt.takesValue) {
           const rest = body.slice(c + 1);
           if (!rest) {
             if (i + 1 < args.length) i++;
-            else return optionFail(cmdName, "option requires an argument -- '" + ch + "'");
+            else return fail("option requires an argument -- '" + ch + "'");
           }
           break;
         }
@@ -397,12 +438,13 @@ function unsupportedMsg(opt: OptionSpec, shown: string): string {
   return "option '" + shown + "' is not supported by fauxnix" + reason;
 }
 
-function optionFail(cmd: string, msg: string): string {
+function optionFail(cmd: string, msg: string, code = 1): string {
   return (
     '[Console]::Error.WriteLine(' +
     psStr(cmd + ': ' + msg) +
     '); [Console]::Error.WriteLine(' +
     psStr("Try '" + cmd + " --help' for more information.") +
-    '); $script:fx_exit = 1'
+    '); $script:fx_exit = ' +
+    String(code)
   );
 }

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -200,9 +200,32 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
 
   it('head/tail/wc', async () => {
     expect((await run('head -1 fruits.txt')).stdout.trim()).toBe('apple');
+    expect((await run('head --lines=1 fruits.txt')).stdout.trim()).toBe('apple');
     expect((await run('tail -1 fruits.txt')).stdout.trim()).toBe('cherry');
+    expect((await run('tail --lines=1 fruits.txt')).stdout.trim()).toBe('cherry');
     expect((await run('wc -l fruits.txt')).stdout.trim()).toMatch(/4/);
     expect((await run('wc -l < fruits.txt')).stdout.trim()).toBe('4');
+  });
+
+  it('grep -m1 stops after the first match', async () => {
+    const r = await run('grep -m1 apple fruits.txt');
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('apple');
+    const all = await run('grep apple fruits.txt');
+    expect(all.stdout.trim().split(/\r?\n/)).toEqual(['apple', 'apple pie']);
+    const viaE = await run('grep -e apple fruits.txt');
+    expect(viaE.exitCode).toBe(0);
+    expect(viaE.stdout.trim().split(/\r?\n/)).toEqual(['apple', 'apple pie']);
+  });
+
+  it('du --max-depth=0 prints only the root', async () => {
+    const deep = await run('du find-depth');
+    const shallow = await run('du --max-depth=0 find-depth');
+    expect(shallow.exitCode).toBe(0);
+    const rows = shallow.stdout.split(/\r?\n/).filter(Boolean);
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toContain('find-depth');
+    expect(deep.stdout.split(/\r?\n/).filter(Boolean).length).toBeGreaterThan(1);
   });
 
   it('echo/printf semantics', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -707,6 +707,36 @@ describe('tokenize', () => {
   });
 });
 
+describe('bounded output flags (#130)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+
+  it('grep -m / --max-count stop after N matching lines', () => {
+    expect(bodyOf('grep -m1 pat f')).toContain('$fx_mleft = 1');
+    expect(bodyOf('grep --max-count=2 pat f')).toContain('$fx_mleft = 2');
+    expect(bodyOf('grep pat f')).not.toContain('$fx_mleft');
+  });
+
+  it('grep -e / --regexp keep the pattern (not an unknown flag)', () => {
+    expect(bodyOf("grep -e apple fruits.txt")).toContain('fx-gmatch');
+    expect(bodyOf("grep -e apple fruits.txt")).not.toContain('invalid option');
+  });
+
+  it('head --lines and --lines=N set the count (not silently skipped)', () => {
+    expect(bodyOf('head --lines=1 fruits.txt')).toContain('$fx_count = [int](1)');
+    expect(bodyOf('head --lines 3 fruits.txt')).toContain('$fx_count = [int](3)');
+    expect(bodyOf('head fruits.txt')).toContain('$fx_count = [int](10)');
+  });
+
+  it('du --max-depth filters subdirectory rows', () => {
+    expect(bodyOf('du --max-depth=0')).toContain('if ($true)');
+    expect(bodyOf('du --max-depth=0')).not.toContain('$fx_ddepth');
+    expect(bodyOf('du --max-depth=1')).toContain('$fx_ddepth');
+    expect(bodyOf('du --max-depth=1')).toContain('-gt 1');
+    expect(bodyOf('du -s --max-depth=1')).toContain('summarizing conflicts');
+    expect(bodyOf('du .')).not.toContain('$fx_ddepth');
+  });
+});
+
 describe('CommandSpec (#130)', () => {
   const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
 


### PR DESCRIPTION
## Why

#130 next family after the destructive five: `grep -m1`, `head --lines=1`, and `du --max-depth=0` were silently ignored while still producing a plausible result.

## What

- `grep -m` / `--max-count` stop after N matching lines per file.
- `head --lines` / `--lines=N` / `--bytes` (and `tail --lines`) are parsed instead of skipped.
- `du --max-depth` / `-d` filter subdirectory rows; `-s` with a nonzero max-depth fails loud.
- `grep` / `head` / `du` now have `CommandSpec` (grep usage exit 2).
- `docs/command-specs.md` and `fauxnix list --markdown` are generated from the same specs.

Unspec'd commands remain unchecked. Remaining names are listed at the bottom of `docs/command-specs.md`.

## Tests

Unit translate-time corpus + integration: `grep -m1 apple fruits.txt`, `head --lines=1`, `du --max-depth=0 find-depth`.
