### PR TITLE
fix: re-split printf-style stdin lines in grep and text-filters

### DIFF
--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -36,7 +36,12 @@ const PS_SPLITLINES_FN = [
   '}',
 ].join('\n');
 
-const STDIN_LINES = '@($input | ForEach-Object { [string]$_ })';
+/** stdin → flat line array (multi-line items from printf-style stages split). */
+const STDIN_LINES = [
+  '$fx_in = New-Object System.Collections.Generic.List[string]',
+  'foreach ($fx_it in @($input | ForEach-Object { [string]$_ })) { $fx_in.AddRange([string[]]@(fx-splitlines $fx_it)) }',
+  '$fx_in = @($fx_in)',
+].join('\n');
 
 /** Operand Words → PS array expression of string exprs. */
 function psArray(words: Word[], fn: (w: Word) => string = operandExpr): string {
@@ -622,7 +627,8 @@ const grep: Handler = (args) => {
   } else {
     lines.push('$fx_pre = $false');
     lines.push("$fx_disp = '(standard input)'");
-    lines.push('$fx_ls = ' + STDIN_LINES);
+    lines.push(STDIN_LINES);
+    lines.push('$fx_ls = $fx_in');
     for (const l of scan) lines.push(l);
   }
 
@@ -1208,7 +1214,8 @@ const sed: Handler = (args) => {
     lines.push('}');
   } else {
     lines.push('$fx_err = $false');
-    lines.push('$fx_lines = ' + STDIN_LINES);
+    lines.push(STDIN_LINES);
+    lines.push('$fx_lines = $fx_in');
     lines.push('$fx_n = $fx_lines.Count');
     lines.push('$fx_out = New-Object System.Collections.Generic.List[string]');
     lines.push('$fx_stop = $false');
@@ -2078,7 +2085,8 @@ const awk: Handler = (args) => {
     lines.push('foreach ($fx_f in $fx_srcs) { $fx_lines += fx-splitlines (fx-read $fx_f) }');
   } else {
     lines.push('$fx_err = $false');
-    lines.push('$fx_lines = ' + STDIN_LINES);
+    lines.push(STDIN_LINES);
+    lines.push('$fx_lines = $fx_in');
   }
 
   const mainLoop: string[] = [];
@@ -2202,7 +2210,8 @@ const sort: Handler = (args) => {
     lines.push('$fx_lines = @()');
     lines.push('foreach ($fx_f in $fx_srcs) { $fx_lines += fx-splitlines (fx-read $fx_f) }');
   } else {
-    lines.push('$fx_lines = ' + STDIN_LINES);
+    lines.push(STDIN_LINES);
+    lines.push('$fx_lines = $fx_in');
   }
 
   const fastPath = specs.length === 0 && !globalN && !globalB;
@@ -2379,7 +2388,8 @@ const uniq: Handler = (args) => {
     lines.push('else { $fx_lines = @() }');
   } else {
     lines.push('$fx_err = $false');
-    lines.push('$fx_lines = ' + STDIN_LINES);
+    lines.push(STDIN_LINES);
+    lines.push('$fx_lines = $fx_in');
   }
 
   lines.push('function fx-ueq($a, $b) {');
@@ -2499,7 +2509,8 @@ const cut: Handler = (args) => {
     lines.push('$fx_lines = @()');
     lines.push('foreach ($fx_f in $fx_srcs) { $fx_lines += fx-splitlines (fx-read $fx_f) }');
   } else {
-    lines.push('$fx_lines = ' + STDIN_LINES);
+    lines.push(STDIN_LINES);
+    lines.push('$fx_lines = $fx_in');
   }
 
   if (charsMode) {
@@ -2636,7 +2647,7 @@ const tr: Handler = (args) => {
     }
   }
 
-  const lines: string[] = [];
+  const lines: string[] = [PS_SPLITLINES_FN];
   lines.push('$fx_dl = @{}');
   if (del) {
     lines.push('foreach ($c in [char[]](' + set1.join(', ') + ')) { $fx_dl[[int]$c] = $true }');
@@ -2650,7 +2661,8 @@ const tr: Handler = (args) => {
     lines.push('foreach ($c in [char[]](' + sqSet.join(', ') + ')) { $fx_sq[[int]$c] = $true }');
   }
 
-  lines.push('foreach ($fx_line in ' + STDIN_LINES + ') {');
+  lines.push(STDIN_LINES);
+  lines.push('foreach ($fx_line in $fx_in) {');
   lines.push('  $fx_sb = New-Object System.Text.StringBuilder');
   lines.push('  $fx_prev = -1');
   lines.push('  foreach ($fx_ch in $fx_line.ToCharArray()) {');

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -162,6 +162,18 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout.split(/\r?\n/).filter(Boolean)).toEqual(['apple', 'apple pie']);
   });
 
+  it('printf-style stdin is re-split so grep matches a later line', async () => {
+    const r = await run("printf 'a\\nb\\n' | grep b");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('b');
+  });
+
+  it('echo hi | grep hi still matches a single line without embedded newlines', async () => {
+    const r = await run('echo hi | grep hi');
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('hi');
+  });
+
   it('pipeline exit status comes from the last stage (pipefail off)', async () => {
     expect((await run('false | true')).exitCode).toBe(0);
     expect((await run('true | false')).exitCode).toBe(1);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -541,6 +541,18 @@ describe('translator', () => {
     expect(body).toContain('$script:fx_exit = 2');
   });
 
+  it('re-splits printf-style stdin for grep and other text-filters', () => {
+    const split = 'fx-splitlines $fx_it';
+    const cmds = ['grep b', "sed 's/a/A/'", "awk '{print}'", 'sort', 'uniq', 'tr a b'];
+    for (const cmd of cmds) {
+      const body = translateCommandList(parse(cmd))[0].body;
+      expect(body, cmd).toContain(split);
+      expect(body, cmd).toContain('$input | ForEach-Object { [string]$_ }');
+    }
+    const grepHi = translateCommandList(parse('grep hi'))[0].body;
+    expect(grepHi).toContain('$fx_ls = $fx_in');
+  });
+
   it('feeds stdin for < redirects', () => {
     const plan = translateCommandList(parse('wc -l < f.txt'))[0];
     expect(plan.script).toContain('fx-readlines $env:FAUXNIX_STDIN_FILE |');


### PR DESCRIPTION
## Problem

`printf 'a\nb\n' | grep b` did not match. In a non-terminal pipeline stage, `printf` emits **one** object with embedded newlines (`fx-write` keeps the payload intact). `grep` stdin used:

```
STDIN_LINES = '@($input | ForEach-Object { [string]$_ })'
```

which does not re-split, so grep tested the whole blob as a single line. text-io consumers (`head`/`tail`/`cat`/…) already re-split via `STDIN_INLINES` + `fx-splitlines`.

## Fix

`src/commands/text-filters.ts` `STDIN_LINES` now matches text-io `STDIN_INLINES`: collect `$input` items, `fx-splitlines` each, flatten. A single line without embedded newlines is identity (`echo hi | grep hi` still works).

Same stdin path is used by grep, sed, awk, sort, uniq, cut, and tr (tr also emits `fx-splitlines`).

## Tests

- integration: `printf 'a\nb\n' | grep b` matches `b`
- integration: `echo hi | grep hi` still matches
- unit: translation of grep/sed/awk/sort/uniq/tr stdin contains `fx-splitlines $fx_it`

`npx vitest run --dir test`: **202 passed** (109 unit + 93 integration, Windows PowerShell).
