### PR TITLE
fix: per-stage redirect ownership and >/dev/null discard

### DIFF
--- a/docs/rfc-redirect-fd-ownership.md
+++ b/docs/rfc-redirect-fd-ownership.md
@@ -1,0 +1,50 @@
+# RFC: per-stage redirection ownership
+
+Follow-up to [#131](https://github.com/20000419/fauxnix/issues/131) item 2.
+Foundational contracts (#129 host, #130 CommandSpec) have landed; this is the
+focused implementation RFC the audit asked for.
+
+## Why
+
+`translateCommandList` concatenates every pipeline command's redirects into one
+segment-level list. The executor then applies that list to the **whole**
+pipeline after capture.
+
+Two independently reproduced failures:
+
+| Command | bash | fauxnix today |
+|---|---|---|
+| `echo hi >/dev/null` | no output | prints `hi` (`devNull` is set and never applied) |
+| `printf x \| cat < README.md \| head -1` | first line of README | `x` (`<` is fed to stage 0) |
+
+A correct model is bash's: each pipeline stage owns its fds. A stdin redirect
+on a middle stage **replaces** the pipe, it does not move to the first stage.
+`>/dev/null` discards that stage's stdout; for a one-command segment that is
+the caller's stdout.
+
+## Contract
+
+- Prep still walks **all** redirects left-to-right (failed earlier `>` must not
+  truncate a later file). Missing `<` targets still fail before the command.
+- **Output apply** (captured stdout/stderr → files / discard) uses the **last**
+  stage's redirects only.
+- **Stdin feed** (`FAUXNIX_STDIN_FILE`) uses the **first** stage's `<` only.
+- A non-first stage with `< file` reads that file as `$input` and does not
+  consume the previous stage's stream (the previous stage still runs).
+- `< /dev/null` on any stage is empty input. `>/dev/null` / `&>/dev/null` on
+  the last stage discards captured stdout (and stderr for `&>`).
+- Non-last-stage **stdout** redirects (`echo hi >f \| cat`) stay a documented
+  follow-up: they need the stage to write the file inside PowerShell instead of
+  the pipe. Not silent-wrong for the audit's two cases.
+
+## Non-goals
+
+- Heredocs, process substitution, `n>` for fds other than 1/2.
+- Job-object / Linux hosts.
+- Version bump / npm publish.
+
+## Tests
+
+- `echo hi >/dev/null` → empty stdout, no `NUL` file in cwd.
+- `printf x | cat < fruits.txt | head -1` → `apple`.
+- Existing `> >> 2>/dev/null 2>&1` and failed-`>` order tests stay green.

--- a/docs/rfc-redirect-fd-ownership.md
+++ b/docs/rfc-redirect-fd-ownership.md
@@ -33,6 +33,9 @@ the caller's stdout.
   consume the previous stage's stream (the previous stage still runs).
 - `< /dev/null` on any stage is empty input. `>/dev/null` / `&>/dev/null` on
   the last stage discards captured stdout (and stderr for `&>`).
+- Successive stdout redirects last-win: `>/dev/null >file` writes the command
+  output to `file`; `>file >/dev/null` truncates `file` and discards output.
+  `2>/dev/null` must not undo a prior `>/dev/null`.
 - Non-last-stage **stdout** redirects (`echo hi >f \| cat`) stay a documented
   follow-up: they need the stage to write the file inside PowerShell instead of
   the pipe. Not silent-wrong for the audit's two cases.
@@ -46,5 +49,7 @@ the caller's stdout.
 ## Tests
 
 - `echo hi >/dev/null` → empty stdout, no `NUL` file in cwd.
+- `echo hi >/dev/null > lastwins.txt` → file contains `hi`.
+- `cat missing.txt &>/dev/null` → empty stderr.
 - `printf x | cat < fruits.txt | head -1` → `apple`.
 - Existing `> >> 2>/dev/null 2>&1` and failed-`>` order tests stay green.

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -48,6 +48,12 @@ function winTarget(target: string): string {
   return p;
 }
 
+/** Windows NUL device — `NUL`, `\\.\NUL`, and `cwd\NUL` after path.resolve. */
+function isNulPath(p: string): boolean {
+  const base = p.split(/[/\\]/).pop() ?? p;
+  return /^NUL$/i.test(base);
+}
+
 interface SegmentRedirects {
   stdinFile: string | null;
   stdoutFile: string | null;
@@ -56,6 +62,7 @@ interface SegmentRedirects {
   appendStderr: boolean;
   mergeStderr: boolean;
   devNull: boolean;
+  swallowStderr: boolean;
 }
 
 /** Where a fd points during left-to-right redirect setup. */
@@ -132,53 +139,72 @@ function planRedirects(redirects: Redirect[]): SegmentRedirects {
     appendStderr: false,
     mergeStderr: false,
     devNull: false,
+    swallowStderr: false,
   };
   for (const red of redirects) {
     const target = winTarget(red.target);
     switch (red.op) {
       case '<':
-        r.stdinFile = target;
+        r.stdinFile = isNulPath(target) ? null : target;
         break;
       case '>':
       case '&>':
-        if (target === 'NUL') {
+        if (isNulPath(target)) {
           r.devNull = true;
-          if (red.op === '&>') (r as { swallowStderr?: boolean }).swallowStderr = true;
+          r.stdoutFile = null;
+          if (red.op === '&>') {
+            r.swallowStderr = true;
+            r.stderrFile = null;
+          }
         } else {
+          r.devNull = false;
           r.stdoutFile = target;
           r.appendStdout = false;
-          if (red.op === '&>') r.stderrFile = target;
+          if (red.op === '&>') {
+            r.stderrFile = target;
+            r.swallowStderr = false;
+          }
         }
         break;
       case '>>':
       case '&>>':
-        if (target === 'NUL') {
+        if (isNulPath(target)) {
           r.devNull = true;
-          if (red.op === '&>>') (r as { swallowStderr?: boolean }).swallowStderr = true;
+          r.stdoutFile = null;
+          if (red.op === '&>>') {
+            r.swallowStderr = true;
+            r.stderrFile = null;
+          }
         } else {
+          r.devNull = false;
           r.stdoutFile = target;
           r.appendStdout = true;
           if (red.op === '&>>') {
             r.stderrFile = target;
             r.appendStderr = true;
+            r.swallowStderr = false;
           }
         }
         break;
       case '2>':
-        if (target === 'NUL') {
-          // 2>/dev/null swallows stderr only
+        if (isNulPath(target)) {
+          // stderr only — must not undo a prior >/dev/null
           r.stderrFile = null;
-          r.devNull = false;
-          (r as { swallowStderr?: boolean }).swallowStderr = true;
+          r.swallowStderr = true;
         } else {
           r.stderrFile = target;
           r.appendStderr = false;
+          r.swallowStderr = false;
         }
         break;
       case '2>>':
-        if (target !== 'NUL') {
+        if (isNulPath(target)) {
+          r.stderrFile = null;
+          r.swallowStderr = true;
+        } else {
           r.stderrFile = target;
           r.appendStderr = true;
+          r.swallowStderr = false;
         }
         break;
       case '2>&1':
@@ -409,6 +435,7 @@ async function runPlans(
       }
       const target = resolveTarget(winTarget(r.target));
       if (r.op === '<') {
+        if (isNulPath(target)) continue;
         if (!existsSync(target)) {
           emitPrepError('bash: ' + target + ': No such file or directory\n');
           redirectPrepFailed = true;
@@ -416,7 +443,7 @@ async function runPlans(
         }
         continue;
       }
-      if (target === 'NUL') {
+      if (isNulPath(target)) {
         if (r.op === '>' || r.op === '>>') prepStdout = { kind: 'nul' };
         else if (r.op === '2>' || r.op === '2>>') prepStderr = { kind: 'nul' };
         else if (r.op === '&>' || r.op === '&>>') {
@@ -521,8 +548,7 @@ async function runPlans(
       segErr += segOut;
       segOut = '';
     }
-    const swallowStderr = (red as { swallowStderr?: boolean }).swallowStderr;
-    if (swallowStderr) segErr = '';
+    if (red.swallowStderr) segErr = '';
     if (red.devNull) segOut = '';
 
     // Write captured streams through the fds opened during preflight

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -141,8 +141,10 @@ function planRedirects(redirects: Redirect[]): SegmentRedirects {
         break;
       case '>':
       case '&>':
-        if (target === 'NUL') r.devNull = true;
-        else {
+        if (target === 'NUL') {
+          r.devNull = true;
+          if (red.op === '&>') (r as { swallowStderr?: boolean }).swallowStderr = true;
+        } else {
           r.stdoutFile = target;
           r.appendStdout = false;
           if (red.op === '&>') r.stderrFile = target;
@@ -150,8 +152,10 @@ function planRedirects(redirects: Redirect[]): SegmentRedirects {
         break;
       case '>>':
       case '&>>':
-        if (target === 'NUL') r.devNull = true;
-        else {
+        if (target === 'NUL') {
+          r.devNull = true;
+          if (red.op === '&>>') (r as { swallowStderr?: boolean }).swallowStderr = true;
+        } else {
           r.stdoutFile = target;
           r.appendStdout = true;
           if (red.op === '&>>') {
@@ -370,7 +374,9 @@ async function runPlans(
       break;
     }
 
-    const red = planRedirects(plan.redirects);
+    const red = planRedirects(plan.outputRedirects);
+    const inRed = planRedirects(plan.stdinRedirects);
+    red.stdinFile = inRed.stdinFile;
     red.stdinFile = red.stdinFile ? resolveTarget(red.stdinFile) : null;
     red.stdoutFile = red.stdoutFile ? resolveTarget(red.stdoutFile) : null;
     red.stderrFile = red.stderrFile ? resolveTarget(red.stderrFile) : null;
@@ -517,6 +523,7 @@ async function runPlans(
     }
     const swallowStderr = (red as { swallowStderr?: boolean }).swallowStderr;
     if (swallowStderr) segErr = '';
+    if (red.devNull) segOut = '';
 
     // Write captured streams through the fds opened during preflight
     // (bash: the redirect refers to the open file, not the path). Reopening

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -3,6 +3,7 @@ import {
   CommandList,
   FauxnixParseError,
   Redirect,
+  ShellCommand,
   SimpleCommand,
   IfCommand,
   ForCommand,
@@ -888,6 +889,20 @@ function translateFor(cmd: ForCommand): string {
   return lines.join('\n');
 }
 
+function stdinTarget(c: ShellCommand): string | null {
+  let t: string | null = null;
+  for (const r of c.redirects) {
+    if (r.op === '<') t = r.target;
+  }
+  return t;
+}
+
+function stdinReadExpr(target: string): string {
+  const n = normalizeLiteralPath(target);
+  if (n === 'NUL') return '@()';
+  return '@(fx-readlines ' + pathExpr(n) + ')';
+}
+
 export function translatePipelineBody(p: {
   commands: Array<SimpleCommand | IfCommand | ForCommand>;
 }): PipelineParts {
@@ -927,7 +942,24 @@ export function translatePipelineBody(p: {
   }
   const pipelineName = '__fx_p' + pipelineId;
   const statuses = bodies.map(() => '0').join(', ');
-  const pipelineCall = names.join(' | ');
+  const stageStdin = p.commands.map((c) => stdinTarget(c));
+  const middleStdin = stageStdin.some((t, i) => i > 0 && t !== null);
+  let pipelineInner: string;
+  if (middleStdin) {
+    // A non-first `< file` replaces the pipe as that stage's stdin. Run
+    // earlier stages anyway (they may have side effects) but do not feed
+    // their stream into the redirected stage.
+    const seq: string[] = ['    $fx_cur = @($input)'];
+    for (let i = 0; i < names.length; i++) {
+      if (stageStdin[i] && i > 0) seq.push('    $fx_cur = ' + stdinReadExpr(stageStdin[i]!));
+      if (i === names.length - 1) seq.push('    $fx_cur | ' + names[i]);
+      else seq.push('    $fx_cur = @($fx_cur | ' + names[i] + ')');
+    }
+    pipelineInner = seq.join('\n');
+  } else {
+    pipelineInner =
+      '    $input | ' + names.join(' | ');
+  }
   defs.push(
     [
       'function ' + pipelineName + ' {',
@@ -936,7 +968,7 @@ export function translatePipelineBody(p: {
       // The wrapper forwards redirect input to stage zero. With no input,
       // PowerShell still invokes a regular function once, which preserves the
       // existing no-stdin pipeline behavior on Windows PowerShell 5.1.
-      '    $input | ' + pipelineCall,
+      pipelineInner,
       '  } finally {',
       // Bash defaults to pipefail off: only the last stage controls the list
       // status used by a following && / || segment.
@@ -958,19 +990,29 @@ export interface SegmentPlan {
   script: string;
   /** Pipeline body before wrapScript — executor host mode re-wraps this. */
   body: string;
-  /** All redirects collected from this segment (executor handles them). */
+  /** Every stage's redirects, in source order — executor prep (open/fail). */
   redirects: Redirect[];
+  /** Last-stage redirects — captured stdout/stderr apply / >/dev/null. */
+  outputRedirects: Redirect[];
+  /** First-stage `<` only — FAUXNIX_STDIN_FILE feed. */
+  stdinRedirects: Redirect[];
 }
 
 export function translateCommandList(list: CommandList): SegmentPlan[] {
   const plans: SegmentPlan[] = [];
   for (const seg of list.segments) {
+    const cmds = seg.pipeline.commands;
     const redirects: Redirect[] = [];
-    for (const c of seg.pipeline.commands) redirects.push(...c.redirects);
+    for (const c of cmds) redirects.push(...c.redirects);
+    const outputRedirects = cmds.length ? cmds[cmds.length - 1].redirects.slice() : [];
+    const stdinRedirects = cmds.length
+      ? cmds[0].redirects.filter((r) => r.op === '<')
+      : [];
     const { defs, call } = translatePipelineBody(seg.pipeline);
     let body = defs ? defs + '\n' + call : call;
-    // `< file` redirects feed the pipeline via the FAUXNIX_STDIN_FILE channel
-    if (redirects.some((r) => r.op === '<')) {
+    // First-stage `< file` feeds stage zero via FAUXNIX_STDIN_FILE.
+    // Later-stage `<` is owned inside the pipeline body, not this wrapper.
+    if (stdinRedirects.length) {
       // `& { ... }` (no parens) so the scriptblock can be a non-first
       // pipeline element receiving the fed lines.
       const pipeCall = call.startsWith('(& {') ? call.slice(1, -1) : call;
@@ -982,7 +1024,14 @@ export function translateCommandList(list: CommandList): SegmentPlan[] {
         call +
         ' }';
     }
-    plans.push({ op: seg.op, script: wrapScript(body), body, redirects });
+    plans.push({
+      op: seg.op,
+      script: wrapScript(body),
+      body,
+      redirects,
+      outputRedirects,
+      stdinRedirects,
+    });
   }
   return plans;
 }

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -257,6 +257,21 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(existsSync(join(dir, 'null'))).toBe(false);
   });
 
+  it('>/dev/null last-wins against a later file redirect', async () => {
+    const lastFile = await run('echo hi >/dev/null > lastwins.txt');
+    expect(lastFile.stdout).toBe('');
+    expect(readFileSync(join(dir, 'lastwins.txt'), 'utf8').trim()).toBe('hi');
+    const lastNull = await run('echo hi > lastnull.txt >/dev/null');
+    expect(lastNull.stdout).toBe('');
+    expect(readFileSync(join(dir, 'lastnull.txt'), 'utf8')).toBe('');
+  });
+
+  it('&>/dev/null discards stdout and stderr', async () => {
+    const r = await run('cat missing.txt &>/dev/null; echo OK');
+    expect(r.stdout.trim()).toBe('OK');
+    expect(r.stderr).toBe('');
+  });
+
   it('middle-stage < overrides the pipe as that stage stdin', async () => {
     const r = await run('printf x | cat < fruits.txt | head -1');
     expect(r.exitCode).toBe(0);

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -249,6 +249,20 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(silenced.stdout.trim()).toBe('OK');
   });
 
+  it('>/dev/null discards stdout', async () => {
+    const r = await run('echo hi >/dev/null');
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe('');
+    // Windows treats NUL as a DOS device; existsSync(dir/NUL) is not a file check.
+    expect(existsSync(join(dir, 'null'))).toBe(false);
+  });
+
+  it('middle-stage < overrides the pipe as that stage stdin', async () => {
+    const r = await run('printf x | cat < fruits.txt | head -1');
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('apple');
+  });
+
   it(
     '[[ ]] file and string tests, including =~',
     async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -544,6 +544,15 @@ describe('translator', () => {
   it('feeds stdin for < redirects', () => {
     const plan = translateCommandList(parse('wc -l < f.txt'))[0];
     expect(plan.script).toContain('fx-readlines $env:FAUXNIX_STDIN_FILE |');
+    expect(plan.stdinRedirects).toEqual([{ op: '<', target: 'f.txt' }]);
+  });
+
+  it('middle-stage < is owned by that stage, not stage zero', () => {
+    const plan = translateCommandList(parse('printf x | cat < fruits.txt | head -1'))[0];
+    expect(plan.stdinRedirects).toEqual([]);
+    expect(plan.body).toContain('fx-readlines');
+    expect(plan.body).toContain('fruits.txt');
+    expect(plan.body).not.toContain('fx-readlines $env:FAUXNIX_STDIN_FILE');
   });
 
   it('uses functions for multi-stage pipelines (PS 5.1 rule)', () => {


### PR DESCRIPTION
## Why

#131: redirection ownership is pipeline-wide, and `/dev/null` stdout is inert.

- `echo hi >/dev/null` printed `hi` (`devNull` was set, never applied).
- `printf x | cat < README.md | head -1` fed `x` into `cat` instead of the file.

## What

RFC: `docs/rfc-redirect-fd-ownership.md`.

- Prep still walks **all** redirects left-to-right (failed earlier `>` still must not truncate a later file).
- Captured stdout/stderr apply the **last** stage only; `>/dev/null` discards that stdout (`&>/dev/null` also stderr).
- `FAUXNIX_STDIN_FILE` is the **first** stage's `<` only.
- A later stage with `< file` reads that file as `$input` and does not consume the previous stage's stream.

Non-last-stage **stdout** redirects (`echo hi >f | cat`) stay a follow-up in the RFC.

## Tests

- Unit: first-stage `<` still uses `FAUXNIX_STDIN_FILE`; middle-stage `<` is `fx-readlines` in the pipeline body.
- Integration: `echo hi >/dev/null` empty stdout; `printf x | cat < fruits.txt | head -1` → `apple`. Existing `> >> 2>/dev/null` suite stays green.
