### PR TITLE
docs: sync command-specs.md with the live CommandSpec registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,13 @@ development:
   translate time (unsupported constructs throw named errors, never silently misbehave)
 - **text I/O**: `echo printf cat head tail wc tee nl tac md5sum sha1sum sha256sum base64 seq yes xargs`
 
-`cp` / `mv` / `rm` / `touch` / `tee` / `grep` / `head` / `du` carry a `CommandSpec`: unknown
-options fail with a GNU-style usage error instead of being ignored. Implemented GNU holes:
-`cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` / `head --lines` / `du --max-depth`.
-`fauxnix list --json` and `docs/command-specs.md` dump the same metadata.
+`cp` / `mv` / `rm` / `touch` / `du` / `ls` / `ll` / `mkdir` / `rmdir` / `mktemp` / `ln` /
+`readlink` / `realpath` / `basename` / `dirname` / `stat` / `file` / `df` / `chmod` / `chown` /
+`diff` / `tee` / `grep` / `head` carry a `CommandSpec`: unknown options fail with a GNU-style
+usage error instead of being ignored (`find` stays unspec'd so predicates like `-name` still
+compile). Implemented GNU holes: `cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` /
+`head --lines` / `du --max-depth`. `fauxnix list --json` and `docs/command-specs.md` dump the
+same metadata.
 - **shell/system**: `cd pwd export unset env printenv ps kill pkill pgrep sleep which type whoami
   id groups date uname hostname uptime free nproc clear true false test [ [[ : pushd popd dirs sudo
   timeout man history less more source . eval exit alias set`

--- a/docs/command-specs.md
+++ b/docs/command-specs.md
@@ -56,6 +56,131 @@ Effects: `read`
 | `-h`, `--human-readable` | flag | implemented |
 | `-d`, `--max-depth` | required | implemented |
 
+## `ls` / `ll`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-l`, `--long` | flag | implemented |
+| `--format` | required | implemented |
+| `-a`, `--all` | flag | implemented |
+| `-A`, `--almost-all` | flag | implemented |
+| `-d`, `--directory` | flag | implemented |
+| `-h`, `--human-readable` | flag | implemented |
+| `-F`, `--classify` | flag | implemented |
+| `-p` | flag | implemented |
+| `-t` | flag | implemented |
+| `-S` | flag | implemented |
+| `-r` | flag | implemented |
+| `-R`, `--recursive` | flag | unsupported (recursive listing) |
+
+## `mkdir`
+
+Effects: `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-p`, `--parents` | flag | implemented |
+| `-v`, `--verbose` | flag | implemented |
+
+## `rmdir`
+
+Effects: `delete`
+
+No options declared.
+
+## `mktemp`
+
+Effects: `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-d`, `--directory` | flag | implemented |
+
+## `ln`
+
+Effects: `read`, `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-s`, `--symbolic` | flag | implemented |
+
+## `readlink`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-f`, `--canonicalize` | flag | implemented |
+
+## `realpath`
+
+Effects: `read`
+
+No options declared.
+
+## `basename`
+
+Effects: `read`
+
+No options declared.
+
+## `dirname`
+
+Effects: `read`
+
+No options declared.
+
+## `stat`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-c` | required | implemented |
+| `--format` | required | implemented |
+| `--printf` | required | implemented |
+
+## `file`
+
+Effects: `read`
+
+No options declared.
+
+## `df`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-h`, `--human-readable` | flag | implemented |
+| `-H` | flag | implemented |
+
+## `chmod`
+
+Effects: `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-R`, `--recursive` | flag | unsupported (recursive chmod) |
+
+## `chown`
+
+Effects: `write`
+
+No options declared.
+
+## `diff`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-q`, `--brief` | flag | implemented |
+| `-u`, `--unified` | flag | implemented |
+| `-U` | flag | implemented |
+
 ## `tee`
 
 Effects: `read`, `write`
@@ -107,4 +232,4 @@ Effects: `read`
 
 ## Unspec'd commands
 
