### PR TITLE
feat: host protocol v2 chunked frames and native stderr marker

### DIFF
--- a/docs/rfc-bounded-cancellable-execution.md
+++ b/docs/rfc-bounded-cancellable-execution.md
@@ -29,7 +29,7 @@ These are one cluster: framing, limits, cancellation, and lifecycle need an expl
 | PR | Ships | Does not ship |
 |---|---|---|
 | **A (this land)** | RFC; structured MCP results; `extra.signal` cancel by killing the host (same recovery as timeout); one lock for run/reset/dispose; dispose on stdin EOF / SIGINT / SIGTERM; stop `.trim()` of whitespace-only stdout; drain/clear native `stderrChunks` per request; ConvertTo-Json overflow becomes a loud frame error instead of a dead loop | v2 handshake, chunked frames, deterministic native-stderr marker |
-| **B (follow-up)** | `{v:2,type:ready,…}` handshake (still accept v1 `{ready:true}`); chunked stdout/stderr + `end`; `stdoutLimit`/`stderrLimit` + `truncated`; `FAUXNIX_ERR_END:<id>` marker on the OS stderr pipe so native bytes return exactly once | runspace `Stop()` in-flight cancel; Job Object tree kill; Linux/macOS |
+| **B (this land)** | `{v:2,type:ready,…}` handshake (still accept v1 `{ready:true}`); chunked stdout/stderr + `end`; `stdoutLimit`/`stderrLimit` + `truncated`; `FAUXNIX_ERR_END:<id>` marker on the OS stderr pipe so native bytes return exactly once | runspace `Stop()` in-flight cancel; Job Object tree kill; Linux/macOS |
 
 PR-A keeps speaking the v1 host frame:
 

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -466,6 +466,7 @@ async function runPlans(
       },
       remainingMs,
       opts.signal,
