### PR TITLE
fix: xargs native invoke via fx-native instead of PS 5.1 splat

### DIFF
--- a/docs/rfc-native-argv-fidelity.md
+++ b/docs/rfc-native-argv-fidelity.md
@@ -35,7 +35,10 @@ That violates fail-loud / never silently-wrong.
   Application (e.g. splat that expands to `echo`), fall back to `&` so PS
   aliases still run; empty-argv fidelity applies to executables.
 - Translated builtins are unchanged (they never went through `& @array`).
-- `xargs` composing a native command is a follow-up (it still builds `&`).
+- `xargs` composing a native command uses `fx-native $fx_cmd $fx_argv` (typed
+  object array, no splat). Built-ins are still rejected; `-t`/`-n`/`-I`/
+  `--no-run-if-empty` are unchanged. `fx-native` already records
+  `$script:fx_exit` from ExitCode, so xargs does not also copy `$LASTEXITCODE`.
 
 ## Non-goals
 
@@ -49,3 +52,4 @@ That violates fail-loud / never silently-wrong.
 empty arg, space, embedded `"`, leading `--foo`.
 (`node -e` is a bad oracle on Windows: `-e` is omitted from `process.argv`,
 so `slice(2)` drops the first user argument.)
+`printf -- 'a b\n' | xargs node dump-argv.js` → `["a","b"]` (xargs splits on blanks).

--- a/src/commands/text-io.ts
+++ b/src/commands/text-io.ts
@@ -1292,12 +1292,12 @@ const xargs: Handler = (args) => {
   const n = chunkN !== null && Number.isFinite(chunkN) && chunkN > 0 ? chunkN : 0;
   const replExpr = repl !== null ? psStr(repl) : null;
 
+  // fx-native already records $script:fx_exit from ExitCode.
   const invoke = [
     '    if (' +
       pb(trace) +
       ") { [Console]::Error.WriteLine(((@($fx_cmd) + @($fx_argv)) -join ' ')) }",
-    '    & $fx_cmd @fx_argv',
-    '    if ($LASTEXITCODE -ne 0 -and $script:fx_exit -eq 0) { $script:fx_exit = $LASTEXITCODE }',
+    '    fx-native $fx_cmd $fx_argv',
   ];
 
   let dispatch: string[];
@@ -1307,7 +1307,7 @@ const xargs: Handler = (args) => {
     dispatch = [
       guard,
       '  foreach ($fx_l in $fx_args) {',
-      '    $fx_argv = @()',
+      '    $fx_argv = [object[]]@()',
       '    $fx_hit = $false',
       '    foreach ($fx_a in $fx_base) {',
       '      if ($fx_a.Contains(' + replExpr + ')) {',
@@ -1327,7 +1327,7 @@ const xargs: Handler = (args) => {
       '  $fx_i = 0',
       '  $fx_ran = $false',
       '  while ($fx_i -lt $fx_args.Count) {',
-      '    $fx_argv = @($fx_base)',
+      '    $fx_argv = [object[]]@($fx_base)',
       '    $fx_j = 0',
       '    while ($fx_j -lt ' + n + ' -and $fx_i -lt $fx_args.Count) {',
       '      $fx_argv += $fx_args[$fx_i]',
@@ -1337,28 +1337,38 @@ const xargs: Handler = (args) => {
       ...invoke,
       '  }',
       '  if (-not $fx_ran) {',
-      '    $fx_argv = @($fx_base)',
-      '    ' + invoke[0],
-      '    ' + invoke[1],
-      '    ' + invoke[2],
+      '    $fx_argv = [object[]]@($fx_base)',
+      ...invoke.map((line) => '  ' + line),
       '  }',
       '  }',
     ];
   } else {
     dispatch = [
       guard,
-      '  $fx_argv = @($fx_base) + @($fx_args)',
+      '  $fx_argv = [object[]](@($fx_base) + @($fx_args))',
       ...invoke,
       '  }',
     ];
   }
+
+  // Default GNU xargs splits on blanks; -I keeps whole lines as one item.
+  const collectArgs =
+    replExpr !== null
+      ? "$fx_args = @($fx_in | Where-Object { $_ -ne '' })"
+      : [
+          '$fx_args = @()',
+          'foreach ($fx_l in $fx_in) {',
+          "  if ($fx_l -eq '') { continue }",
+          "  $fx_args += @($fx_l -split '[ \\t]+' | Where-Object { $_ -ne '' })",
+          '}',
+        ].join('\n');
 
   return [
     PS_SPLITLINES_FN,
     STDIN_INLINES,
     '$fx_tg = ' + argListExpr(target, exprOfWord),
     "if ($fx_tg.Count -eq 0) { $fx_cmd = ''; $fx_base = @() } else { $fx_cmd = [string]$fx_tg[0]; $fx_base = $(if ($fx_tg.Count -gt 1) { @($fx_tg[1..($fx_tg.Count - 1)]) } else { @() }) }",
-    "$fx_args = @($fx_in | Where-Object { $_ -ne '' })",
+    collectArgs,
     ...dispatch,
   ].join('\n');
 };

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1139,6 +1139,12 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout.trim()).toMatch(/^v\d+\.\d+/);
   });
 
