### PR TITLE
release: v0.9.1 — P1 hotfix (redirect budgets + UTF-8 boundary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.9.1 — 2026-08-23
+
+Hotfix for the two P1 findings from the Codex review of #145 (both verified
+on published 0.9.0):
+
+- **Redirected files are never truncated by response budgets** — limits
+  apply only to data returned to the caller; `printf … > file` under a small
+  (or default 8 MiB) budget was writing a clipped file
+- **Truncation cuts at valid UTF-8 boundaries** — a mid-codepoint cut made
+  Node's decoder reject the whole buffer and fall back to GBK mojibake;
+  the cut now backs off to a sequence boundary (lead-byte scan)
 ## v0.9.0 — 2026-08-23
 
 Protocol v2 + bounded outputs (#141 #142 #144):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fauxnix-cli",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Fauxnix — run Linux-style commands on Windows via deterministic PowerShell translation. No VM, no WSL. MCP server + CLI for AI agents.",
   "type": "module",
   "bin": {

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -457,6 +457,11 @@ async function runPlans(
     }
 
     const encoded = wrapScript(plan.body, { mode: 'host' });
+    // Response budgets cap what the CALLER receives — streams redirected to
+    // files must never be truncated by them (Codex-review P1: `printf … > f`
+    // with a small stdoutLimit was writing a clipped file). The final
+    // clipUtf8 below still enforces the returned-data budget.
+    const fileRedirected = !!(red.stdoutFile || red.stderrFile);
     const inv = await ensureHost().invoke(
       encoded,
       {
@@ -466,7 +471,9 @@ async function runPlans(
       },
       remainingMs,
       opts.signal,
-      { stdoutLimit, stderrLimit },
+      fileRedirected
+        ? { stdoutLimit: 0, stderrLimit: 0 }
+        : { stdoutLimit, stderrLimit },
     );
 
     if (inv.spawnError === 'ENOENT' || inv.spawnError === 'START') {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1355,7 +1355,22 @@ function fx-emit-chunks($type, $id, [byte[]]$bytes, $limit, [ref]$seq) {
   if ($null -ne $bytes) { $n = $bytes.Length }
   $use = $n
   $trunc = $false
-  if ($use -gt $limit) { $use = $limit; $trunc = $true }
+  # limit 0 = uncapped (file-redirected streams must never be budget-clipped)
+  if ($limit -gt 0 -and $use -gt $limit) {
+    $use = $limit
+    $trunc = $true
+    # back the cut off to a valid UTF-8 boundary — a split codepoint makes
+    # Node's decoder reject the whole buffer and fall back to GBK mojibake
+    $i = $use - 1
+    $back = 0
+    while ($back -lt 3 -and $i -ge 0 -and (($bytes[$i] -band 0xC0) -eq 0x80)) { $i = $i - 1; $back = $back + 1 }
+    if ($i -ge 0) {
+      $lead = $bytes[$i]
+      $seqlen = 1
+      if (($lead -band 0xE0) -eq 0xC0) { $seqlen = 2 } elseif (($lead -band 0xF0) -eq 0xE0) { $seqlen = 3 } elseif (($lead -band 0xF8) -eq 0xF0) { $seqlen = 4 }
+      if (($i + $seqlen) -gt $use) { $use = $i }
+    }
+  }
   $off = 0
   while ($off -lt $use) {
     $len = $use - $off

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1273,6 +1273,38 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     }
   }, 30000);
 
+  it('response budgets never truncate file-redirected streams (Codex P1)', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const target = join(dir, 'budget-redirect.txt');
+      const r = await extra.run(
+        translateCommandList(parseCommand('printf AAAAAAAAAA > ' + JSON.stringify(target))),
+        { stdoutLimit: 4 },
+      );
+      expect(r.exitCode).toBe(0);
+      expect(readFileSync(target, 'utf8')).toBe('AAAAAAAAAA');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('truncation cuts at a UTF-8 boundary, never mid-codepoint (Codex P1)', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const r = await extra.run(
+        translateCommandList(parseCommand('printf "\u4f60\u597d\u4e16\u754c\u4f60\u597d\u4e16\u754c"')),
+        { stdoutLimit: 7 },
+      );
+      expect(r.truncated).toBe(true);
+      expect(Buffer.byteLength(r.stdout, 'utf8')).toBeLessThanOrEqual(7);
+      expect(r.stdout).toBe('你好');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
   it('whitespace-only stdout is preserved', async () => {
     const r = await run("printf '   '");
     expect(r.exitCode).toBe(0);


### PR DESCRIPTION
Hotfix for both P1 findings from the Codex review on #145 — **verified broken on the published 0.9.0 before fixing**:

1. **Redirected-file corruption**: repro `printf AAAAAAAAAA > f` with `stdoutLimit: 4` wrote a 4-byte file (defaults 8MiB/1MiB silently clip bigger redirects). Fix: file-redirected segments invoke the host uncapped (`limit 0`); the returned-data budget stays enforced by the existing final clipUtf8.
2. **UTF-8 mid-codepoint truncation**: repro `printf "你好世界×2"` at `stdoutLimit: 7` returned GBK mojibake (`浣犲`) because the split codepoint made the decoder reject the buffer. Fix: the host backs the cut off to a valid sequence boundary (lead-byte scan, ≤3 bytes).

Both have regression tests (file content asserted; `expect(stdout).toBe('你好')`).

The three P2s (head --lines=-N semantics, grep -e accumulation, stale command-specs.md unspec'd list) are real too — routing them to the wave authors on the tracking issue rather than blocking this hotfix.
