### PR TITLE
fix: grep -e/--regexp repeats OR-accumulate patterns

### DIFF
--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -134,6 +134,50 @@ function collectLongValues(args: Word[], names: string[]): LongOptionValue[] {
   return out;
 }
 
+/**
+ * Collect EVERY value of a short option and its long aliases, in argv order.
+ * parseWords keeps only the last; grep -e/--regexp must OR-accumulate.
+ * Handles -e PAT, -ePAT, -ie PAT (bundled), --regexp PAT, --regexp=PAT.
+ */
+function collectRepeatOptionValues(args: Word[], short: string, longs: string[]): string[] {
+  const out: string[] = [];
+  let onlyOps = false;
+  for (let i = 0; i < args.length; i++) {
+    const t = wordToString(args[i]);
+    if (t === '--') {
+      onlyOps = true;
+      continue;
+    }
+    if (onlyOps) continue;
+    if (t.startsWith('--')) {
+      const eq = t.indexOf('=');
+      const name = eq >= 0 ? t.slice(0, eq) : t;
+      if (!longs.includes(name)) continue;
+      if (eq >= 0) {
+        out.push(t.slice(eq + 1));
+      } else if (i + 1 < args.length) {
+        out.push(wordToString(args[i + 1]));
+        i++;
+      }
+      continue;
+    }
+    if (!(t.startsWith('-') && t.length > 1 && !/^-?\d/.test(t.slice(1, 2)))) continue;
+    const body = t.slice(1);
+    for (let c = 0; c < body.length; c++) {
+      if (body[c] !== short) continue;
+      const rest = body.slice(c + 1);
+      if (rest) {
+        out.push(rest);
+      } else if (i + 1 < args.length) {
+        out.push(wordToString(args[i + 1]));
+        i++;
+      }
+      break;
+    }
+  }
+  return out;
+}
+
 /** Build the "collect file operands through fx-glob" PS prologue. */
 function psCollectSources(
   filesExpr: string,
@@ -331,29 +375,47 @@ const grep: Handler = (args) => {
   const ctxA = Math.max(toInt(values.get('-A')), toInt(values.get('-C')));
   const ctxB = Math.max(toInt(values.get('-B')), toInt(values.get('-C')));
 
-  const ePat = values.get('-e') ?? values.get('--regexp');
-  if (ePat === undefined && operandWords.length === 0) {
+  const regexpPats = collectRepeatOptionValues(args, 'e', ['--regexp']);
+  if (regexpPats.length === 0 && operandWords.length === 0) {
     return (
       "[Console]::Error.WriteLine('usage: grep [OPTION]... PATTERN [FILE]...'); $script:fx_exit = 2"
     );
   }
-  const patternWord: Word =
-    ePat !== undefined ? [{ kind: 'Text', text: ePat }] : operandWords[0];
-  const fileWords = ePat !== undefined ? operandWords : operandWords.slice(1);
-  const patLit = literalOfWord(patternWord);
-  let patExpr: string;
-  if (fixed || patLit === null) {
-    patExpr = textExpr(patternWord);
-  } else {
-    patExpr = psStr(ere ? ereToDotNet(patLit) : breToDotNet(patLit));
+  const fileWords = regexpPats.length > 0 ? operandWords : operandWords.slice(1);
+  const multiFixed = fixed && regexpPats.length > 1;
+  let patExpr = "''";
+  if (!multiFixed) {
+    if (regexpPats.length > 1) {
+      patExpr = psStr(
+        regexpPats.map((p) => '(?:' + (ere ? ereToDotNet(p) : breToDotNet(p)) + ')').join('|'),
+      );
+    } else {
+      const patternWord: Word =
+        regexpPats.length === 1 ? [{ kind: 'Text', text: regexpPats[0] }] : operandWords[0];
+      const patLit = literalOfWord(patternWord);
+      if (fixed || patLit === null) {
+        patExpr = textExpr(patternWord);
+      } else {
+        patExpr = psStr(ere ? ereToDotNet(patLit) : breToDotNet(patLit));
+      }
+    }
   }
 
   const lines: string[] = [PS_READTEXT_FN, PS_SPLITLINES_FN];
 
   // --- pattern objects -------------------------------------------------
   if (fixed) {
-    lines.push('$fx_needle = ' + patExpr);
-    if (ci) lines.push('$fx_needle_ll = $fx_needle.ToLower()');
+    if (multiFixed) {
+      lines.push(
+        '$fx_needles = @(' +
+          regexpPats.map((p) => textExpr([{ kind: 'Text', text: p }])).join(', ') +
+          ')',
+      );
+      if (ci) lines.push('$fx_needles_ll = @($fx_needles | ForEach-Object { $_.ToLower() })');
+    } else {
+      lines.push('$fx_needle = ' + patExpr);
+      if (ci) lines.push('$fx_needle_ll = $fx_needle.ToLower()');
+    }
   } else {
     lines.push('$fx_pat = ' + patExpr);
     if (word) lines.push("$fx_pat = '(?<!\\w)(?:' + $fx_pat + ')(?!\\w)'");
@@ -364,24 +426,50 @@ const grep: Handler = (args) => {
     );
   }
 
-  // --- fx-gmatch: line test (-v applied) -------------------------------
+  // --- fx-gmatch: line test (-v applied once to the combined OR) --------
   lines.push('function fx-gmatch($l) {');
   if (fixed) {
     if (word) {
       if (ci) lines.push('  $lx = $l.ToLower()');
       const hay = ci ? '$lx' : '$l';
-      const needle = ci ? '$fx_needle_ll' : '$fx_needle';
-      lines.push('  $p = ' + hay + '.IndexOf(' + needle + ')');
-      lines.push('  while ($p -ge 0) {');
-      lines.push('    $ok = $true');
-      lines.push(
-        "    if ($p -gt 0) { $c = " + hay + "[$p - 1]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') }",
-      );
-      lines.push(
-        '    if ($ok) { $e = $p + ' + needle + '.Length; if ($e -lt ' + hay + '.Length) { $c = ' + hay + "[$e]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') } }",
-      );
-      lines.push('    if ($ok) { return ' + pb(!inv) + ' }');
-      lines.push('    $p = ' + hay + '.IndexOf(' + needle + ', $p + 1)');
+      if (multiFixed) {
+        const arr = ci ? '$fx_needles_ll' : '$fx_needles';
+        lines.push('  foreach ($fx_needle in ' + arr + ') {');
+        lines.push('    $p = ' + hay + '.IndexOf($fx_needle)');
+        lines.push('    while ($p -ge 0) {');
+        lines.push('      $ok = $true');
+        lines.push(
+          "      if ($p -gt 0) { $c = " + hay + "[$p - 1]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') }",
+        );
+        lines.push(
+          '      if ($ok) { $e = $p + $fx_needle.Length; if ($e -lt ' + hay + '.Length) { $c = ' + hay + "[$e]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') } }",
+        );
+        lines.push('      if ($ok) { return ' + pb(!inv) + ' }');
+        lines.push('      $p = ' + hay + '.IndexOf($fx_needle, $p + 1)');
+        lines.push('    }');
+        lines.push('  }');
+        lines.push('  return ' + pb(inv));
+      } else {
+        const needle = ci ? '$fx_needle_ll' : '$fx_needle';
+        lines.push('  $p = ' + hay + '.IndexOf(' + needle + ')');
+        lines.push('  while ($p -ge 0) {');
+        lines.push('    $ok = $true');
+        lines.push(
+          "    if ($p -gt 0) { $c = " + hay + "[$p - 1]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') }",
+        );
+        lines.push(
+          '    if ($ok) { $e = $p + ' + needle + '.Length; if ($e -lt ' + hay + '.Length) { $c = ' + hay + "[$e]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') } }",
+        );
+        lines.push('    if ($ok) { return ' + pb(!inv) + ' }');
+        lines.push('    $p = ' + hay + '.IndexOf(' + needle + ', $p + 1)');
+        lines.push('  }');
+        lines.push('  return ' + pb(inv));
+      }
+    } else if (multiFixed) {
+      const hay = ci ? '$l.ToLower()' : '$l';
+      const arr = ci ? '$fx_needles_ll' : '$fx_needles';
+      lines.push('  foreach ($fx_needle in ' + arr + ') {');
+      lines.push('    if (' + hay + '.Contains($fx_needle)) { return ' + pb(!inv) + ' }');
       lines.push('  }');
       lines.push('  return ' + pb(inv));
     } else {
@@ -543,33 +631,53 @@ const grep: Handler = (args) => {
     if (maxCount !== null) scan.push('    $fx_mleft--');
     if (onlyMatch && !inv) {
       if (fixed) {
-        if (ci) {
-          scan.push('    $lx = $fx_l.ToLower()');
-          scan.push('    $p = $lx.IndexOf($fx_needle_ll)');
-        } else {
-          scan.push('    $p = $fx_l.IndexOf($fx_needle)');
-        }
+        if (ci) scan.push('    $lx = $fx_l.ToLower()');
         const hay = ci ? '$lx' : '$fx_l';
-        const needle = ci ? '$fx_needle_ll' : '$fx_needle';
-        scan.push('    while ($p -ge 0) {');
-        scan.push('      $ok = $true');
-        if (word) {
-          scan.push(
-            "      if ($p -gt 0) { $c = " + hay + "[$p - 1]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') }",
-          );
-          scan.push(
-            '      if ($ok) { $e = $p + ' + needle + '.Length; if ($e -lt ' + hay + '.Length) { $c = ' + hay + "[$e]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') } }",
-          );
-          scan.push(
-            '      if ($ok) { fx-emitline $fx_i (' + hay + '.Substring($p, ' + needle + '.Length)) }',
-          );
+        const emitFixedHits = (needle: string, indent: string) => {
+          scan.push(indent + '$p = ' + hay + '.IndexOf(' + needle + ')');
+          scan.push(indent + 'while ($p -ge 0) {');
+          scan.push(indent + '  $ok = $true');
+          if (word) {
+            scan.push(
+              indent +
+                "  if ($p -gt 0) { $c = " +
+                hay +
+                "[$p - 1]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') }",
+            );
+            scan.push(
+              indent +
+                '  if ($ok) { $e = $p + ' +
+                needle +
+                '.Length; if ($e -lt ' +
+                hay +
+                '.Length) { $c = ' +
+                hay +
+                "[$e]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') } }",
+            );
+            scan.push(
+              indent +
+                '  if ($ok) { fx-emitline $fx_i (' +
+                hay +
+                '.Substring($p, ' +
+                needle +
+                '.Length)) }',
+            );
+          } else {
+            scan.push(
+              indent + '  fx-emitline $fx_i (' + hay + '.Substring($p, ' + needle + '.Length))',
+            );
+          }
+          scan.push(indent + '  $p = ' + hay + '.IndexOf(' + needle + ', $p + 1)');
+          scan.push(indent + '}');
+        };
+        if (multiFixed) {
+          const arr = ci ? '$fx_needles_ll' : '$fx_needles';
+          scan.push('    foreach ($fx_needle in ' + arr + ') {');
+          emitFixedHits('$fx_needle', '      ');
+          scan.push('    }');
         } else {
-          scan.push(
-            '      fx-emitline $fx_i (' + hay + '.Substring($p, ' + needle + '.Length))',
-          );
+          emitFixedHits(ci ? '$fx_needle_ll' : '$fx_needle', '    ');
         }
-        scan.push('      $p = ' + hay + '.IndexOf(' + needle + ', $p + 1)');
-        scan.push('    }');
       } else {
         scan.push(
           '    foreach ($fx_m in $fx_re.Matches($fx_l)) { fx-emitline $fx_i $fx_m.Value }',

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -25,6 +25,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
   beforeAll(async () => {
     dir = mkdtempSync(join(tmpdir(), 'fauxnix-it-'));
     writeFileSync(join(dir, 'fruits.txt'), 'apple\nBanana\napple pie\ncherry\n', 'utf8');
+    writeFileSync(join(dir, 'letters.txt'), 'a\nb\nc\n', 'utf8');
     writeFileSync(join(dir, 'nums.txt'), '1 2\n3 4\n5 6\n', 'utf8');
     writeFileSync(join(dir, 'dups.txt'), 'aaa\naaa\nbbb\n', 'utf8');
     mkdirSync(join(dir, 'sub'));
@@ -216,6 +217,28 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     const viaE = await run('grep -e apple fruits.txt');
     expect(viaE.exitCode).toBe(0);
     expect(viaE.stdout.trim().split(/\r?\n/)).toEqual(['apple', 'apple pie']);
+  });
+
+  it('grep -e a -e c OR-accumulates patterns', async () => {
+    const r = await run('grep -e a -e c letters.txt');
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim().split(/\r?\n/)).toEqual(['a', 'c']);
+    expect(r.stdout).not.toContain('b');
+  });
+
+  it('grep --regexp repeats OR-accumulate', async () => {
+    const spaced = await run('grep --regexp a --regexp c letters.txt');
+    expect(spaced.exitCode).toBe(0);
+    expect(spaced.stdout.trim().split(/\r?\n/)).toEqual(['a', 'c']);
+    const equals = await run('grep --regexp=a --regexp=c letters.txt');
+    expect(equals.exitCode).toBe(0);
+    expect(equals.stdout.trim().split(/\r?\n/)).toEqual(['a', 'c']);
+  });
+
+  it('grep -v -e a -e c inverts the combined OR', async () => {
+    const r = await run('grep -v -e a -e c letters.txt');
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim().split(/\r?\n/)).toEqual(['b']);
   });
 
   it('du --max-depth=0 prints only the root', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -731,8 +731,43 @@ describe('bounded output flags (#130)', () => {
   });
 
   it('grep -e / --regexp keep the pattern (not an unknown flag)', () => {
-    expect(bodyOf("grep -e apple fruits.txt")).toContain('fx-gmatch');
-    expect(bodyOf("grep -e apple fruits.txt")).not.toContain('invalid option');
+    expect(bodyOf('grep -e apple fruits.txt')).toContain('fx-gmatch');
+    expect(bodyOf('grep -e apple fruits.txt')).toContain("$fx_pat = 'apple'");
+    expect(bodyOf('grep -e apple fruits.txt')).not.toContain('invalid option');
+    expect(bodyOf('grep --regexp apple fruits.txt')).toContain("$fx_pat = 'apple'");
+    expect(bodyOf('grep --regexp=apple fruits.txt')).toContain("$fx_pat = 'apple'");
+  });
+
+  it('grep -e / --regexp repeats OR-accumulate (#143)', () => {
+    const short = bodyOf('grep -e a -e c f');
+    expect(short).toContain("$fx_pat = '(?:a)|(?:c)'");
+    expect(short).toContain("foreach ($fx_o in (@('f')))");
+    expect(short).not.toContain("$fx_pat = 'c'");
+    expect(short).toContain('return $fx_re.IsMatch($l)');
+
+    const longs = bodyOf('grep --regexp a --regexp=c f');
+    expect(longs).toContain("$fx_pat = '(?:a)|(?:c)'");
+    expect(longs).toContain("foreach ($fx_o in (@('f')))");
+
+    const mixed = bodyOf('grep -e a --regexp=c f');
+    expect(mixed).toContain("$fx_pat = '(?:a)|(?:c)'");
+
+    const glued = bodyOf('grep -ea -ec f');
+    expect(glued).toContain("$fx_pat = '(?:a)|(?:c)'");
+  });
+
+  it('grep -v -e a -e c inverts the combined OR once (#143)', () => {
+    const body = bodyOf('grep -v -e a -e c f');
+    expect(body).toContain("$fx_pat = '(?:a)|(?:c)'");
+    expect(body).toContain('return -not ($fx_re.IsMatch($l))');
+    expect(body).not.toContain('return -not ($fx_re.IsMatch($l))\n  return -not');
+  });
+
+  it('grep with no pattern fails loud with usage', () => {
+    const body = bodyOf('grep');
+    expect(body).toContain('usage: grep [OPTION]... PATTERN [FILE]...');
+    expect(body).toContain('$script:fx_exit = 2');
+    expect(bodyOf('grep -v')).toContain('usage: grep [OPTION]... PATTERN [FILE]...');
   });
 
   it('head --lines and --lines=N set the count (not silently skipped)', () => {


### PR DESCRIPTION
## Why
GNU grep OR-accumulates every `-e`/`--regexp`. `parseWords` stores option values in a map, so `grep -e a -e c` kept only the last pattern.

Owner note on https://github.com/20000419/fauxnix/issues/143: the values map last-wins, while `--include`/`--exclude` already collect repeats.

## What
- Collect every `-e` / `--regexp` value in argv order: `-e pat`, `-epat`, bundled `-ie pat`, `--regexp pat`, `--regexp=pat`.
- If any `-e`/`--regexp` is present, those are the patterns and remaining operands are files.
- Multiple regexps compile as one alternation (`(?:a)|(?:c)`); `-v` inverts that combined match once, not per-pattern.
- Multiple `-F` needles OR via `Contains`/`IndexOf` and invert once.
- No `-e`/`--regexp` still uses the first operand as the pattern (existing path).
- Missing pattern still fails loud with usage (exit 2).

## Tests
- Unit: `-e a -e c`, `--regexp` repeats (space and `=`), mixed `-e`/`--regexp=`, glued `-ea -ec`; `-v` wraps a single `IsMatch`; existing single `-e`/`--regexp` still emit `$fx_pat = ''apple''`; `grep` / `grep -v` with no pattern emit usage.
- Integration: `grep -e a -e c` on a file with lines a/b/c matches a and c, not b; `--regexp` repeats; `-v -e a -e c` prints only b; existing `grep -e apple fruits.txt` stays green.

`npx vitest run test/unit.test.ts`: 111 passed.
`npx vitest run test/integration.windows.test.ts -t grep`: 10 passed (84 skipped).