+  it('xargs splits stdin words onto native argv', async () => {
+    const r = await run("printf -- 'a b\\n' | xargs node dump-argv.js");
+    expect(r.exitCode).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual(['a', 'b']);
+  });
+
   it('host guard refuses loopback URLs for curl', async () => {
     const r = await run('curl -s http://127.0.0.1:9/x');
     expect(r.stderr).toContain('refused private/loopback address');

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -556,6 +556,31 @@ describe('translator', () => {
     expect(script).toContain("if ($null -eq $argv) { $argv = @() }");
   });
 
+  it('xargs native invoke uses fx-native instead of call-operator splat', () => {
+    const plan = translateCommandList(parse('xargs node'))[0];
+    expect(plan.body).toContain('fx-native $fx_cmd $fx_argv');
+    expect(plan.body).not.toContain('@fx_argv');
+    expect(plan.body).not.toContain('& $fx_cmd');
+    expect(plan.body).not.toContain('$LASTEXITCODE');
+    expect(plan.body).toContain("-split '[ \\t]+'");
+    expect(plan.script).toContain('function fx-native');
+    const n = translateCommandList(parse('xargs -n 1 node'))[0].body;
+    expect(n).toContain('fx-native $fx_cmd $fx_argv');
+    expect(n).toContain('$fx_j -lt 1');
+    const repl = translateCommandList(parse('xargs -I {} node dump-argv.js {}'))[0].body;
+    expect(repl).toContain('fx-native $fx_cmd $fx_argv');
+    expect(repl).toContain(".Contains('{}')");
+    expect(repl).not.toContain("-split '[ \\t]+'");
+    const empty = translateCommandList(parse('xargs --no-run-if-empty node'))[0].body;
+    expect(empty).toContain('$fx_args.Count -eq 0');
+    expect(empty).toContain('fx-native $fx_cmd $fx_argv');
+    const trace = translateCommandList(parse('xargs -t node'))[0].body;
+    expect(trace).toContain('[Console]::Error.WriteLine');
+    expect(trace).toContain('$true');
+    const builtin = translateCommandList(parse('xargs grep'))[0].body;
+    expect(builtin).toContain('xargs currently passes arguments to native commands');
+  });
+
   it('re-splits printf-style stdin for grep and other text-filters', () => {
     const split = 'fx-splitlines $fx_it';
     const cmds = ['grep b', "sed 's/a/A/'", "awk '{print}'", 'sort', 'uniq', 'tr a b'];


### PR DESCRIPTION
## Why

#148 landed native passthrough through `fx-native`. RFC `docs/rfc-native-argv-fidelity.md` still called xargs a follow-up — it still built `& $fx_cmd @fx_argv`. On Windows PowerShell 5.1 that splat drops empty argv entries and eats embedded quotes.

## What

- xargs native invoke is `fx-native $fx_cmd $fx_argv` (typed object array, no splat).
- `fx-native` already records `$script:fx_exit` from ExitCode; xargs no longer also copies `$LASTEXITCODE`.
- `-t` trace, `-n`, `-I`, `--no-run-if-empty`, and builtin-reject are unchanged.
- Default xargs splits stdin on blanks (`printf -- 'a b\n'` → `[a,b]`); `-I` stays line-oriented.
- RFC updated: xargs is no longer a follow-up that builds `&`.

## Tests

- Unit: `xargs node` translation contains `fx-native $fx_cmd $fx_argv`, not `@fx_argv` splat / `& $fx_cmd` / `$LASTEXITCODE`; `-n` / `-I` / `--no-run-if-empty` / `-t` / builtin-reject still compile.
- Integration: `printf -- '--version\n' | xargs node` still prints `v…`; `printf -- 'a b\n' | xargs node dump-argv.js` → `[a,b]`.

`npx vitest run --dir test`: 225 passed (120 unit + 105 integration).

Not merging.