-`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `basename`, `cat`, `cd`, `chmod`, `chown`, `clear`, `command`, `curl`, `cut`, `date`, `df`, `diff`, `dig`, `dirname`, `dirs`, `echo`, `egrep`, `env`, `eval`, `exit`, `export`, `false`, `file`, `find`, `free`, `groups`, `gunzip`, `gzip`, `history`, `host`, `hostname`, `id`, `ifconfig`, `ip`, `kill`, `less`, `ll`, `ln`, `ls`, `man`, `md5sum`, `mkdir`, `mktemp`, `more`, `netstat`, `nl`, `nproc`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `printenv`, `printf`, `ps`, `pushd`, `pwd`, `read`, `readlink`, `realpath`, `rmdir`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `sleep`, `sort`, `source`, `ss`, `stat`, `sudo`, `tac`, `tail`, `tar`, `test`, `timeout`, `tr`, `true`, `type`, `uname`, `uniq`, `unset`, `unzip`, `uptime`, `wc`, `wget`, `which`, `whoami`, `xargs`, `yes`, `zcat`, `zip`
+`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `cat`, `cd`, `clear`, `command`, `curl`, `cut`, `date`, `dig`, `dirs`, `echo`, `egrep`, `env`, `eval`, `exit`, `export`, `false`, `find`, `free`, `groups`, `gunzip`, `gzip`, `history`, `host`, `hostname`, `id`, `ifconfig`, `ip`, `kill`, `less`, `man`, `md5sum`, `more`, `netstat`, `nl`, `nproc`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `printenv`, `printf`, `ps`, `pushd`, `pwd`, `read`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `sleep`, `sort`, `source`, `ss`, `sudo`, `tac`, `tail`, `tar`, `test`, `timeout`, `tr`, `true`, `type`, `uname`, `uniq`, `unset`, `unzip`, `uptime`, `wc`, `wget`, `which`, `whoami`, `xargs`, `yes`, `zcat`, `zip`

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { FauxnixParseError, isUnquotedLiteral, wordToString } from '../src/ast.js';
 import { parseCommand as parse, tokenize } from '../src/parser.js';
@@ -17,6 +18,7 @@ import { normalizeStderr } from '../src/errors.js';
 import { decodeHostResponse, encodeHostRequest, parseHostLine } from '../src/ps-host.js';
 import { bashToolResult, formatBashText } from '../src/mcp.js';
 import '../src/commands/install-all.js';
+import { specsMarkdown } from '../src/registry.js';
 
 /* ---------------------------- parser ---------------------------- */
 
@@ -834,6 +836,16 @@ describe('CommandSpec files leftovers (#130)', () => {
   it('mkdir --verbose and ln --symbolic are implemented longs', () => {
     expect(bodyOf('mkdir --verbose d')).toContain('if ($true)');
     expect(bodyOf('ln --symbolic a b')).toContain('SymbolicLink');
+  });
+});
+
+describe('command-specs.md (#143)', () => {
+  it('equals specsMarkdown() from the live registry', () => {
+    const onDisk = readFileSync(new URL('../docs/command-specs.md', import.meta.url), 'utf8').replace(
+      /\r\n/g,
+      '\n',
+    );
+    expect(onDisk).toBe(specsMarkdown());
   });
 });
 


### PR DESCRIPTION
## Why

Owner P2 on #143: after #144, `docs/command-specs.md` still listed `ls`/`mkdir`/`rmdir`/`mktemp`/`ln`/`readlink`/`realpath`/`basename`/`dirname`/`stat`/`file`/`df`/`chmod`/`chown`/`diff` as unspec'd, and README only named `cp`/`mv`/`rm`/`touch`/`tee`/`grep`/`head`/`du`. That contradicts the live registry and `fauxnix list --markdown`.

## What

- Regenerated `docs/command-specs.md` from `specsMarkdown()` (same text as `fauxnix list --markdown`).
- Updated the README CommandSpec list so it matches the registry; `find` stays unspec'd.
- Unit test: `docs/command-specs.md` equals `specsMarkdown()` (newlines normalized). `specsMarkdown` is imported after `install-all`.

No runtime command behavior change.

## Tests

`npx vitest run test/unit.test.ts` — 109 passed.

Refs #143.