### PR TITLE
feat: CommandSpec for remaining file commands (skip find)

### DIFF
--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -66,8 +66,9 @@ function psArray(words: Word[], fn: (w: Word) => string = operandExpr): string {
 /* ------------------------------------------------------------------ */
 
 const ls: Handler = (args) => {
-  const { flags, longs, operandWords } = parseWords(args);
-  const long = flags.has('l') || longs.has('--format=long') || longs.has('--long');
+  const { flags, longs, values, operandWords } = parseWords(args, [], ['--format']);
+  const long =
+    flags.has('l') || longs.has('--long') || values.get('--format') === 'long';
   const all = flags.has('a') || longs.has('--all');
   const almost = flags.has('A') || longs.has('--almost-all');
   const dirOnly = flags.has('d') || longs.has('--directory');
@@ -230,7 +231,7 @@ const rm: Handler = (args) => {
 const mkdir: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args);
   const parents = flags.has('p') || longs.has('--parents');
-  const verbose = flags.has('v');
+  const verbose = flags.has('v') || longs.has('--verbose');
   return [
     '$fx_dirs = ' + psArray(operandWords),
     "if ($fx_dirs.Count -eq 0) { [Console]::Error.WriteLine('mkdir: missing operand'); $script:fx_exit = 1 }",
@@ -279,8 +280,8 @@ const touch: Handler = (args) => {
 };
 
 const mktemp: Handler = (args) => {
-  const { flags } = parseWords(args);
-  const dir = flags.has('d');
+  const { flags, longs } = parseWords(args);
+  const dir = flags.has('d') || longs.has('--directory');
   return [
     'try {',
     '  if (' + (dir ? '$true' : '$false') + ') {',
@@ -299,8 +300,8 @@ const mktemp: Handler = (args) => {
 /* ------------------------------------------------------------------ */
 
 const ln: Handler = (args) => {
-  const { flags, operandWords } = parseWords(args);
-  const sym = flags.has('s');
+  const { flags, longs, operandWords } = parseWords(args);
+  const sym = flags.has('s') || longs.has('--symbolic');
   const kind = sym ? 'SymbolicLink' : 'HardLink';
   const label = sym ? 'symbolic link' : 'hard link';
   return [
@@ -316,8 +317,8 @@ const ln: Handler = (args) => {
 };
 
 const readlink: Handler = (args) => {
-  const { flags, operandWords } = parseWords(args);
-  const canon = flags.has('f');
+  const { flags, longs, operandWords } = parseWords(args);
+  const canon = flags.has('f') || longs.has('--canonicalize');
   return [
     '$fx_p = ' + (operandWords.length ? operandExpr(operandWords[0]) : "''"),
     "if ($fx_p -eq '') { [Console]::Error.WriteLine('readlink: missing operand'); $script:fx_exit = 1 }",
@@ -491,8 +492,8 @@ const du: Handler = (args) => {
 };
 
 const df: Handler = (args) => {
-  const { flags } = parseWords(args);
-  const human = flags.has('h') || flags.has('H');
+  const { flags, longs } = parseWords(args);
+  const human = flags.has('h') || flags.has('H') || longs.has('--human-readable');
   return [
     PS_HSIZE_FN,
     '"Filesystem      Size  Used Avail Use% Mounted on"',
@@ -865,9 +866,9 @@ const chown: Handler = () => {
 /* ------------------------------------------------------------------ */
 
 const diff: Handler = (args) => {
-  const { flags, operandWords } = parseWords(args);
-  const unified = flags.has('u') || flags.has('U');
-  const brief = flags.has('q') || flags.has('brief');
+  const { flags, longs, operandWords } = parseWords(args);
+  const unified = flags.has('u') || flags.has('U') || longs.has('--unified');
+  const brief = flags.has('q') || longs.has('--brief');
   void unified;
   return [
     PS_READTEXT_FN,
@@ -1006,25 +1007,61 @@ export const specs: CommandSpec[] = [
     [opt('c', '--no-create')],
     touch,
   ),
+  fileSpec(
+    ['ls', 'll'],
+    ['read'],
+    [
+      opt('l', '--long'),
+      opt(undefined, '--format', 'implemented', { takesValue: true }),
+      opt('a', '--all'),
+      opt('A', '--almost-all'),
+      opt('d', '--directory'),
+      opt('h', '--human-readable'),
+      opt('F', '--classify'),
+      opt('p', undefined),
+      opt('t', undefined),
+      opt('S', undefined),
+      opt('r', undefined),
+      opt('R', '--recursive', 'unsupported', { reason: 'recursive listing' }),
+    ],
+    ls,
+  ),
+  fileSpec(['mkdir'], ['write'], [opt('p', '--parents'), opt('v', '--verbose')], mkdir),
+  fileSpec(['rmdir'], ['delete'], [], rmdir),
+  fileSpec(['mktemp'], ['write'], [opt('d', '--directory')], mktemp),
+  fileSpec(['ln'], ['read', 'write'], [opt('s', '--symbolic')], ln),
+  fileSpec(['readlink'], ['read'], [opt('f', '--canonicalize')], readlink),
+  fileSpec(['realpath'], ['read'], [], realpath),
+  fileSpec(['basename'], ['read'], [], basename),
+  fileSpec(['dirname'], ['read'], [], dirname),
+  fileSpec(
+    ['stat'],
+    ['read'],
+    [
+      opt('c', undefined, 'implemented', { takesValue: true }),
+      opt(undefined, '--format', 'implemented', { takesValue: true }),
+      opt(undefined, '--printf', 'implemented', { takesValue: true }),
+    ],
+    stat,
+  ),
+  fileSpec(['file'], ['read'], [], file),
+  fileSpec(['df'], ['read'], [opt('h', '--human-readable'), opt('H', undefined)], df),
+  fileSpec(
+    ['chmod'],
+    ['write'],
+    [opt('R', '--recursive', 'unsupported', { reason: 'recursive chmod' })],
+    chmod,
+  ),
+  fileSpec(['chown'], ['write'], [], chown),
+  fileSpec(
+    ['diff'],
+    ['read'],
+    [opt('q', '--brief'), opt('u', '--unified'), opt('U', undefined)],
+    diff,
+  ),
 ];
 
 export const handlers: Record<string, Handler> = {
-  ls,
-  ll: ls, // common alias
-  mkdir,
-  rmdir,
-  mktemp,
-  ln,
-  readlink,
-  realpath,
-  basename,
-  dirname,
-  stat,
-  file,
   du,
-  df,
   find,
-  chmod,
-  chown,
-  diff,
 };

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -745,13 +745,10 @@ describe('CommandSpec (#130)', () => {
     expect(bodyOf('tee out.txt')).toContain('if ($false)');
   });
 
-  it('spec\'d rm fails loud on unknown flags; unspec\'d ls still ignores them', () => {
+  it('spec\'d rm fails loud on unknown flags', () => {
     const rm = bodyOf('rm -z x');
     expect(rm).toContain("invalid option -- ''z''");
     expect(rm).not.toContain('Remove-Item');
-    const ls = bodyOf('ls -Z');
-    expect(ls).not.toContain('invalid option');
-    expect(ls).toContain('Get-ChildItem');
   });
 
   it('rm --verbose matches -v; tee -i is not silently ignored', () => {
@@ -767,10 +764,32 @@ describe('CommandSpec (#130)', () => {
     expect(cp?.spec?.options.some((o) => o.short === 'n' && o.support === 'implemented')).toBe(
       true,
     );
-    expect(rows.find((r) => r.name === 'ls')?.spec).toBeNull();
+    expect(rows.find((r) => r.name === 'ls')?.spec).toBeTruthy();
     expect(lookupSpec('cp')).toBeTruthy();
-    expect(lookupSpec('ls')).toBeUndefined();
+    expect(lookupSpec('ls')).toBeTruthy();
+    expect(lookupSpec('find')).toBeUndefined();
     expect(lookup('tee')).toBeTypeOf('function');
+  });
+});
+
+describe('CommandSpec files leftovers (#130)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+
+  it('ls unknown flags fail loud; --format=long still means -l', () => {
+    expect(bodyOf('ls -Z')).toContain("invalid option -- ''Z''");
+    expect(bodyOf('ls --format=long')).toContain("'{0} 1");
+    expect(bodyOf('ls --recursive')).toContain('not supported by fauxnix');
+  });
+
+  it('chmod -R is unsupported; find stays unspec\'d so -name still compiles', () => {
+    expect(bodyOf('chmod -R 644 x')).toContain('not supported by fauxnix');
+    expect(bodyOf("find . -name '*.ts'")).toContain('-clike');
+    expect(lookupSpec('find')).toBeUndefined();
+  });
+
+  it('mkdir --verbose and ln --symbolic are implemented longs', () => {
+    expect(bodyOf('mkdir --verbose d')).toContain('if ($true)');
+    expect(bodyOf('ln --symbolic a b')).toContain('SymbolicLink');
   });
 });
 


### PR DESCRIPTION
## Why

#130 / #143: after the destructive five, the rest of `files.ts` still ignored unknown flags. The remaining-specs workflow listed this as family PR 1.

**`find` is not spec'd.** `specOptionError` would treat `-name` as bundled shorts.

## What

- CommandSpec for: `ls`/`ll`, `mkdir`, `rmdir`, `mktemp`, `ln`, `readlink`, `realpath`, `basename`, `dirname`, `stat`, `file`, `df`, `chmod`, `chown`, `diff`.
- Implemented longs actually wired: `ls --format=long`, `mkdir --verbose`, `mktemp --directory`, `ln --symbolic`, `readlink --canonicalize`, `df --human-readable`, `diff --brief`.
- `chmod -R` / `ls --recursive` fail loud (unsupported), not silent ignore.
- `du` stays on #141. `find` stays unspec'd.

## Tests

Unknown `ls -Z`, `chmod -R` unsupported, `find . -name '*.ts'` still compiles, `mkdir --verbose` / `ln --symbolic` emit the implemented path.
