### PR TITLE
fix: route curl/tar nativeCall through fx-native

### DIFF
--- a/src/commands/archive.ts
+++ b/src/commands/archive.ts
@@ -253,8 +253,9 @@ const tar: Handler = (args) => {
     '  if ($fx_c) { $fx_tar = $fx_c.Source } else { $fx_tar = $null }',
     '}',
     'if ($fx_tar) {',
-    '  & $fx_tar @($fx_args) | ForEach-Object { [string]$_ }',
-    '  if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE }',
+    // fx-native captures stdout as pipeline strings and sets fx_exit.
+    // [object[]]@(...) keeps an empty argv from unwrapping to $null on PS 5.1.
+    '  fx-native $fx_tar ([object[]]@($fx_args))',
     '} else {',
     "  [Console]::Error.WriteLine('tar: fauxnix: tar.exe not found (Windows 10+ ships bsdtar as tar.exe)')",
     '  $script:fx_exit = 1',

--- a/src/commands/net.ts
+++ b/src/commands/net.ts
@@ -84,10 +84,9 @@ function synthWord(text: string): Word {
 
 /** A native-exe invocation obeying the fauxnix contract (string lines + exit code). */
 function nativeCall(exe: string, argArray: string): string {
-  return [
-    '& ' + psStr(exe) + ' @(' + argArray + ') | ForEach-Object { [string]$_ }',
-    'if ($LASTEXITCODE -gt 0) { $script:fx_exit = $LASTEXITCODE }',
-  ].join('\n');
+  // fx-native captures stdout as pipeline strings and sets fx_exit.
+  // [object[]]@(...) keeps an empty argv from unwrapping to $null on PS 5.1.
+  return 'fx-native ' + psStr(exe) + ' ([object[]]@(' + argArray + '))';
 }
 
 /* ------------------------------------------------------------------ */

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -556,6 +556,23 @@ describe('translator', () => {
     expect(script).toContain("if ($null -eq $argv) { $argv = @() }");
   });
 
+  it('curl translation uses fx-native, not call-operator splat', () => {
+    const plan = translateCommandList(parse('curl -s https://example.com/x'))[0];
+    expect(plan.body).toContain('fx-native');
+    expect(plan.body).not.toContain("& 'curl.exe' @");
+    expect(plan.body.indexOf('fx-netguard')).toBeGreaterThan(-1);
+    expect(plan.body.indexOf('fx-netguard')).toBeLessThan(plan.body.indexOf('fx-native'));
+    expect(plan.script).toContain('function fx-native');
+  });
+
+  it('tar translation uses fx-native, not call-operator splat', () => {
+    const plan = translateCommandList(parse('tar -tf a.tar'))[0];
+    expect(plan.body).toContain('fx-native');
+    expect(plan.body).toContain('$env:SystemRoot\\System32\\tar.exe');
+    expect(plan.body).not.toContain('& $fx_tar @($fx_args)');
+    expect(plan.script).toContain('function fx-native');
+  });
+
   it('re-splits printf-style stdin for grep and other text-filters', () => {
     const split = 'fx-splitlines $fx_it';
     const cmds = ['grep b', "sed 's/a/A/'", "awk '{print}'", 'sort', 'uniq', 'tr a b'];


### PR DESCRIPTION
## Why

Same splat hole as #148, leftover sites. `net.ts` `nativeCall()` and `archive.ts` tar still used `& exe @array` plus `$LASTEXITCODE`. PowerShell 5.1 drops empty argv entries and eats embedded quotes.

## What

- `nativeCall()` now emits `fx-native` (callers: curl.exe, wget.exe, ping.exe, netstat.exe, nslookup.exe). Curl/wget still run `fx-netguard` before launch.
- tar uses `fx-native $fx_tar ([object[]]@($fx_args))`. System32 tar.exe preference is unchanged (Git Bash tar host:path bug).
- gzip/zip stay translated; they were never native splat.

`fx-native` already captures stdout as pipeline objects and sets `fx_exit`. Empty-array null-safety is `[object[]]@(...)` plus fx-native's null check.

## Tests

- Unit: curl translation contains `fx-native`, not `& 'curl.exe' @`; host-guard still precedes launch
- Unit: tar translation contains `fx-native` and System32 tar.exe
- Integration: host guard refuses loopback curl; gzip roundtrip stays (no tar integration exists)

Not merging.