+      { stdoutLimit, stderrLimit },
     );
 
     if (inv.spawnError === 'ENOENT' || inv.spawnError === 'START') {

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -28,12 +28,48 @@ export interface HostRequestEnv {
   [key: string]: string;
 }
 
-export function encodeHostRequest(id: string, script: string, env: HostRequestEnv): string {
-  return JSON.stringify({
+export function encodeHostRequest(
+  id: string,
+  script: string,
+  env: HostRequestEnv,
+  opts?: { v?: number; stdoutLimit?: number; stderrLimit?: number },
+): string {
+  const body: Record<string, unknown> = {
     id,
     scriptB64: Buffer.from(script, 'utf8').toString('base64'),
     env,
-  });
+  };
+  if (opts?.v === 2) {
+    body.v = 2;
+    body.type = 'run';
+    body.stdoutLimit = opts.stdoutLimit ?? DEFAULT_STDOUT_LIMIT;
+    body.stderrLimit = opts.stderrLimit ?? DEFAULT_STDERR_LIMIT;
+  }
+  return JSON.stringify(body);
+}
+
+export type HostV2Frame =
+  | { v: 2; type: 'ready'; capabilities?: { cancel?: boolean; maxChunkBytes?: number; stderrMarker?: boolean } }
+  | { v: 2; type: 'stdout' | 'stderr'; id: string; seq: number; dataB64: string }
+  | {
+      v: 2;
+      type: 'end';
+      id: string;
+      exitCode: number;
+      timedOut?: boolean;
+      cancelled?: boolean;
+      truncated?: boolean;
+    };
+
+export function parseHostLine(line: string): {
+  v1Ready?: boolean;
+  v2?: HostV2Frame;
+  v1?: ReturnType<typeof decodeHostResponse>;
+} {
+  const j = JSON.parse(line) as Record<string, unknown>;
+  if (j && j.v === 2 && typeof j.type === 'string') return { v2: j as unknown as HostV2Frame };
+  if (j && j.ready === true) return { v1Ready: true };
+  return { v1: decodeHostResponse(line) };
 }
 
 export function decodeHostResponse(line: string): {
@@ -79,6 +115,7 @@ export class PowerShellHost {
   private closed = false;
   private startLock: Promise<void> | null = null;
   private invokeLock: Promise<unknown> = Promise.resolve();
+  protocol: 1 | 2 = 1;
 
   constructor(
     private readonly hostFile: string,
@@ -95,8 +132,11 @@ export class PowerShellHost {
     env: HostRequestEnv,
     timeoutMs: number,
     signal?: AbortSignal,
+    limits?: { stdoutLimit?: number; stderrLimit?: number },
   ): Promise<HostInvokeResult> {
-    const run = this.invokeLock.then(() => this.invokeSerial(script, env, timeoutMs, signal));
+    const run = this.invokeLock.then(() =>
+      this.invokeSerial(script, env, timeoutMs, signal, limits),
+    );
     this.invokeLock = run.then(
       () => undefined,
       () => undefined,
@@ -152,6 +192,7 @@ export class PowerShellHost {
     env: HostRequestEnv,
     timeoutMs: number,
     signal?: AbortSignal,
+    limits?: { stdoutLimit?: number; stderrLimit?: number },
   ): Promise<HostInvokeResult> {
     if (signal?.aborted) {
       await this.stop();
@@ -162,7 +203,14 @@ export class PowerShellHost {
     if (started) return { ...started, cancelled: false, truncated: false };
 
     const id = 'f' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
-    const line = encodeHostRequest(id, script, env);
+    const line = encodeHostRequest(
+      id,
+      script,
+      env,
+      this.protocol === 2
+        ? { v: 2, stdoutLimit: limits?.stdoutLimit, stderrLimit: limits?.stderrLimit }
+        : undefined,
+    );
     try {
       this.proc!.stdin!.write(line + '\n');
     } catch (e) {
@@ -185,6 +233,9 @@ export class PowerShellHost {
     };
     signal?.addEventListener('abort', onAbort, { once: true });
     try {
+      if (this.protocol === 2) {
+        return await this.collectV2(id, timeoutMs);
+      }
       const raw = await this.nextJsonLine(timeoutMs, id);
       const msg = decodeHostResponse(raw);
       const native = this.drainNativeStderr();
@@ -321,10 +372,10 @@ export class PowerShellHost {
     });
     try {
       const readyLine = await this.nextReadyLine(READY_TIMEOUT_MS);
-      const msg = decodeHostResponse(readyLine);
-      if (!msg.ready) {
-        throw new Error('fauxnix: powershell host handshake failed');
-      }
+      const parsed = parseHostLine(readyLine);
+      if (parsed.v2?.type === 'ready') this.protocol = 2;
+      else if (parsed.v1Ready || decodeHostResponse(readyLine).ready) this.protocol = 1;
+      else throw new Error('fauxnix: powershell host handshake failed');
     } catch (e) {
       await this.stop();
       throw e;
@@ -379,8 +430,9 @@ export class PowerShellHost {
       const line = await this.nextLine(Math.max(1, deadline - Date.now()));
       if (!line.trim()) continue;
       try {
-        const msg = decodeHostResponse(line);
-        if (msg.ready) return line;
+        const parsed = parseHostLine(line);
+        if (parsed.v2?.type === 'ready' || parsed.v1Ready) return line;
+        if (parsed.v1?.ready) return line;
       } catch {
         /* skip PS boot noise */
       }
@@ -408,6 +460,71 @@ export class PowerShellHost {
     const err = new Error('fauxnix: powershell host timed out') as Error & { timedOut: boolean };
     err.timedOut = true;
     throw err;
+  }
+
+  private async collectV2(id: string, timeoutMs: number): Promise<HostInvokeResult> {
+    const deadline = Date.now() + timeoutMs;
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    let outSeq = 0;
+    let errSeq = 0;
+    let end: Extract<HostV2Frame, { type: 'end' }> | null = null;
+    while (!end) {
+      const line = await this.nextLine(Math.max(1, deadline - Date.now()));
+      if (!line.trim()) continue;
+      let parsed: ReturnType<typeof parseHostLine>;
+      try {
+        parsed = parseHostLine(line);
+      } catch {
+        continue;
+      }
+      const f = parsed.v2;
+      if (!f) continue;
+      if (f.type === 'stdout' && f.id === id) {
+        if (f.seq !== outSeq) throw new Error('fauxnix: host stdout seq gap');
+        out.push(Buffer.from(f.dataB64 ?? '', 'base64'));
+        outSeq++;
+      } else if (f.type === 'stderr' && f.id === id) {
+        if (f.seq !== errSeq) throw new Error('fauxnix: host stderr seq gap');
+        err.push(Buffer.from(f.dataB64 ?? '', 'base64'));
+        errSeq++;
+      } else if (f.type === 'end' && f.id === id) {
+        end = f;
+      }
+    }
+    let native = Buffer.alloc(0);
+    try {
+      native = Buffer.from(await this.waitNativeMarker(id, 2000));
+    } catch {
+      native = Buffer.from(this.drainNativeStderr());
+    }
+    const capturedErr = Buffer.from(Buffer.concat(err));
+    const n = Number(end.exitCode);
+    return {
+      stdout: Buffer.from(Buffer.concat(out)),
+      stderr: native.length ? Buffer.from(Buffer.concat([capturedErr, native])) : capturedErr,
+      exitCode: Number.isFinite(n) ? n : 0,
+      timedOut: end.timedOut === true,
+      cancelled: end.cancelled === true,
+      truncated: end.truncated === true,
+    };
+  }
+
+  private async waitNativeMarker(id: string, timeoutMs: number): Promise<Buffer> {
+    const needle = Buffer.from('FAUXNIX_ERR_END:' + id + '\n', 'utf8');
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const buf = Buffer.concat(this.stderrChunks);
+      const idx = buf.indexOf(needle);
+      if (idx >= 0) {
+        const before = buf.subarray(0, idx);
+        const after = buf.subarray(idx + needle.length);
+        this.stderrChunks = after.length ? [Buffer.from(after)] : [];
+        return Buffer.from(before) as Buffer;
+      }
+      await new Promise((r) => setTimeout(r, 15));
+    }
+    throw new Error('fauxnix: native stderr marker missing');
   }
 
   private failWaiters(err: Error): void {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1343,12 +1343,36 @@ $fx_reader = New-Object System.IO.StreamReader($fx_in, $fx_utf8, $true, 8192, $t
 $fx_proto = New-Object System.IO.StreamWriter($fx_out, $fx_utf8, 8192, $true)
 $fx_proto.NewLine = [string][char]10
 $fx_proto.AutoFlush = $true
-$fx_proto.WriteLine('{"ready":true}')
+$fx_proto.WriteLine('{"v":2,"type":"ready","capabilities":{"cancel":false,"maxChunkBytes":65536,"stderrMarker":true}}')
+function fx-b64([byte[]]$bytes, $off, $len) {
+  if ($len -le 0) { return '' }
+  $slice = New-Object byte[] $len
+  [Array]::Copy($bytes, $off, $slice, 0, $len)
+  return [Convert]::ToBase64String($slice)
+}
+function fx-emit-chunks($type, $id, [byte[]]$bytes, $limit, [ref]$seq) {
+  $n = 0
+  if ($null -ne $bytes) { $n = $bytes.Length }
+  $use = $n
+  $trunc = $false
+  if ($use -gt $limit) { $use = $limit; $trunc = $true }
+  $off = 0
+  while ($off -lt $use) {
+    $len = $use - $off
+    if ($len -gt 65536) { $len = 65536 }
+    $b64 = fx-b64 $bytes $off $len
+    $fx_proto.WriteLine('{"v":2,"type":"' + $type + '","id":"' + $id + '","seq":' + $seq.Value + ',"dataB64":"' + $b64 + '"}')
+    $seq.Value = $seq.Value + 1
+    $off += $len
+  }
+  return $trunc
+}
 while ($true) {
   $fx_line = $fx_reader.ReadLine()
   if ($null -eq $fx_line) { break }
   if ($fx_line -eq '') { continue }
   $fx_id = ''
+  $fx_req = $null
   $fx_msOut = $null
   $fx_msErr = $null
   $fx_outW = $null
@@ -1395,20 +1419,47 @@ while ($true) {
     try { [Console]::SetOut($fx_oldOut) } catch {}
     try { [Console]::SetError($fx_oldErr) } catch {}
   }
-  $fx_outB64 = ''
-  $fx_errB64 = ''
-  if ($null -ne $fx_msOut) { $fx_outB64 = [Convert]::ToBase64String($fx_msOut.ToArray()) }
-  if ($null -ne $fx_msErr) { $fx_errB64 = [Convert]::ToBase64String($fx_msErr.ToArray()) }
   $fx_code = 0
   try { $fx_code = [int]$script:fx_exit } catch { $fx_code = 1 }
-  $fx_res = @{ id = $fx_id; stdoutB64 = $fx_outB64; stderrB64 = $fx_errB64; exitCode = $fx_code }
-  try {
-    $fx_json = $fx_res | ConvertTo-Json -Compress
-  } catch {
-    $fx_msg = 'fauxnix: host result exceeded ConvertTo-Json MaxJsonLength (~2MB)'
-    $fx_res = @{ id = $fx_id; stdoutB64 = ''; stderrB64 = [Convert]::ToBase64String($fx_utf8.GetBytes($fx_msg)); exitCode = 1 }
-    $fx_json = $fx_res | ConvertTo-Json -Compress
+  $fx_v2 = $false
+  if ($null -ne $fx_req -and $null -ne $fx_req.PSObject.Properties['v']) {
+    if ([int]$fx_req.v -eq 2) { $fx_v2 = $true }
   }
-  $fx_proto.WriteLine($fx_json)
+  $fx_outBytes = New-Object byte[] 0
+  $fx_errBytes = New-Object byte[] 0
+  if ($null -ne $fx_msOut) { $fx_outBytes = $fx_msOut.ToArray() }
+  if ($null -ne $fx_msErr) { $fx_errBytes = $fx_msErr.ToArray() }
+  if ($fx_v2) {
+    $fx_outLimit = 8388608
+    $fx_errLimit = 1048576
+    if ($null -ne $fx_req.PSObject.Properties['stdoutLimit']) { $fx_outLimit = [int]$fx_req.stdoutLimit }
+    if ($null -ne $fx_req.PSObject.Properties['stderrLimit']) { $fx_errLimit = [int]$fx_req.stderrLimit }
+    $fx_outSeq = 0
+    $fx_errSeq = 0
+    $fx_trunc = $false
+    if (fx-emit-chunks 'stdout' $fx_id $fx_outBytes $fx_outLimit ([ref]$fx_outSeq)) { $fx_trunc = $true }
+    if (fx-emit-chunks 'stderr' $fx_id $fx_errBytes $fx_errLimit ([ref]$fx_errSeq)) { $fx_trunc = $true }
+    $fx_nativeErr = [Console]::OpenStandardError()
+    $fx_mark = $fx_utf8.GetBytes(('FAUXNIX_ERR_END:' + $fx_id + [char]10))
+    $fx_nativeErr.Write($fx_mark, 0, $fx_mark.Length)
+    $fx_nativeErr.Flush()
+    $fx_end = '{"v":2,"type":"end","id":"' + $fx_id + '","exitCode":' + $fx_code + ',"timedOut":false,"cancelled":false,"truncated":'
+    if ($fx_trunc) { $fx_end = $fx_end + 'true}' } else { $fx_end = $fx_end + 'false}' }
+    $fx_proto.WriteLine($fx_end)
+  } else {
+    $fx_outB64 = ''
+    $fx_errB64 = ''
+    if ($fx_outBytes.Length -gt 0) { $fx_outB64 = [Convert]::ToBase64String($fx_outBytes) }
+    if ($fx_errBytes.Length -gt 0) { $fx_errB64 = [Convert]::ToBase64String($fx_errBytes) }
+    $fx_res = @{ id = $fx_id; stdoutB64 = $fx_outB64; stderrB64 = $fx_errB64; exitCode = $fx_code }
+    try {
+      $fx_json = $fx_res | ConvertTo-Json -Compress
+    } catch {
+      $fx_msg = 'fauxnix: host result exceeded ConvertTo-Json MaxJsonLength (~2MB)'
+      $fx_res = @{ id = $fx_id; stdoutB64 = ''; stderrB64 = [Convert]::ToBase64String($fx_utf8.GetBytes($fx_msg)); exitCode = 1 }
+      $fx_json = $fx_res | ConvertTo-Json -Compress
+    }
+    $fx_proto.WriteLine($fx_json)
+  }
 }
 `.trim();

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1233,6 +1233,23 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stderr).toContain("invalid option -- 'z'");
     expect(readFileSync(join(dir, 'cp-z-dst.txt'), 'utf8')).toBe('DST\n');
   });
+  it('v2 host truncates stdout at the per-run budget', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const r = await extra.run(translateCommandList(parseCommand('printf AAAAAAAAAA')), {
+        stdoutLimit: 4,
+      });
+      expect(r.truncated).toBe(true);
+      expect(Buffer.byteLength(r.stdout, 'utf8')).toBeLessThanOrEqual(4);
+      const hi = await extra.run(translateCommandList(parseCommand('echo hi')));
+      expect(hi.exitCode).toBe(0);
+      expect(hi.stdout.trim()).toBe('hi');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
   it('whitespace-only stdout is preserved', async () => {
     const r = await run("printf '   '");
     expect(r.exitCode).toBe(0);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -14,7 +14,7 @@ import {
 import { listCommandsJson, lookup, lookupSpec, parseWords, psStr } from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import { normalizeStderr } from '../src/errors.js';
-import { decodeHostResponse, encodeHostRequest } from '../src/ps-host.js';
+import { decodeHostResponse, encodeHostRequest, parseHostLine } from '../src/ps-host.js';
 import { bashToolResult, formatBashText } from '../src/mcp.js';
 import '../src/commands/install-all.js';
 
@@ -475,7 +475,9 @@ describe('translator', () => {
     const boot = hostBootstrapScript();
     expect(boot).toContain('function fx-arrload');
     expect(boot).toContain('function fx-csub');
-    expect(boot).toContain('{"ready":true}');
+    expect(boot).toContain('"type":"ready"');
+    expect(boot).toContain('FAUXNIX_ERR_END:');
+    expect(boot).toContain('maxChunkBytes');
     expect(boot).toContain('ConvertFrom-Json');
     expect(boot).toContain('MaxJsonLength');
     expect(boot).not.toContain('exit $script:fx_exit');
@@ -662,6 +664,18 @@ describe('persistent PowerShell host protocol', () => {
     expect(msg.stderr.toString('utf8')).toBe('err');
     expect(msg.exitCode).toBe(2);
     expect(decodeHostResponse('{"ready":true}').ready).toBe(true);
+  });
+
+  it('encodes v2 run frames and parses v2 ready / v1 ready', () => {
+    const line = encodeHostRequest('r1', 'echo', { FAUXNIX_CWD: 'D:\\tmp' }, { v: 2, stdoutLimit: 10, stderrLimit: 4 });
+    const parsed = JSON.parse(line) as { v: number; type: string; stdoutLimit: number };
+    expect(parsed.v).toBe(2);
+    expect(parsed.type).toBe('run');
+    expect(parsed.stdoutLimit).toBe(10);
+    expect(parseHostLine('{"v":2,"type":"ready","capabilities":{"cancel":false}}').v2?.type).toBe(
+      'ready',
+    );
+    expect(parseHostLine('{"ready":true}').v1Ready).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Why

#129 PR-B: the v1 one-line host frame still hits ConvertTo-Json ~2MB and cannot bound native stderr across two OS pipes. #138 landed the MCP/lifecycle contract on that v1 frame.

## What

- Handshake `{"v":2,"type":"ready","capabilities":{"cancel":false,"maxChunkBytes":65536,"stderrMarker":true}}`. Node still accepts `{"ready":true}`.
- v2 `run` carries `stdoutLimit`/`stderrLimit`. Missing limits do not become 0 (`[int]$null` pitfall).
- Chunked `stdout`/`stderr` frames with per-stream `seq`, then `end` with `truncated`.
- `FAUXNIX_ERR_END:<id>` on the process stderr pipe; Node splits native bytes on that marker.
- `capabilities.cancel` is **false** — in-flight cancel is still process kill + cold start (#138).

## Tests

- Unit: v2 encode/parse, v1 ready still decodes, bootstrap contains the marker and chunk helpers.
- Integration: per-run `stdoutLimit: 4` truncates `printf AAAAAAAAAA` and the next `echo hi` still works; existing cancel/native-stderr tests stay green.
