### PR TITLE
fix: emit grep -F -o matches in input order

### DIFF
--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -636,53 +636,53 @@ const grep: Handler = (args) => {
     if (maxCount !== null) scan.push('    $fx_mleft--');
     if (onlyMatch && !inv) {
       if (fixed) {
+        // GNU -o: emit leftmost-longest matches in input order, not per-needle.
         if (ci) scan.push('    $lx = $fx_l.ToLower()');
         const hay = ci ? '$lx' : '$fx_l';
-        const emitFixedHits = (needle: string, indent: string) => {
-          scan.push(indent + '$p = ' + hay + '.IndexOf(' + needle + ')');
-          scan.push(indent + 'while ($p -ge 0) {');
-          scan.push(indent + '  $ok = $true');
-          if (word) {
-            scan.push(
-              indent +
-                "  if ($p -gt 0) { $c = " +
-                hay +
-                "[$p - 1]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') }",
-            );
-            scan.push(
-              indent +
-                '  if ($ok) { $e = $p + ' +
-                needle +
-                '.Length; if ($e -lt ' +
-                hay +
-                '.Length) { $c = ' +
-                hay +
-                "[$e]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') } }",
-            );
-            scan.push(
-              indent +
-                '  if ($ok) { fx-emitline $fx_i (' +
-                hay +
-                '.Substring($p, ' +
-                needle +
-                '.Length)) }',
-            );
-          } else {
-            scan.push(
-              indent + '  fx-emitline $fx_i (' + hay + '.Substring($p, ' + needle + '.Length))',
-            );
-          }
-          scan.push(indent + '  $p = ' + hay + '.IndexOf(' + needle + ', $p + 1)');
-          scan.push(indent + '}');
-        };
-        if (multiFixed) {
-          const arr = ci ? '$fx_needles_ll' : '$fx_needles';
-          scan.push('    foreach ($fx_needle in ' + arr + ') {');
-          emitFixedHits('$fx_needle', '      ');
-          scan.push('    }');
+        const needleArr = multiFixed
+          ? ci
+            ? '$fx_needles_ll'
+            : '$fx_needles'
+          : '@(' + (ci ? '$fx_needle_ll' : '$fx_needle') + ')';
+        scan.push('    $fx_cands = New-Object System.Collections.Generic.List[object]');
+        scan.push('    foreach ($fx_needle in ' + needleArr + ') {');
+        scan.push('      if ($fx_needle.Length -lt 1) { continue }');
+        scan.push('      $p = ' + hay + '.IndexOf($fx_needle)');
+        scan.push('      while ($p -ge 0) {');
+        if (word) {
+          scan.push('        $ok = $true');
+          scan.push(
+            "        if ($p -gt 0) { $c = " +
+              hay +
+              "[$p - 1]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') }",
+          );
+          scan.push(
+            '        if ($ok) { $e = $p + $fx_needle.Length; if ($e -lt ' +
+              hay +
+              '.Length) { $c = ' +
+              hay +
+              "[$e]; $ok = -not ([char]::IsLetterOrDigit($c) -or $c -eq '_') } }",
+          );
+          scan.push(
+            '        if ($ok) { [void]$fx_cands.Add([pscustomobject]@{ Start = $p; Len = $fx_needle.Length }) }',
+          );
         } else {
-          emitFixedHits(ci ? '$fx_needle_ll' : '$fx_needle', '    ');
+          scan.push(
+            '        [void]$fx_cands.Add([pscustomobject]@{ Start = $p; Len = $fx_needle.Length })',
+          );
         }
+        scan.push('        $p = ' + hay + '.IndexOf($fx_needle, $p + 1)');
+        scan.push('      }');
+        scan.push('    }');
+        scan.push('    $fx_end = 0');
+        scan.push(
+          '    foreach ($fx_c in @($fx_cands | Sort-Object Start, @{ Expression = { $_.Len }; Descending = $true })) {',
+        );
+        scan.push('      if ($fx_c.Start -ge $fx_end) {');
+        scan.push('        fx-emitline $fx_i (' + hay + '.Substring($fx_c.Start, $fx_c.Len))');
+        scan.push('        $fx_end = $fx_c.Start + $fx_c.Len');
+        scan.push('      }');
+        scan.push('    }');
       } else {
         scan.push(
           '    foreach ($fx_m in $fx_re.Matches($fx_l)) { fx-emitline $fx_i $fx_m.Value }',

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -262,6 +262,20 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout).not.toContain('b');
   });
 
+  it('grep -F -o -e a -e b emits matches left-to-right', async () => {
+    const r = await run("printf 'ba\\n' | grep -F -o -e a -e b");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim().split(/\r?\n/)).toEqual(['b', 'a']);
+
+    const overlap = await run("printf 'aaa\\n' | grep -F -o -e a -e aa");
+    expect(overlap.exitCode).toBe(0);
+    expect(overlap.stdout.trim().split(/\r?\n/)).toEqual(['aa', 'a']);
+
+    const single = await run("printf 'ba\\n' | grep -F -o a");
+    expect(single.exitCode).toBe(0);
+    expect(single.stdout.trim()).toBe('a');
+  });
+
   it('grep --regexp repeats OR-accumulate', async () => {
     const spaced = await run('grep --regexp a --regexp c letters.txt');
     expect(spaced.exitCode).toBe(0);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -799,6 +799,33 @@ describe('bounded output flags (#130)', () => {
     expect(body).not.toContain('return -not ($fx_re.IsMatch($l))\n  return -not');
   });
 
+  it('grep -F -o with multiple -e collects matches by position then length', () => {
+    const body = bodyOf('grep -F -o -e a -e b');
+    expect(body).toContain('$fx_needles = @(');
+    expect(body).toContain('$fx_cands');
+    expect(body).toContain('Sort-Object Start');
+    expect(body).toContain('Descending = $true');
+    expect(body).toContain('$fx_c.Start -ge $fx_end');
+    expect(body).toContain('fx-emitline $fx_i ($fx_l.Substring($fx_c.Start, $fx_c.Len))');
+    expect(body).not.toMatch(/foreach \(\$fx_needle in \$fx_needles\) \{[\s\S]*fx-emitline \$fx_i \(\$fx_l\.Substring\(\$p/);
+  });
+
+  it('grep -F -o single pattern still emits via position-ordered candidates', () => {
+    const body = bodyOf('grep -F -o a f');
+    expect(body).toContain('$fx_cands');
+    expect(body).toContain('$fx_needle = ');
+    expect(body).not.toContain('$fx_needles');
+    expect(body).toContain('fx-emitline $fx_i ($fx_l.Substring($fx_c.Start, $fx_c.Len))');
+  });
+
+  it('grep -F -e a -e b without -o still ORs whole lines', () => {
+    const body = bodyOf('grep -F -e a -e b f');
+    expect(body).not.toContain('$fx_cands');
+    expect(body).toContain('$fx_needles = @(');
+    expect(body).toContain('.Contains($fx_needle)');
+    expect(body).toContain('fx-gmatch');
+  });
+
   it('grep with no pattern fails loud with usage', () => {
     const body = bodyOf('grep');
     expect(body).toContain('usage: grep [OPTION]... PATTERN [FILE]...');


### PR DESCRIPTION
## Summary
Codex P2 on https://github.com/20000419/fauxnix/pull/155#discussion_r3891636706

`grep -F -o` with multiple `-e` needles looped per pattern, so `printf 'ba\n' | grep -F -o -e a -e b` printed `a` then `b`. GNU `-o` prints matches in input order and uses leftmost-longest at a given position.

The `-o` scan now collects candidates by start/length, then emits greedily in that order. Single-pattern `-o` still works. `-e` OR without `-o` is unchanged.

## Tests
- unit: `grep -F -o -e a -e b` translation collects/sorts by position+length; single-pattern `-F -o` still emits via candidates; `grep -F -e a -e b` without `-o` still ORs whole lines; existing `grep -e apple fruits.txt` / `grep -e a -e c`
- integration: `printf 'ba\n' | grep -F -o -e a -e b` -> `b` then `a`; overlapping `aaa` / `-e a -e aa` -> `aa` then `a`; existing `grep -e a -e c` and `grep -e apple fruits.txt`

`npx vitest run --dir test test/unit.test.ts`: 122 passed
`npx vitest run --dir test test/integration.windows.test.ts -t grep`: 13 passed, 92 skipped