### PR TITLE
fix: print FAILED when powershell.exe spawn fails

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,6 +96,10 @@ async function runCheck(): Promise<void> {
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
   });
+  probe.on('error', (e) => {
+    console.error('status     : FAILED to run powershell.exe: ' + e.message);
+    process.exit(1);
+  });
   let out = '';
   probe.stdout.on('data', (d) => (out += d.toString('utf8')));
   const code = await new Promise<number>((resolve) => probe.on('close', (c) => resolve(c ?? 1)));

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { FauxnixParseError, isUnquotedLiteral, wordToString } from '../src/ast.js';
 import { parseCommand as parse, tokenize } from '../src/parser.js';
@@ -925,5 +926,15 @@ describe('MCP structured results (#129)', () => {
     expect(r.structuredContent.exitCode).toBe(1);
     expect(r.content[0].text).toContain('Exit code: 1');
     expect('isError' in r && r.isError).toBeFalsy();
+  });
+});
+
+describe('cli check spawn error', () => {
+  it('runCheck attaches an error listener so missing powershell.exe prints FAILED', () => {
+    const src = readFileSync('src/cli.ts', 'utf8');
+    const check = src.slice(src.indexOf('async function runCheck'));
+    expect(check).toContain("probe.on('error'");
+    expect(check).toMatch(/FAILED to run powershell\.exe:.*e\.message/);
+    expect(check).toContain('process.exit(1)');
   });
 });


### PR DESCRIPTION
## Problem
`fauxnix check` spawns `powershell.exe` in `runCheck()` with stdout and close listeners only. `src/ps-host.ts` already attaches `child.on('error', ...)`. Missing `powershell.exe` emits an unhandled EventEmitter `error` and never prints FAILED.

## Fix
Copy the persistent-host pattern: on spawn error, print FAILED with the error message and `process.exit(1)`.

## Test
No CLI test harness, so a unit test asserts the listener is present in `runCheck()` source.

`npx vitest run --dir test test/unit.test.ts` — 109 passed.