### PR TITLE
fix: GNU head negative line/byte counts print all but last N

### DIFF
--- a/src/commands/text-io.ts
+++ b/src/commands/text-io.ts
@@ -559,8 +559,9 @@ const head: Handler = (args, ctx) => {
       "    [void]$fx_out.Append('==> ' + $fx_disp + ' <==' + [string][char]10)",
       '  }',
       '  $fx_first = $false',
-      '  $fx_len = [math]::Min($fx_count, $fx_txt.Length)',
-      '  if ($fx_len -lt 0) { $fx_len = 0 }',
+      // GNU: --bytes=-N prints all but last N; -0 / N≥size → empty
+      '  if ($fx_count -lt 0) { $fx_len = [math]::Max(0, $fx_txt.Length + $fx_count) }',
+      '  else { $fx_len = [math]::Min($fx_count, $fx_txt.Length) }',
       '  if ($fx_len -gt 0) { [void]$fx_out.Append($fx_txt.Substring(0, $fx_len)) }',
       '}',
       'fx-write $fx_out.ToString() $fx_term',

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -207,6 +207,24 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('wc -l < fruits.txt')).stdout.trim()).toBe('4');
   });
 
+  it('head --lines=-N / --bytes=-N print all but last N (GNU)', async () => {
+    const droppedLine = await run('head --lines=-1 fruits.txt');
+    expect(droppedLine.exitCode).toBe(0);
+    expect(droppedLine.stdout.split(/\r?\n/).filter(Boolean)).toEqual([
+      'apple',
+      'Banana',
+      'apple pie',
+    ]);
+
+    writeFileSync(join(dir, 'head-bytes.txt'), 'abc', 'utf8');
+    const droppedByte = await run('head --bytes=-1 head-bytes.txt');
+    expect(droppedByte.exitCode).toBe(0);
+    expect(droppedByte.stdout).toBe('ab');
+
+    expect((await run('head --bytes=2 head-bytes.txt')).stdout).toBe('ab');
+    expect((await run('head --lines=1 fruits.txt')).stdout.trim()).toBe('apple');
+  });
+
   it('grep -m1 stops after the first match', async () => {
     const r = await run('grep -m1 apple fruits.txt');
     expect(r.exitCode).toBe(0);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -741,6 +741,23 @@ describe('bounded output flags (#130)', () => {
     expect(bodyOf('head fruits.txt')).toContain('$fx_count = [int](10)');
   });
 
+  it('head --lines=-N uses count+length (all but last N lines)', () => {
+    const body = bodyOf('head --lines=-1 fruits.txt');
+    expect(body).toContain('$fx_count = [int](-1)');
+    expect(body).toContain('$fx_ls.Count + $fx_count');
+  });
+
+  it('head --bytes=-N uses length + negative count (not Min/clamp-to-0 first)', () => {
+    const body = bodyOf('head --bytes=-1 fruits.txt');
+    expect(body).toContain('$fx_count = [int](-1)');
+    expect(body).toContain('$fx_txt.Length + $fx_count');
+    expect(body).toMatch(/if \(\$fx_count -lt 0\)/);
+    // old bug: Min(-N, length) then clamp $fx_len to 0 → empty output
+    expect(body).not.toMatch(
+      /\$fx_len = \[math\]::Min\(\$fx_count, \$fx_txt\.Length\)\s+if \(\$fx_len -lt 0\) \{ \$fx_len = 0 \}/,
+    );
+  });
+
   it('du --max-depth filters subdirectory rows', () => {
     expect(bodyOf('du --max-depth=0')).toContain('if ($true)');
     expect(bodyOf('du --max-depth=0')).not.toContain('$fx_ddepth');


### PR DESCRIPTION
﻿## Why

Owner P2 on #143: GNU `head --lines=-N` / `--bytes=-N` print all but the last N. The bytes path did `Min(-N, length)` then clamped to 0, so negative counts silently emitted empty output. The lines path already had `$fx_lim = $fx_ls.Count + $fx_count`.

## What

- Bytes: if `$fx_count -lt 0` then `len = max(0, $fx_txt.Length + $fx_count)` then `Substring(0, len)`. `-0` / N >= size yields empty.
- Lines path left as-is; covered by tests.

## Tests

- Unit: translation body contains `$fx_txt.Length + $fx_count` (does not clamp negative to 0 before adding length); lines body still contains `$fx_ls.Count + $fx_count`.
- Integration: known file, `head --lines=-1` drops the last line; `head --bytes=-1` drops the last byte; positive `--lines` / `--bytes` still work.

`npx vitest run test/unit.test.ts`: 110 passed.
Relevant integration tests (`head/tail/wc` and the new GNU negative-count case): 2 passed.

Relates to #143.
