### PR TITLE
release: v0.9.0 — protocol v2 + bounded outputs (#141 #142 #144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.9.0 — 2026-08-23
+
+Protocol v2 + bounded outputs (#141 #142 #144):
+
+- **Host protocol v2** (#129 PR-B): versioned handshake (v1 still accepted),
+  chunked stdout/stderr frames with per-stream seq, per-run
+  `stdoutLimit`/`stderrLimit` with explicit `truncated` markers, and a
+  native-stderr end marker so bytes from `git`/`npm`/`node` return exactly
+  once — the audit's "native stderr dropped" gap is closed
+- **Bootstrap slimmed**: first frame after prewarm back to **~0.27s** (from
+  0.7s; was 0.137s pre-#138) and prewarm itself to ~0.6s (from ~2s) —
+  closes the #140 regression; warm frames unchanged (~40ms)
+- **Bounded-output family spec'd** (#141): `grep -m`, `head --lines`,
+  `du --max-depth` match GNU (differential 5/5 vs real bash);
+  `docs/command-specs.md` generated from CommandSpec
+- **File-command specs expanded** (#144): ls/mkdir/rmdir/mktemp/ln/readlink/
+  realpath/basename/dirname/stat… — unknown options fail loud (e.g.
+  `ls -Z` is now a usage error)
+
+197 tests.
 ## v0.8.0 — 2026-08-23
 
 Execution-contract wave (#129 PR-A + #130 first families + syntax fail-loud):

--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ development:
   translate time (unsupported constructs throw named errors, never silently misbehave)
 - **text I/O**: `echo printf cat head tail wc tee nl tac md5sum sha1sum sha256sum base64 seq yes xargs`
 
-`cp` / `mv` / `rm` / `touch` / `tee` carry a `CommandSpec`: unknown options fail with a GNU-style
-usage error instead of being ignored. `cp -n` / `mv -n` / `touch -c` / `tee --append` match GNU
-(no clobber / no-create / append). `fauxnix list --json` dumps the same capability metadata.
+`cp` / `mv` / `rm` / `touch` / `tee` / `grep` / `head` / `du` carry a `CommandSpec`: unknown
+options fail with a GNU-style usage error instead of being ignored. Implemented GNU holes:
+`cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` / `head --lines` / `du --max-depth`.
+`fauxnix list --json` and `docs/command-specs.md` dump the same metadata.
 - **shell/system**: `cd pwd export unset env printenv ps kill pkill pgrep sleep which type whoami
   id groups date uname hostname uptime free nproc clear true false test [ [[ : pushd popd dirs sudo
   timeout man history less more source . eval exit alias set`

--- a/docs/command-specs.md
+++ b/docs/command-specs.md
@@ -1,0 +1,110 @@
+# Command specs
+
+Generated from `CommandSpec`. Unlisted commands still use unchecked `parseWords` (unknown flags ignored). Spec'd commands fail loud on unknown or unsupported options.
+
+## `cp`
+
+Effects: `read`, `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-r` | flag | implemented |
+| `-R`, `--recursive` | flag | implemented |
+| `-v`, `--verbose` | flag | implemented |
+| `-n`, `--no-clobber` | flag | implemented |
+| `-f`, `--force` | flag | implemented |
+| `-i`, `--interactive` | flag | unsupported (interactive prompt) |
+
+## `mv`
+
+Effects: `read`, `write`, `delete`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-v`, `--verbose` | flag | implemented |
+| `-n`, `--no-clobber` | flag | implemented |
+| `-f`, `--force` | flag | implemented |
+| `-i`, `--interactive` | flag | unsupported (interactive prompt) |
+
+## `rm`
+
+Effects: `delete`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-r` | flag | implemented |
+| `-R`, `--recursive` | flag | implemented |
+| `-f`, `--force` | flag | implemented |
+| `-v`, `--verbose` | flag | implemented |
+| `-i`, `--interactive` | flag | unsupported (interactive prompt) |
+
+## `touch`
+
+Effects: `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-c`, `--no-create` | flag | implemented |
+
+## `du`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-s`, `--summarize` | flag | implemented |
+| `-h`, `--human-readable` | flag | implemented |
+| `-d`, `--max-depth` | required | implemented |
+
+## `tee`
+
+Effects: `read`, `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-a`, `--append` | flag | implemented |
+
+## `head`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-n`, `--lines` | required | implemented |
+| `-c`, `--bytes` | required | implemented |
+| `-q`, `--quiet` | flag | implemented |
+| `--silent` | flag | implemented |
+| `-v`, `--verbose` | flag | implemented |
+
+## `grep`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-i` | flag | implemented |
+| `-v` | flag | implemented |
+| `-n` | flag | implemented |
+| `-c` | flag | implemented |
+| `-l` | flag | implemented |
+| `-r` | flag | implemented |
+| `-R` | flag | implemented |
+| `-E` | flag | implemented |
+| `-F` | flag | implemented |
+| `-w` | flag | implemented |
+| `-q` | flag | implemented |
+| `-o` | flag | implemented |
+| `-h` | flag | implemented |
+| `-H` | flag | implemented |
+| `-A` | required | implemented |
+| `-B` | required | implemented |
+| `-C` | required | implemented |
+| `-m`, `--max-count` | required | implemented |
+| `-e`, `--regexp` | required | implemented |
+| `--include` | required | implemented |
+| `--exclude` | required | implemented |
+| `--exclude-dir` | required | implemented |
+
+## Unspec'd commands
+
+`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `basename`, `cat`, `cd`, `chmod`, `chown`, `clear`, `command`, `curl`, `cut`, `date`, `df`, `diff`, `dig`, `dirname`, `dirs`, `echo`, `egrep`, `env`, `eval`, `exit`, `export`, `false`, `file`, `find`, `free`, `groups`, `gunzip`, `gzip`, `history`, `host`, `hostname`, `id`, `ifconfig`, `ip`, `kill`, `less`, `ll`, `ln`, `ls`, `man`, `md5sum`, `mkdir`, `mktemp`, `more`, `netstat`, `nl`, `nproc`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `printenv`, `printf`, `ps`, `pushd`, `pwd`, `read`, `readlink`, `realpath`, `rmdir`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `sleep`, `sort`, `source`, `ss`, `stat`, `sudo`, `tac`, `tail`, `tar`, `test`, `timeout`, `tr`, `true`, `type`, `uname`, `uniq`, `unset`, `unzip`, `uptime`, `wc`, `wget`, `which`, `whoami`, `xargs`, `yes`, `zcat`, `zip`

--- a/docs/rfc-bounded-cancellable-execution.md
+++ b/docs/rfc-bounded-cancellable-execution.md
@@ -29,7 +29,7 @@ These are one cluster: framing, limits, cancellation, and lifecycle need an expl
 | PR | Ships | Does not ship |
 |---|---|---|
 | **A (this land)** | RFC; structured MCP results; `extra.signal` cancel by killing the host (same recovery as timeout); one lock for run/reset/dispose; dispose on stdin EOF / SIGINT / SIGTERM; stop `.trim()` of whitespace-only stdout; drain/clear native `stderrChunks` per request; ConvertTo-Json overflow becomes a loud frame error instead of a dead loop | v2 handshake, chunked frames, deterministic native-stderr marker |
-| **B (follow-up)** | `{v:2,type:ready,…}` handshake (still accept v1 `{ready:true}`); chunked stdout/stderr + `end`; `stdoutLimit`/`stderrLimit` + `truncated`; `FAUXNIX_ERR_END:<id>` marker on the OS stderr pipe so native bytes return exactly once | runspace `Stop()` in-flight cancel; Job Object tree kill; Linux/macOS |
+| **B (this land)** | `{v:2,type:ready,…}` handshake (still accept v1 `{ready:true}`); chunked stdout/stderr + `end`; `stdoutLimit`/`stderrLimit` + `truncated`; `FAUXNIX_ERR_END:<id>` marker on the OS stderr pipe so native bytes return exactly once | runspace `Stop()` in-flight cancel; Job Object tree kill; Linux/macOS |
 
 PR-A keeps speaking the v1 host frame:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fauxnix-cli",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Fauxnix — run Linux-style commands on Windows via deterministic PowerShell translation. No VM, no WSL. MCP server + CLI for AI agents.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { FauxnixSession } from './executor.js';
 import { parseCommand } from './parser.js';
 import { translateCommandList } from './translator.js';
-import { listCommandsJson, registeredNames } from './registry.js';
+import { listCommandsJson, registeredNames, specsMarkdown } from './registry.js';
 import { encodeCommand } from './encoding.js';
 import { startMcpServer } from './mcp.js';
 import { packageVersion } from './version.js';
@@ -17,6 +17,7 @@ Usage:
   fauxnix mcp                        start the MCP stdio server (for agent harnesses)
   fauxnix list                       list translated commands
   fauxnix list --json                same list as machine-readable capability metadata
+  fauxnix list --markdown            CommandSpec tables (same text as docs/command-specs.md)
   fauxnix check                      verify the local PowerShell environment
   fauxnix --version
 
@@ -39,6 +40,10 @@ export async function runCli(argv: string[]): Promise<void> {
   if (verb === 'list') {
     if (rest[0] === '--json') {
       console.log(JSON.stringify(listCommandsJson(), null, 2));
+      return;
+    }
+    if (rest[0] === '--markdown') {
+      console.log(specsMarkdown());
       return;
     }
     const names = registeredNames();

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -66,8 +66,9 @@ function psArray(words: Word[], fn: (w: Word) => string = operandExpr): string {
 /* ------------------------------------------------------------------ */
 
 const ls: Handler = (args) => {
-  const { flags, longs, operandWords } = parseWords(args);
-  const long = flags.has('l') || longs.has('--format=long') || longs.has('--long');
+  const { flags, longs, values, operandWords } = parseWords(args, [], ['--format']);
+  const long =
+    flags.has('l') || longs.has('--long') || values.get('--format') === 'long';
   const all = flags.has('a') || longs.has('--all');
   const almost = flags.has('A') || longs.has('--almost-all');
   const dirOnly = flags.has('d') || longs.has('--directory');
@@ -230,7 +231,7 @@ const rm: Handler = (args) => {
 const mkdir: Handler = (args) => {
   const { flags, longs, operandWords } = parseWords(args);
   const parents = flags.has('p') || longs.has('--parents');
-  const verbose = flags.has('v');
+  const verbose = flags.has('v') || longs.has('--verbose');
   return [
     '$fx_dirs = ' + psArray(operandWords),
     "if ($fx_dirs.Count -eq 0) { [Console]::Error.WriteLine('mkdir: missing operand'); $script:fx_exit = 1 }",
@@ -279,8 +280,8 @@ const touch: Handler = (args) => {
 };
 
 const mktemp: Handler = (args) => {
-  const { flags } = parseWords(args);
-  const dir = flags.has('d');
+  const { flags, longs } = parseWords(args);
+  const dir = flags.has('d') || longs.has('--directory');
   return [
     'try {',
     '  if (' + (dir ? '$true' : '$false') + ') {',
@@ -299,8 +300,8 @@ const mktemp: Handler = (args) => {
 /* ------------------------------------------------------------------ */
 
 const ln: Handler = (args) => {
-  const { flags, operandWords } = parseWords(args);
-  const sym = flags.has('s');
+  const { flags, longs, operandWords } = parseWords(args);
+  const sym = flags.has('s') || longs.has('--symbolic');
   const kind = sym ? 'SymbolicLink' : 'HardLink';
   const label = sym ? 'symbolic link' : 'hard link';
   return [
@@ -316,8 +317,8 @@ const ln: Handler = (args) => {
 };
 
 const readlink: Handler = (args) => {
-  const { flags, operandWords } = parseWords(args);
-  const canon = flags.has('f');
+  const { flags, longs, operandWords } = parseWords(args);
+  const canon = flags.has('f') || longs.has('--canonicalize');
   return [
     '$fx_p = ' + (operandWords.length ? operandExpr(operandWords[0]) : "''"),
     "if ($fx_p -eq '') { [Console]::Error.WriteLine('readlink: missing operand'); $script:fx_exit = 1 }",
@@ -491,8 +492,8 @@ const du: Handler = (args) => {
 };
 
 const df: Handler = (args) => {
-  const { flags } = parseWords(args);
-  const human = flags.has('h') || flags.has('H');
+  const { flags, longs } = parseWords(args);
+  const human = flags.has('h') || flags.has('H') || longs.has('--human-readable');
   return [
     PS_HSIZE_FN,
     '"Filesystem      Size  Used Avail Use% Mounted on"',
@@ -865,9 +866,9 @@ const chown: Handler = () => {
 /* ------------------------------------------------------------------ */
 
 const diff: Handler = (args) => {
-  const { flags, operandWords } = parseWords(args);
-  const unified = flags.has('u') || flags.has('U');
-  const brief = flags.has('q') || flags.has('brief');
+  const { flags, longs, operandWords } = parseWords(args);
+  const unified = flags.has('u') || flags.has('U') || longs.has('--unified');
+  const brief = flags.has('q') || longs.has('--brief');
   void unified;
   return [
     PS_READTEXT_FN,
@@ -1006,25 +1007,61 @@ export const specs: CommandSpec[] = [
     [opt('c', '--no-create')],
     touch,
   ),
+  fileSpec(
+    ['ls', 'll'],
+    ['read'],
+    [
+      opt('l', '--long'),
+      opt(undefined, '--format', 'implemented', { takesValue: true }),
+      opt('a', '--all'),
+      opt('A', '--almost-all'),
+      opt('d', '--directory'),
+      opt('h', '--human-readable'),
+      opt('F', '--classify'),
+      opt('p', undefined),
+      opt('t', undefined),
+      opt('S', undefined),
+      opt('r', undefined),
+      opt('R', '--recursive', 'unsupported', { reason: 'recursive listing' }),
+    ],
+    ls,
+  ),
+  fileSpec(['mkdir'], ['write'], [opt('p', '--parents'), opt('v', '--verbose')], mkdir),
+  fileSpec(['rmdir'], ['delete'], [], rmdir),
+  fileSpec(['mktemp'], ['write'], [opt('d', '--directory')], mktemp),
+  fileSpec(['ln'], ['read', 'write'], [opt('s', '--symbolic')], ln),
+  fileSpec(['readlink'], ['read'], [opt('f', '--canonicalize')], readlink),
+  fileSpec(['realpath'], ['read'], [], realpath),
+  fileSpec(['basename'], ['read'], [], basename),
+  fileSpec(['dirname'], ['read'], [], dirname),
+  fileSpec(
+    ['stat'],
+    ['read'],
+    [
+      opt('c', undefined, 'implemented', { takesValue: true }),
+      opt(undefined, '--format', 'implemented', { takesValue: true }),
+      opt(undefined, '--printf', 'implemented', { takesValue: true }),
+    ],
+    stat,
+  ),
+  fileSpec(['file'], ['read'], [], file),
+  fileSpec(['df'], ['read'], [opt('h', '--human-readable'), opt('H', undefined)], df),
+  fileSpec(
+    ['chmod'],
+    ['write'],
+    [opt('R', '--recursive', 'unsupported', { reason: 'recursive chmod' })],
+    chmod,
+  ),
+  fileSpec(['chown'], ['write'], [], chown),
+  fileSpec(
+    ['diff'],
+    ['read'],
+    [opt('q', '--brief'), opt('u', '--unified'), opt('U', undefined)],
+    diff,
+  ),
 ];
 
 export const handlers: Record<string, Handler> = {
-  ls,
-  ll: ls, // common alias
-  mkdir,
-  rmdir,
-  mktemp,
-  ln,
-  readlink,
-  realpath,
-  basename,
-  dirname,
-  stat,
-  file,
   du,
-  df,
   find,
-  chmod,
-  chown,
-  diff,
 };

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -459,10 +459,41 @@ const file: Handler = (args) => {
 /* ------------------------------------------------------------------ */
 
 const du: Handler = (args) => {
-  const { flags, longs, operandWords } = parseWords(args, [], ['--max-depth']);
+  const { flags, longs, values, missingValue, operandWords } = parseWords(
+    args,
+    ['d'],
+    ['--max-depth'],
+  );
   const sum = flags.has('s') || longs.has('--summarize');
   const human = flags.has('h') || longs.has('--human-readable');
+  if (missingValue.includes('-d') || missingValue.includes('--max-depth')) {
+    return (
+      '[Console]::Error.WriteLine(' +
+      psStr("du: option requires an argument -- 'max-depth'") +
+      '); $script:fx_exit = 1'
+    );
+  }
+  const maxDepthRaw = values.get('-d') ?? values.get('--max-depth');
+  let maxDepth: number | null = null;
+  if (maxDepthRaw !== undefined) {
+    if (!/^\d+$/.test(maxDepthRaw)) {
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr("du: invalid maximum depth '" + maxDepthRaw + "'") +
+        '); $script:fx_exit = 1'
+      );
+    }
+    maxDepth = parseInt(maxDepthRaw, 10);
+  }
+  if (sum && maxDepth !== null && maxDepth !== 0) {
+    return (
+      '[Console]::Error.WriteLine(' +
+      psStr('du: summarizing conflicts with --max-depth=' + String(maxDepth)) +
+      '); $script:fx_exit = 1'
+    );
+  }
   const targets = operandWords.length ? argListExpr(operandWords) : "@('.')";
+  const onlyRoot = sum || maxDepth === 0;
   return [
     PS_HSIZE_FN,
     'function fx-size($p) {',
@@ -473,7 +504,7 @@ const du: Handler = (args) => {
     '$fx_ts = ' + targets,
     'foreach ($fx_t in $fx_ts) {',
     '  if (-not (Test-Path -LiteralPath $fx_t)) { [Console]::Error.WriteLine("du: cannot access \'" + $fx_t + "\': No such file or directory"); $script:fx_exit = 1; continue }',
-    '  if (' + (sum ? '$true' : '$false') + ') {',
+    '  if (' + (onlyRoot ? '$true' : '$false') + ') {',
     '    $fx_kb = fx-size $fx_t',
     '    if (' + (human ? '$true' : '$false') + ') { "{0}`t{1}" -f (fx-hsize ($fx_kb * 1KB)), $fx_t } else { "{0}`t{1}" -f $fx_kb, $fx_t }',
     '  } else {',
@@ -481,6 +512,11 @@ const du: Handler = (args) => {
     '    foreach ($fx_d in @(Get-ChildItem -LiteralPath $fx_t -Recurse -Force -Directory -ErrorAction SilentlyContinue)) {',
     '      $fx_kb = fx-size $fx_d.FullName',
     "      $fx_rel = './' + $fx_d.FullName.Substring($fx_root.Length).TrimStart('\\').Replace('\\', '/')",
+    maxDepth !== null && maxDepth > 0
+      ? "      $fx_ddepth = @($fx_rel.ToCharArray() | Where-Object { $_ -eq '/' }).Count; if ($fx_ddepth -gt " +
+        maxDepth +
+        ') { continue }'
+      : '',
     '      if (' + (human ? '$true' : '$false') + ') { "{0}`t{1}" -f (fx-hsize ($fx_kb * 1KB)), $fx_rel } else { "{0}`t{1}" -f $fx_kb, $fx_rel }',
     '    }',
     '    $fx_kb = fx-size $fx_t',
@@ -1006,6 +1042,16 @@ export const specs: CommandSpec[] = [
     [opt('c', '--no-create')],
     touch,
   ),
+  fileSpec(
+    ['du'],
+    ['read'],
+    [
+      opt('s', '--summarize'),
+      opt('h', '--human-readable'),
+      opt('d', '--max-depth', 'implemented', { takesValue: true }),
+    ],
+    du,
+  ),
 ];
 
 export const handlers: Record<string, Handler> = {
@@ -1021,7 +1067,6 @@ export const handlers: Record<string, Handler> = {
   dirname,
   stat,
   file,
-  du,
   df,
   find,
   chmod,

--- a/src/commands/install-all.ts
+++ b/src/commands/install-all.ts
@@ -1,6 +1,6 @@
 import { registerAll, registerSpecs } from '../registry.js';
 import { handlers as files, specs as fileSpecs } from './files.js';
-import { handlers as textFilters } from './text-filters.js';
+import { handlers as textFilters, specs as textFilterSpecs } from './text-filters.js';
 import { handlers as textIo, specs as textIoSpecs } from './text-io.js';
 import { handlers as sysinfo } from './sysinfo.js';
 import { handlers as net } from './net.js';
@@ -16,6 +16,7 @@ export function installAll(): void {
   registerAll(archive);
   registerSpecs(fileSpecs);
   registerSpecs(textIoSpecs);
+  registerSpecs(textFilterSpecs);
 }
 
 installAll();

--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { FauxnixParseError, Word, wordToString } from '../ast.js';
-import { Handler, parseWords, psStr } from '../registry.js';
+import { CommandSpec, Handler, parseWords, psStr } from '../registry.js';
 import { argListExpr, exprOfWord, literalOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
@@ -285,16 +285,30 @@ const grep: Handler = (args) => {
 
   const { flags, operandWords, values, missingValue } = parseWords(
     args,
-    ['A', 'B', 'C'],
-    filterOptionNames,
+    ['A', 'B', 'C', 'm', 'e'],
+    [...filterOptionNames, '--max-count', '--regexp'],
   );
-  const missingFilterOption = missingValue.find((o) => filterOptionNames.includes(o));
+  const missingFilterOption = missingValue.find((o) =>
+    [...filterOptionNames, '-m', '--max-count', '-e', '--regexp'].includes(o),
+  );
   if (missingFilterOption) {
     return (
       '[Console]::Error.WriteLine(' +
       psStr("grep: option '" + missingFilterOption + "' requires an argument") +
       '); $script:fx_exit = 2'
     );
+  }
+  const maxCountRaw = values.get('-m') ?? values.get('--max-count');
+  let maxCount: number | null = null;
+  if (maxCountRaw !== undefined) {
+    if (!/^\d+$/.test(maxCountRaw)) {
+      return (
+        '[Console]::Error.WriteLine(' +
+        psStr("grep: invalid max count '" + maxCountRaw + "'") +
+        '); $script:fx_exit = 2'
+      );
+    }
+    maxCount = parseInt(maxCountRaw, 10);
   }
   const ci = flags.has('i');
   const inv = flags.has('v');
@@ -317,13 +331,15 @@ const grep: Handler = (args) => {
   const ctxA = Math.max(toInt(values.get('-A')), toInt(values.get('-C')));
   const ctxB = Math.max(toInt(values.get('-B')), toInt(values.get('-C')));
 
-  if (operandWords.length === 0) {
+  const ePat = values.get('-e') ?? values.get('--regexp');
+  if (ePat === undefined && operandWords.length === 0) {
     return (
       "[Console]::Error.WriteLine('usage: grep [OPTION]... PATTERN [FILE]...'); $script:fx_exit = 2"
     );
   }
-  const patternWord = operandWords[0];
-  const fileWords = operandWords.slice(1);
+  const patternWord: Word =
+    ePat !== undefined ? [{ kind: 'Text', text: ePat }] : operandWords[0];
+  const fileWords = ePat !== undefined ? operandWords : operandWords.slice(1);
   const patLit = literalOfWord(patternWord);
   let patExpr: string;
   if (fixed || patLit === null) {
@@ -490,10 +506,16 @@ const grep: Handler = (args) => {
 
   // --- per-source scan body ----------------------------------------------
   const scan: string[] = [];
+  if (maxCount !== null) scan.push('$fx_mleft = ' + maxCount);
   if (cntMode) {
     scan.push('$fx_c = 0');
     scan.push('for ($fx_i = 0; $fx_i -lt $fx_ls.Count; $fx_i++) {');
-    scan.push('  if (fx-gmatch $fx_ls[$fx_i]) { $fx_c++ }');
+    if (maxCount !== null) scan.push('  if ($fx_mleft -le 0) { break }');
+    scan.push(
+      '  if (fx-gmatch $fx_ls[$fx_i]) { $fx_c++' +
+        (maxCount !== null ? '; $fx_mleft--; if ($fx_mleft -le 0) { break }' : '') +
+        ' }',
+    );
     scan.push('}');
     scan.push('if ($fx_c -gt 0) { $fx_any = $true }');
     scan.push(
@@ -502,19 +524,23 @@ const grep: Handler = (args) => {
   } else if (listMode) {
     scan.push('$fx_hit1 = $false');
     scan.push('for ($fx_i = 0; $fx_i -lt $fx_ls.Count; $fx_i++) {');
+    if (maxCount !== null) scan.push('  if ($fx_mleft -le 0) { break }');
     scan.push('  if (fx-gmatch $fx_ls[$fx_i]) { $fx_hit1 = $true; break }');
     scan.push('}');
     scan.push('if ($fx_hit1) { $fx_any = $true; $fx_disp }');
   } else if (quiet) {
     scan.push('for ($fx_i = 0; $fx_i -lt $fx_ls.Count; $fx_i++) {');
+    if (maxCount !== null) scan.push('  if ($fx_mleft -le 0) { break }');
     scan.push('  if (fx-gmatch $fx_ls[$fx_i]) { $fx_any = $true; break }');
     scan.push('}');
   } else {
     scan.push('$fx_hits = @()');
     scan.push('for ($fx_i = 0; $fx_i -lt $fx_ls.Count; $fx_i++) {');
+    if (maxCount !== null) scan.push('  if ($fx_mleft -le 0) { break }');
     scan.push('  $fx_l = $fx_ls[$fx_i]');
     scan.push('  if (fx-gmatch $fx_l) {');
     scan.push('    $fx_any = $true');
+    if (maxCount !== null) scan.push('    $fx_mleft--');
     if (onlyMatch && !inv) {
       if (fixed) {
         if (ci) {
@@ -552,6 +578,7 @@ const grep: Handler = (args) => {
     } else if (!onlyMatch) {
       scan.push('    $fx_hits += $fx_i');
     }
+    if (maxCount !== null) scan.push('    if ($fx_mleft -le 0) { break }');
     scan.push('  }');
     scan.push('}');
     if (!onlyMatch) {
@@ -2646,8 +2673,42 @@ const tr: Handler = (args) => {
 
 /* ------------------------------------------------------------------ */
 
+export const specs: CommandSpec[] = [
+  {
+    names: ['grep'],
+    options: [
+      { short: 'i', support: 'implemented' },
+      { short: 'v', support: 'implemented' },
+      { short: 'n', support: 'implemented' },
+      { short: 'c', support: 'implemented' },
+      { short: 'l', support: 'implemented' },
+      { short: 'r', support: 'implemented' },
+      { short: 'R', support: 'implemented' },
+      { short: 'E', support: 'implemented' },
+      { short: 'F', support: 'implemented' },
+      { short: 'w', support: 'implemented' },
+      { short: 'q', support: 'implemented' },
+      { short: 'o', support: 'implemented' },
+      { short: 'h', support: 'implemented' },
+      { short: 'H', support: 'implemented' },
+      { short: 'A', takesValue: true, support: 'implemented' },
+      { short: 'B', takesValue: true, support: 'implemented' },
+      { short: 'C', takesValue: true, support: 'implemented' },
+      { short: 'm', long: '--max-count', takesValue: true, support: 'implemented' },
+      { short: 'e', long: '--regexp', takesValue: true, support: 'implemented' },
+      { long: '--include', takesValue: true, support: 'implemented' },
+      { long: '--exclude', takesValue: true, support: 'implemented' },
+      { long: '--exclude-dir', takesValue: true, support: 'implemented' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    usageExit: 2,
+    handler: grep,
+  },
+];
+
 export const handlers: Record<string, Handler> = {
-  grep,
   egrep: (args, ctx) => grep([[{ kind: 'Text', text: '-E' }], ...args], ctx), // egrep = grep -E
   sed,
   awk,

--- a/src/commands/text-io.ts
+++ b/src/commands/text-io.ts
@@ -455,6 +455,34 @@ const head: Handler = (args, ctx) => {
         continue;
       }
       if (t.startsWith('--')) {
+        const eq = t.indexOf('=');
+        const name = eq >= 0 ? t.slice(0, eq) : t;
+        const inline = eq >= 0 ? t.slice(eq + 1) : null;
+        if (name === '--lines' || name === '--bytes') {
+          let val = inline;
+          if (val === null) {
+            if (i + 1 >= args.length) {
+              return psErrExpr(psStr('head: option requires an argument -- ' + name.slice(2)));
+            }
+            val = wordToString(args[i + 1]);
+            i += 2;
+          } else {
+            i++;
+          }
+          if (name === '--bytes') nBytes = val;
+          else nLines = val;
+          continue;
+        }
+        if (name === '--quiet' || name === '--silent') {
+          quiet = true;
+          i++;
+          continue;
+        }
+        if (name === '--verbose') {
+          verbose = true;
+          i++;
+          continue;
+        }
         i++;
         continue;
       }
@@ -494,6 +522,11 @@ const head: Handler = (args, ctx) => {
   }
   const bytesMode = nBytes !== null;
   const countLit = bytesMode ? nBytes! : nLines !== null ? nLines : '10';
+  if (!/^[+-]?\d+$/.test(countLit)) {
+    return psErrExpr(
+      psStr("head: invalid number of " + (bytesMode ? 'bytes' : 'lines') + ": '" + countLit + "'"),
+    );
+  }
 
   const lines: string[] = [
     PS_GLOB_FN,
@@ -587,6 +620,35 @@ const tail: Handler = (args, ctx) => {
         continue;
       }
       if (t.startsWith('--')) {
+        const eq = t.indexOf('=');
+        const name = eq >= 0 ? t.slice(0, eq) : t;
+        const inline = eq >= 0 ? t.slice(eq + 1) : null;
+        if (name === '--lines' || name === '--bytes') {
+          let val = inline;
+          if (val === null) {
+            if (i + 1 >= args.length) {
+              return psErrExpr(psStr('tail: option requires an argument -- ' + name.slice(2)));
+            }
+            val = wordToString(args[i + 1]);
+            i += 2;
+          } else {
+            i++;
+          }
+          if (name === '--bytes') nBytes = val;
+          else if (val.startsWith('+')) fromLine = val.slice(1);
+          else nLines = val.replace(/^-/, '');
+          continue;
+        }
+        if (name === '--quiet' || name === '--silent') {
+          quiet = true;
+          i++;
+          continue;
+        }
+        if (name === '--verbose') {
+          verbose = true;
+          i++;
+          continue;
+        }
         i++;
         continue;
       }
@@ -1313,13 +1375,26 @@ export const specs: CommandSpec[] = [
     dispatch: 'translated',
     handler: tee,
   },
+  {
+    names: ['head'],
+    options: [
+      { short: 'n', long: '--lines', takesValue: true, support: 'implemented' },
+      { short: 'c', long: '--bytes', takesValue: true, support: 'implemented' },
+      { short: 'q', long: '--quiet', support: 'implemented' },
+      { long: '--silent', support: 'implemented' },
+      { short: 'v', long: '--verbose', support: 'implemented' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: head,
+  },
 ];
 
 export const handlers: Record<string, Handler> = {
   echo,
   printf,
   cat,
-  head,
   tail,
   wc,
   nl,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -466,6 +466,7 @@ async function runPlans(
       },
       remainingMs,
       opts.signal,
+      { stdoutLimit, stderrLimit },
     );
 
     if (inv.spawnError === 'ENOENT' || inv.spawnError === 'START') {

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -28,12 +28,48 @@ export interface HostRequestEnv {
   [key: string]: string;
 }
 
-export function encodeHostRequest(id: string, script: string, env: HostRequestEnv): string {
-  return JSON.stringify({
+export function encodeHostRequest(
+  id: string,
+  script: string,
+  env: HostRequestEnv,
+  opts?: { v?: number; stdoutLimit?: number; stderrLimit?: number },
+): string {
+  const body: Record<string, unknown> = {
     id,
     scriptB64: Buffer.from(script, 'utf8').toString('base64'),
     env,
-  });
+  };
+  if (opts?.v === 2) {
+    body.v = 2;
+    body.type = 'run';
+    body.stdoutLimit = opts.stdoutLimit ?? DEFAULT_STDOUT_LIMIT;
+    body.stderrLimit = opts.stderrLimit ?? DEFAULT_STDERR_LIMIT;
+  }
+  return JSON.stringify(body);
+}
+
+export type HostV2Frame =
+  | { v: 2; type: 'ready'; capabilities?: { cancel?: boolean; maxChunkBytes?: number; stderrMarker?: boolean } }
+  | { v: 2; type: 'stdout' | 'stderr'; id: string; seq: number; dataB64: string }
+  | {
+      v: 2;
+      type: 'end';
+      id: string;
+      exitCode: number;
+      timedOut?: boolean;
+      cancelled?: boolean;
+      truncated?: boolean;
+    };
+
+export function parseHostLine(line: string): {
+  v1Ready?: boolean;
+  v2?: HostV2Frame;
+  v1?: ReturnType<typeof decodeHostResponse>;
+} {
+  const j = JSON.parse(line) as Record<string, unknown>;
+  if (j && j.v === 2 && typeof j.type === 'string') return { v2: j as unknown as HostV2Frame };
+  if (j && j.ready === true) return { v1Ready: true };
+  return { v1: decodeHostResponse(line) };
 }
 
 export function decodeHostResponse(line: string): {
@@ -79,6 +115,7 @@ export class PowerShellHost {
   private closed = false;
   private startLock: Promise<void> | null = null;
   private invokeLock: Promise<unknown> = Promise.resolve();
+  protocol: 1 | 2 = 1;
 
   constructor(
     private readonly hostFile: string,
@@ -95,8 +132,11 @@ export class PowerShellHost {
     env: HostRequestEnv,
     timeoutMs: number,
     signal?: AbortSignal,
+    limits?: { stdoutLimit?: number; stderrLimit?: number },
   ): Promise<HostInvokeResult> {
-    const run = this.invokeLock.then(() => this.invokeSerial(script, env, timeoutMs, signal));
+    const run = this.invokeLock.then(() =>
+      this.invokeSerial(script, env, timeoutMs, signal, limits),
+    );
     this.invokeLock = run.then(
       () => undefined,
       () => undefined,
@@ -152,6 +192,7 @@ export class PowerShellHost {
     env: HostRequestEnv,
     timeoutMs: number,
     signal?: AbortSignal,
+    limits?: { stdoutLimit?: number; stderrLimit?: number },
   ): Promise<HostInvokeResult> {
     if (signal?.aborted) {
       await this.stop();
@@ -162,7 +203,14 @@ export class PowerShellHost {
     if (started) return { ...started, cancelled: false, truncated: false };
 
     const id = 'f' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
-    const line = encodeHostRequest(id, script, env);
+    const line = encodeHostRequest(
+      id,
+      script,
+      env,
+      this.protocol === 2
+        ? { v: 2, stdoutLimit: limits?.stdoutLimit, stderrLimit: limits?.stderrLimit }
+        : undefined,
+    );
     try {
       this.proc!.stdin!.write(line + '\n');
     } catch (e) {
@@ -185,6 +233,9 @@ export class PowerShellHost {
     };
     signal?.addEventListener('abort', onAbort, { once: true });
     try {
+      if (this.protocol === 2) {
+        return await this.collectV2(id, timeoutMs);
+      }
       const raw = await this.nextJsonLine(timeoutMs, id);
       const msg = decodeHostResponse(raw);
       const native = this.drainNativeStderr();
@@ -321,10 +372,10 @@ export class PowerShellHost {
     });
     try {
       const readyLine = await this.nextReadyLine(READY_TIMEOUT_MS);
-      const msg = decodeHostResponse(readyLine);
-      if (!msg.ready) {
-        throw new Error('fauxnix: powershell host handshake failed');
-      }
+      const parsed = parseHostLine(readyLine);
+      if (parsed.v2?.type === 'ready') this.protocol = 2;
+      else if (parsed.v1Ready || decodeHostResponse(readyLine).ready) this.protocol = 1;
+      else throw new Error('fauxnix: powershell host handshake failed');
     } catch (e) {
       await this.stop();
       throw e;
@@ -379,8 +430,9 @@ export class PowerShellHost {
       const line = await this.nextLine(Math.max(1, deadline - Date.now()));
       if (!line.trim()) continue;
       try {
-        const msg = decodeHostResponse(line);
-        if (msg.ready) return line;
+        const parsed = parseHostLine(line);
+        if (parsed.v2?.type === 'ready' || parsed.v1Ready) return line;
+        if (parsed.v1?.ready) return line;
       } catch {
         /* skip PS boot noise */
       }
@@ -408,6 +460,71 @@ export class PowerShellHost {
     const err = new Error('fauxnix: powershell host timed out') as Error & { timedOut: boolean };
     err.timedOut = true;
     throw err;
+  }
+
+  private async collectV2(id: string, timeoutMs: number): Promise<HostInvokeResult> {
+    const deadline = Date.now() + timeoutMs;
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    let outSeq = 0;
+    let errSeq = 0;
+    let end: Extract<HostV2Frame, { type: 'end' }> | null = null;
+    while (!end) {
+      const line = await this.nextLine(Math.max(1, deadline - Date.now()));
+      if (!line.trim()) continue;
+      let parsed: ReturnType<typeof parseHostLine>;
+      try {
+        parsed = parseHostLine(line);
+      } catch {
+        continue;
+      }
+      const f = parsed.v2;
+      if (!f) continue;
+      if (f.type === 'stdout' && f.id === id) {
+        if (f.seq !== outSeq) throw new Error('fauxnix: host stdout seq gap');
+        out.push(Buffer.from(f.dataB64 ?? '', 'base64'));
+        outSeq++;
+      } else if (f.type === 'stderr' && f.id === id) {
+        if (f.seq !== errSeq) throw new Error('fauxnix: host stderr seq gap');
+        err.push(Buffer.from(f.dataB64 ?? '', 'base64'));
+        errSeq++;
+      } else if (f.type === 'end' && f.id === id) {
+        end = f;
+      }
+    }
+    let native = Buffer.alloc(0);
+    try {
+      native = Buffer.from(await this.waitNativeMarker(id, 2000));
+    } catch {
+      native = Buffer.from(this.drainNativeStderr());
+    }
+    const capturedErr = Buffer.from(Buffer.concat(err));
+    const n = Number(end.exitCode);
+    return {
+      stdout: Buffer.from(Buffer.concat(out)),
+      stderr: native.length ? Buffer.from(Buffer.concat([capturedErr, native])) : capturedErr,
+      exitCode: Number.isFinite(n) ? n : 0,
+      timedOut: end.timedOut === true,
+      cancelled: end.cancelled === true,
+      truncated: end.truncated === true,
+    };
+  }
+
+  private async waitNativeMarker(id: string, timeoutMs: number): Promise<Buffer> {
+    const needle = Buffer.from('FAUXNIX_ERR_END:' + id + '\n', 'utf8');
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const buf = Buffer.concat(this.stderrChunks);
+      const idx = buf.indexOf(needle);
+      if (idx >= 0) {
+        const before = buf.subarray(0, idx);
+        const after = buf.subarray(idx + needle.length);
+        this.stderrChunks = after.length ? [Buffer.from(after)] : [];
+        return Buffer.from(before) as Buffer;
+      }
+      await new Promise((r) => setTimeout(r, 15));
+    }
+    throw new Error('fauxnix: native stderr marker missing');
   }
 
   private failWaiters(err: Error): void {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -246,6 +246,8 @@ export interface CommandSpec {
   effects: CommandEffect[];
   platform?: 'windows-ps51' | 'portable-translate';
   dispatch?: 'translated' | 'native' | 'dynamic';
+  /** GNU usage/syntax exit (grep uses 2; cp/mv/rm use 1). */
+  usageExit?: number;
   handler: Handler;
 }
 
@@ -282,6 +284,43 @@ export function registeredSpecs(): CommandSpec[] {
     out.push(spec);
   }
   return out;
+}
+
+/** Markdown dump of every CommandSpec — source for docs/command-specs.md. */
+export function specsMarkdown(): string {
+  const lines = [
+    '# Command specs',
+    '',
+    'Generated from `CommandSpec`. Unlisted commands still use unchecked `parseWords` (unknown flags ignored). Spec\'d commands fail loud on unknown or unsupported options.',
+    '',
+  ];
+  for (const spec of registeredSpecs()) {
+    lines.push('## `' + spec.names.join('` / `') + '`');
+    lines.push('');
+    lines.push('Effects: ' + spec.effects.map((e) => '`' + e + '`').join(', '));
+    lines.push('');
+    if (!spec.options.length) {
+      lines.push('No options declared.');
+    } else {
+      lines.push('| Option | Value | Support |');
+      lines.push('| --- | --- | --- |');
+      for (const o of spec.options) {
+        const names = [o.short ? '`-' + o.short + '`' : '', o.long ? '`' + o.long + '`' : '']
+          .filter((s) => s !== '')
+          .join(', ');
+        const val = o.takesValue ? 'required' : 'flag';
+        const extra = o.reason ? ' (' + o.reason + ')' : '';
+        lines.push('| ' + names + ' | ' + val + ' | ' + o.support + extra + ' |');
+      }
+    }
+    lines.push('');
+  }
+  const unspec = registeredNames().filter((n) => !lookupSpec(n));
+  lines.push('## Unspec\'d commands');
+  lines.push('');
+  lines.push(unspec.map((n) => '`' + n + '`').join(', '));
+  lines.push('');
+  return lines.join('\n');
 }
 
 export interface ListedCommand {
@@ -328,6 +367,8 @@ export function listCommandsJson(): ListedCommand[] {
  * null when every option is recognized and implemented.
  */
 export function specOptionError(spec: CommandSpec, args: Word[], cmdName: string): string | null {
+  const usageExit = spec.usageExit ?? 1;
+  const fail = (msg: string) => optionFail(cmdName, msg, usageExit);
   const shorts = new Map<string, OptionSpec>();
   const longs = new Map<string, OptionSpec>();
   for (const o of spec.options) {
@@ -352,16 +393,16 @@ export function specOptionError(spec: CommandSpec, args: Word[], cmdName: string
       const eq = t.indexOf('=');
       const name = eq >= 0 ? t.slice(0, eq) : t;
       const opt = longs.get(name);
-      if (!opt) return optionFail(cmdName, "unrecognized option '" + name + "'");
+      if (!opt) return fail("unrecognized option '" + name + "'");
       if (opt.support === 'unsupported') {
-        return optionFail(cmdName, unsupportedMsg(opt, name));
+        return fail(unsupportedMsg(opt, name));
       }
       if (!opt.takesValue && eq >= 0) {
-        return optionFail(cmdName, "option '" + name + "' doesn't allow an argument");
+        return fail("option '" + name + "' doesn't allow an argument");
       }
       if (opt.takesValue && eq < 0) {
         if (i + 1 < args.length) i++;
-        else return optionFail(cmdName, "option '" + name + "' requires an argument");
+        else return fail("option '" + name + "' requires an argument");
       }
       i++;
       continue;
@@ -371,15 +412,15 @@ export function specOptionError(spec: CommandSpec, args: Word[], cmdName: string
       for (let c = 0; c < body.length; c++) {
         const ch = body[c];
         const opt = shorts.get(ch);
-        if (!opt) return optionFail(cmdName, "invalid option -- '" + ch + "'");
+        if (!opt) return fail("invalid option -- '" + ch + "'");
         if (opt.support === 'unsupported') {
-          return optionFail(cmdName, unsupportedMsg(opt, '-' + ch));
+          return fail(unsupportedMsg(opt, '-' + ch));
         }
         if (opt.takesValue) {
           const rest = body.slice(c + 1);
           if (!rest) {
             if (i + 1 < args.length) i++;
-            else return optionFail(cmdName, "option requires an argument -- '" + ch + "'");
+            else return fail("option requires an argument -- '" + ch + "'");
           }
           break;
         }
@@ -397,12 +438,13 @@ function unsupportedMsg(opt: OptionSpec, shown: string): string {
   return "option '" + shown + "' is not supported by fauxnix" + reason;
 }
 
-function optionFail(cmd: string, msg: string): string {
+function optionFail(cmd: string, msg: string, code = 1): string {
   return (
     '[Console]::Error.WriteLine(' +
     psStr(cmd + ': ' + msg) +
     '); [Console]::Error.WriteLine(' +
     psStr("Try '" + cmd + " --help' for more information.") +
-    '); $script:fx_exit = 1'
+    '); $script:fx_exit = ' +
+    String(code)
   );
 }

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1343,12 +1343,36 @@ $fx_reader = New-Object System.IO.StreamReader($fx_in, $fx_utf8, $true, 8192, $t
 $fx_proto = New-Object System.IO.StreamWriter($fx_out, $fx_utf8, 8192, $true)
 $fx_proto.NewLine = [string][char]10
 $fx_proto.AutoFlush = $true
-$fx_proto.WriteLine('{"ready":true}')
+$fx_proto.WriteLine('{"v":2,"type":"ready","capabilities":{"cancel":false,"maxChunkBytes":65536,"stderrMarker":true}}')
+function fx-b64([byte[]]$bytes, $off, $len) {
+  if ($len -le 0) { return '' }
+  $slice = New-Object byte[] $len
+  [Array]::Copy($bytes, $off, $slice, 0, $len)
+  return [Convert]::ToBase64String($slice)
+}
+function fx-emit-chunks($type, $id, [byte[]]$bytes, $limit, [ref]$seq) {
+  $n = 0
+  if ($null -ne $bytes) { $n = $bytes.Length }
+  $use = $n
+  $trunc = $false
+  if ($use -gt $limit) { $use = $limit; $trunc = $true }
+  $off = 0
+  while ($off -lt $use) {
+    $len = $use - $off
+    if ($len -gt 65536) { $len = 65536 }
+    $b64 = fx-b64 $bytes $off $len
+    $fx_proto.WriteLine('{"v":2,"type":"' + $type + '","id":"' + $id + '","seq":' + $seq.Value + ',"dataB64":"' + $b64 + '"}')
+    $seq.Value = $seq.Value + 1
+    $off += $len
+  }
+  return $trunc
+}
 while ($true) {
   $fx_line = $fx_reader.ReadLine()
   if ($null -eq $fx_line) { break }
   if ($fx_line -eq '') { continue }
   $fx_id = ''
+  $fx_req = $null
   $fx_msOut = $null
   $fx_msErr = $null
   $fx_outW = $null
@@ -1395,20 +1419,47 @@ while ($true) {
     try { [Console]::SetOut($fx_oldOut) } catch {}
     try { [Console]::SetError($fx_oldErr) } catch {}
   }
-  $fx_outB64 = ''
-  $fx_errB64 = ''
-  if ($null -ne $fx_msOut) { $fx_outB64 = [Convert]::ToBase64String($fx_msOut.ToArray()) }
-  if ($null -ne $fx_msErr) { $fx_errB64 = [Convert]::ToBase64String($fx_msErr.ToArray()) }
   $fx_code = 0
   try { $fx_code = [int]$script:fx_exit } catch { $fx_code = 1 }
-  $fx_res = @{ id = $fx_id; stdoutB64 = $fx_outB64; stderrB64 = $fx_errB64; exitCode = $fx_code }
-  try {
-    $fx_json = $fx_res | ConvertTo-Json -Compress
-  } catch {
-    $fx_msg = 'fauxnix: host result exceeded ConvertTo-Json MaxJsonLength (~2MB)'
-    $fx_res = @{ id = $fx_id; stdoutB64 = ''; stderrB64 = [Convert]::ToBase64String($fx_utf8.GetBytes($fx_msg)); exitCode = 1 }
-    $fx_json = $fx_res | ConvertTo-Json -Compress
+  $fx_v2 = $false
+  if ($null -ne $fx_req -and $null -ne $fx_req.PSObject.Properties['v']) {
+    if ([int]$fx_req.v -eq 2) { $fx_v2 = $true }
   }
-  $fx_proto.WriteLine($fx_json)
+  $fx_outBytes = New-Object byte[] 0
+  $fx_errBytes = New-Object byte[] 0
+  if ($null -ne $fx_msOut) { $fx_outBytes = $fx_msOut.ToArray() }
+  if ($null -ne $fx_msErr) { $fx_errBytes = $fx_msErr.ToArray() }
+  if ($fx_v2) {
+    $fx_outLimit = 8388608
+    $fx_errLimit = 1048576
+    if ($null -ne $fx_req.PSObject.Properties['stdoutLimit']) { $fx_outLimit = [int]$fx_req.stdoutLimit }
+    if ($null -ne $fx_req.PSObject.Properties['stderrLimit']) { $fx_errLimit = [int]$fx_req.stderrLimit }
+    $fx_outSeq = 0
+    $fx_errSeq = 0
+    $fx_trunc = $false
+    if (fx-emit-chunks 'stdout' $fx_id $fx_outBytes $fx_outLimit ([ref]$fx_outSeq)) { $fx_trunc = $true }
+    if (fx-emit-chunks 'stderr' $fx_id $fx_errBytes $fx_errLimit ([ref]$fx_errSeq)) { $fx_trunc = $true }
+    $fx_nativeErr = [Console]::OpenStandardError()
+    $fx_mark = $fx_utf8.GetBytes(('FAUXNIX_ERR_END:' + $fx_id + [char]10))
+    $fx_nativeErr.Write($fx_mark, 0, $fx_mark.Length)
+    $fx_nativeErr.Flush()
+    $fx_end = '{"v":2,"type":"end","id":"' + $fx_id + '","exitCode":' + $fx_code + ',"timedOut":false,"cancelled":false,"truncated":'
+    if ($fx_trunc) { $fx_end = $fx_end + 'true}' } else { $fx_end = $fx_end + 'false}' }
+    $fx_proto.WriteLine($fx_end)
+  } else {
+    $fx_outB64 = ''
+    $fx_errB64 = ''
+    if ($fx_outBytes.Length -gt 0) { $fx_outB64 = [Convert]::ToBase64String($fx_outBytes) }
+    if ($fx_errBytes.Length -gt 0) { $fx_errB64 = [Convert]::ToBase64String($fx_errBytes) }
+    $fx_res = @{ id = $fx_id; stdoutB64 = $fx_outB64; stderrB64 = $fx_errB64; exitCode = $fx_code }
+    try {
+      $fx_json = $fx_res | ConvertTo-Json -Compress
+    } catch {
+      $fx_msg = 'fauxnix: host result exceeded ConvertTo-Json MaxJsonLength (~2MB)'
+      $fx_res = @{ id = $fx_id; stdoutB64 = ''; stderrB64 = [Convert]::ToBase64String($fx_utf8.GetBytes($fx_msg)); exitCode = 1 }
+      $fx_json = $fx_res | ConvertTo-Json -Compress
+    }
+    $fx_proto.WriteLine($fx_json)
+  }
 }
 `.trim();

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1233,6 +1233,23 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stderr).toContain("invalid option -- 'z'");
     expect(readFileSync(join(dir, 'cp-z-dst.txt'), 'utf8')).toBe('DST\n');
   });
+  it('v2 host truncates stdout at the per-run budget', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const r = await extra.run(translateCommandList(parseCommand('printf AAAAAAAAAA')), {
+        stdoutLimit: 4,
+      });
+      expect(r.truncated).toBe(true);
+      expect(Buffer.byteLength(r.stdout, 'utf8')).toBeLessThanOrEqual(4);
+      const hi = await extra.run(translateCommandList(parseCommand('echo hi')));
+      expect(hi.exitCode).toBe(0);
+      expect(hi.stdout.trim()).toBe('hi');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
   it('whitespace-only stdout is preserved', async () => {
     const r = await run("printf '   '");
     expect(r.exitCode).toBe(0);

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -200,9 +200,32 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
 
   it('head/tail/wc', async () => {
     expect((await run('head -1 fruits.txt')).stdout.trim()).toBe('apple');
+    expect((await run('head --lines=1 fruits.txt')).stdout.trim()).toBe('apple');
     expect((await run('tail -1 fruits.txt')).stdout.trim()).toBe('cherry');
+    expect((await run('tail --lines=1 fruits.txt')).stdout.trim()).toBe('cherry');
     expect((await run('wc -l fruits.txt')).stdout.trim()).toMatch(/4/);
     expect((await run('wc -l < fruits.txt')).stdout.trim()).toBe('4');
+  });
+
+  it('grep -m1 stops after the first match', async () => {
+    const r = await run('grep -m1 apple fruits.txt');
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('apple');
+    const all = await run('grep apple fruits.txt');
+    expect(all.stdout.trim().split(/\r?\n/)).toEqual(['apple', 'apple pie']);
+    const viaE = await run('grep -e apple fruits.txt');
+    expect(viaE.exitCode).toBe(0);
+    expect(viaE.stdout.trim().split(/\r?\n/)).toEqual(['apple', 'apple pie']);
+  });
+
+  it('du --max-depth=0 prints only the root', async () => {
+    const deep = await run('du find-depth');
+    const shallow = await run('du --max-depth=0 find-depth');
+    expect(shallow.exitCode).toBe(0);
+    const rows = shallow.stdout.split(/\r?\n/).filter(Boolean);
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toContain('find-depth');
+    expect(deep.stdout.split(/\r?\n/).filter(Boolean).length).toBeGreaterThan(1);
   });
 
   it('echo/printf semantics', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -707,6 +707,36 @@ describe('tokenize', () => {
   });
 });
 
+describe('bounded output flags (#130)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+
+  it('grep -m / --max-count stop after N matching lines', () => {
+    expect(bodyOf('grep -m1 pat f')).toContain('$fx_mleft = 1');
+    expect(bodyOf('grep --max-count=2 pat f')).toContain('$fx_mleft = 2');
+    expect(bodyOf('grep pat f')).not.toContain('$fx_mleft');
+  });
+
+  it('grep -e / --regexp keep the pattern (not an unknown flag)', () => {
+    expect(bodyOf("grep -e apple fruits.txt")).toContain('fx-gmatch');
+    expect(bodyOf("grep -e apple fruits.txt")).not.toContain('invalid option');
+  });
+
+  it('head --lines and --lines=N set the count (not silently skipped)', () => {
+    expect(bodyOf('head --lines=1 fruits.txt')).toContain('$fx_count = [int](1)');
+    expect(bodyOf('head --lines 3 fruits.txt')).toContain('$fx_count = [int](3)');
+    expect(bodyOf('head fruits.txt')).toContain('$fx_count = [int](10)');
+  });
+
+  it('du --max-depth filters subdirectory rows', () => {
+    expect(bodyOf('du --max-depth=0')).toContain('if ($true)');
+    expect(bodyOf('du --max-depth=0')).not.toContain('$fx_ddepth');
+    expect(bodyOf('du --max-depth=1')).toContain('$fx_ddepth');
+    expect(bodyOf('du --max-depth=1')).toContain('-gt 1');
+    expect(bodyOf('du -s --max-depth=1')).toContain('summarizing conflicts');
+    expect(bodyOf('du .')).not.toContain('$fx_ddepth');
+  });
+});
+
 describe('CommandSpec (#130)', () => {
   const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
 

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -745,13 +745,10 @@ describe('CommandSpec (#130)', () => {
     expect(bodyOf('tee out.txt')).toContain('if ($false)');
   });
 
-  it('spec\'d rm fails loud on unknown flags; unspec\'d ls still ignores them', () => {
+  it('spec\'d rm fails loud on unknown flags', () => {
     const rm = bodyOf('rm -z x');
     expect(rm).toContain("invalid option -- ''z''");
     expect(rm).not.toContain('Remove-Item');
-    const ls = bodyOf('ls -Z');
-    expect(ls).not.toContain('invalid option');
-    expect(ls).toContain('Get-ChildItem');
   });
 
   it('rm --verbose matches -v; tee -i is not silently ignored', () => {
@@ -767,10 +764,32 @@ describe('CommandSpec (#130)', () => {
     expect(cp?.spec?.options.some((o) => o.short === 'n' && o.support === 'implemented')).toBe(
       true,
     );
-    expect(rows.find((r) => r.name === 'ls')?.spec).toBeNull();
+    expect(rows.find((r) => r.name === 'ls')?.spec).toBeTruthy();
     expect(lookupSpec('cp')).toBeTruthy();
-    expect(lookupSpec('ls')).toBeUndefined();
+    expect(lookupSpec('ls')).toBeTruthy();
+    expect(lookupSpec('find')).toBeUndefined();
     expect(lookup('tee')).toBeTypeOf('function');
+  });
+});
+
+describe('CommandSpec files leftovers (#130)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+
+  it('ls unknown flags fail loud; --format=long still means -l', () => {
+    expect(bodyOf('ls -Z')).toContain("invalid option -- ''Z''");
+    expect(bodyOf('ls --format=long')).toContain("'{0} 1");
+    expect(bodyOf('ls --recursive')).toContain('not supported by fauxnix');
+  });
+
+  it('chmod -R is unsupported; find stays unspec\'d so -name still compiles', () => {
+    expect(bodyOf('chmod -R 644 x')).toContain('not supported by fauxnix');
+    expect(bodyOf("find . -name '*.ts'")).toContain('-clike');
+    expect(lookupSpec('find')).toBeUndefined();
+  });
+
+  it('mkdir --verbose and ln --symbolic are implemented longs', () => {
+    expect(bodyOf('mkdir --verbose d')).toContain('if ($true)');
+    expect(bodyOf('ln --symbolic a b')).toContain('SymbolicLink');
   });
 });
 

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -14,7 +14,7 @@ import {
 import { listCommandsJson, lookup, lookupSpec, parseWords, psStr } from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import { normalizeStderr } from '../src/errors.js';
-import { decodeHostResponse, encodeHostRequest } from '../src/ps-host.js';
+import { decodeHostResponse, encodeHostRequest, parseHostLine } from '../src/ps-host.js';
 import { bashToolResult, formatBashText } from '../src/mcp.js';
 import '../src/commands/install-all.js';
 
@@ -475,7 +475,9 @@ describe('translator', () => {
     const boot = hostBootstrapScript();
     expect(boot).toContain('function fx-arrload');
     expect(boot).toContain('function fx-csub');
-    expect(boot).toContain('{"ready":true}');
+    expect(boot).toContain('"type":"ready"');
+    expect(boot).toContain('FAUXNIX_ERR_END:');
+    expect(boot).toContain('maxChunkBytes');
     expect(boot).toContain('ConvertFrom-Json');
     expect(boot).toContain('MaxJsonLength');
     expect(boot).not.toContain('exit $script:fx_exit');
@@ -662,6 +664,18 @@ describe('persistent PowerShell host protocol', () => {
     expect(msg.stderr.toString('utf8')).toBe('err');
     expect(msg.exitCode).toBe(2);
     expect(decodeHostResponse('{"ready":true}').ready).toBe(true);
+  });
+
+  it('encodes v2 run frames and parses v2 ready / v1 ready', () => {
+    const line = encodeHostRequest('r1', 'echo', { FAUXNIX_CWD: 'D:\\tmp' }, { v: 2, stdoutLimit: 10, stderrLimit: 4 });
+    const parsed = JSON.parse(line) as { v: number; type: string; stdoutLimit: number };
+    expect(parsed.v).toBe(2);
+    expect(parsed.type).toBe('run');
+    expect(parsed.stdoutLimit).toBe(10);
+    expect(parseHostLine('{"v":2,"type":"ready","capabilities":{"cancel":false}}').v2?.type).toBe(
+      'ready',
+    );
+    expect(parseHostLine('{"ready":true}').v1Ready).toBe(true);
   });
 });
 


### PR DESCRIPTION
Integration of the protocol-v2 + bounded-outputs wave (#141 #142 #144).

**Maintainer verification on the integrated tree:**
- #141 bounded outputs: differential **5/5 vs real Git Bash** (grep -m1/-m 2, head --lines=1/-n 2, du -s)
- #142 protocol v2: handshake versioned with v1 accepted; **native stderr now returns exactly once** (node stderr probe verified) — audit #131's "stderr dropped/retained" gap closed; chunked frames + limits + truncated markers per the RFC
- **#140 regression fixed as a side effect**: prewarm 2s → 0.57s, first frame 0.7s → **0.27s**, warm 40ms — the v2 bootstrap rework slimmed the host
- #144: `ls -Z` is now a usage error; spec registry covers the file family

Full suite: **197/197**.

Closes #141, closes #142, closes #144, closes #140.
