### PR TITLE
docs: RFC for Windows computer-use parity after Mac-fleet training

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Linux command line — file ops, text processing, process management, archives, 
 maps cleanly onto PowerShell + .NET. fauxnix implements that subset faithfully and *fails loudly
 and helpfully* on what it can't translate, so the agent never gets silently-wrong results.
 
+Labs now train computer-use agents on fleets of real desktops. Reporting in 2026 (*The
+Information*, widely repeated) has OpenAI buying tens of thousands of Mac mini / Mac Studio
+boxes — no screen, no keyboard — to reinforcement-learn agents that click, edit, test, and
+run bash workflows, and Anthropic renting Mac minis through AWS for the same class of work.
+That scoring environment is macOS. Windows users should not have to install a guest Unix to
+keep up: the agent keeps writing bash; fauxnix makes the Windows box answer like the box the
+agent was trained on. See [`docs/rfc-computer-use-windows.md`](docs/rfc-computer-use-windows.md).
+
 ## Install
 
 ```bash

--- a/docs/rfc-computer-use-windows.md
+++ b/docs/rfc-computer-use-windows.md
@@ -1,0 +1,54 @@
+# RFC: Windows computer-use parity
+
+Tracking: [#156](https://github.com/20000419/fauxnix/issues/156).
+Roadmap: [#118](https://github.com/20000419/fauxnix/issues/118).
+
+## Why
+
+Computer-use agents are being trained on **real desktops**, not only GPU
+clusters. *The Information* (30 Aug 2026; widely repeated) reported that
+OpenAI bought tens of thousands of Mac mini / Mac Studio machines — no
+screen, no keyboard — for reinforcement learning of agents that click,
+edit, test, and run multi-step shell workflows. Anthropic is reported to
+rent Mac minis through AWS for the same class of work.
+
+That fleet is macOS. The language those agents emit is bash. Windows is
+still the OS most people actually sit in front of. “Install Git Bash” or
+“use WSL” makes Windows a guest Unix: wrong filesystem, wrong env, and a
+model scored on a Mac.
+
+fauxnix’s contract is the other direction: **translate, don’t emulate**.
+The agent keeps the bash it was trained on. PowerShell 5.1 runs a faithful
+subset. Anything else **fails loud**. v0.9.2 closed the post-v0.7 audit
+([#131](https://github.com/20000419/fauxnix/issues/131)). What remains is
+what still makes a Mac-trained agent silently wrong on Windows.
+
+This is not a GNU-completeness wishlist. It is the same bar as #129/#130:
+never silently-wrong argv, redirects, or ignored flags on the daily path
+(`git` / `node` / `npm` / `python` / `ls` / `grep` / `find` / `cd` / `curl`).
+
+## In scope (post-v0.9.2 leftovers)
+
+| Slice | Why an agent hits it |
+|---|---|
+| `xargs` still `& cmd @array` | same empty/quote drop #148 fixed for `node` |
+| `curl`/`wget`/`tar`/`ping` `nativeCall` splat | curl is the computer-use workhorse |
+| Non-last-stage stdout (`echo hi >f \| cat`) | #147 RFC follow-up |
+| CommandSpec on echo/printf/cat/tail/wc | unknown flags currently ignored |
+| Later #143 families (filters, sysinfo, net, archive) | same fail-loud hole |
+
+`find` stays unspec’d (predicates must compile).
+
+## Out of scope
+
+- WSL / Git Bash as the runtime.
+- `pwsh` 7 `ArgumentList`.
+- Version bump / npm publish.
+- Primary-source access to *The Information*; this RFC cites the widely
+  reported claim plus our own measurements
+  (`docs/benchmark-deepseek-v4-pro.md`).
+
+## Tests
+
+Each slice is its own one-commit PR with unit + Windows integration, the
+same bar as #147–#154. No silent “looks like bash” approximations.


### PR DESCRIPTION
## Why

Labs train computer-use agents on real desktops. *The Information* (30 Aug 2026, widely repeated) has OpenAI buying tens of thousands of Mac mini / Mac Studio boxes for RL computer-use, and Anthropic renting Macs through AWS. Those agents emit bash. Windows users should not need a guest Unix to keep up.

## What

- RFC: `docs/rfc-computer-use-windows.md` ([#156](https://github.com/20000419/fauxnix/issues/156))
- README: one paragraph tying translate-don't-emulate to that scoring environment

No runtime change. No version bump. Not merging.

Follow-up issues: [#156](https://github.com/20000419/fauxnix/issues/156) leftovers, [#157](https://github.com/20000419/fauxnix/issues/157) per-stage stdout.
