### PR TITLE
fix: quote cmd metacharacters when launching .cmd/.bat

### DIFF
--- a/docs/rfc-native-argv-fidelity.md
+++ b/docs/rfc-native-argv-fidelity.md
@@ -28,7 +28,9 @@ That violates fail-loud / never silently-wrong.
   throws and the wrap catch turns that into exit 1.
 - Empty `[object[]]` must not unwrap to `$null` (that became a phantom `""`
   argv). `.cmd`/`.bat` Applications go through `cmd.exe /d /s /c` because
-  `CreateProcess` cannot launch them with `UseShellExecute = $false`.
+  `CreateProcess` cannot launch them with `UseShellExecute = $false`. The
+  `/c` tail is wrapped in extra quotes (`/s` strips that pair); arguments
+  containing `& | ( ) < > ^` are CRT-quoted so cmd.exe does not split them.
 - Pipelines still work: `$input` is copied to the child stdin; stdout/stderr
   are captured without the `& @array` splat.
 - Dynamic/`[@]` command names use the same helper. If the name is not an
@@ -39,7 +41,8 @@ That violates fail-loud / never silently-wrong.
 
 ## Non-goals
 
-- Byte-identical cmd.exe metacharacter quirks beyond CRT argv.
+- Byte-identical cmd.exe quirks beyond that quoting (`%VAR%` expansion,
+  delayed-expansion `!`, nested quote encoding).
 - `pwsh` 7 `ArgumentList`.
 - Version bump / npm publish.
 
@@ -49,3 +52,4 @@ That violates fail-loud / never silently-wrong.
 empty arg, space, embedded `"`, leading `--foo`.
 (`node -e` is a bad oracle on Windows: `-e` is omitted from `process.argv`,
 so `slice(2)` drops the first user argument.)
+`.cmd` that echoes `%*`: `'a&b'` / `'--flag=a&b'` stay one argument containing `&`.

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1349,8 +1349,9 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '}',
     ],
     'fx-winargv': [
-      'function fx-winargv($argv) {',
+      'function fx-winargv($argv, $cmdmeta) {',
       // Empty [object[]] unwraps to $null on PS 5.1; @($null) is one empty arg.
+      // $cmdmeta: also quote & | () <> ^ so cmd.exe /c does not split the tail.
       '  if ($null -eq $argv) { $argv = @() }',
       '  $parts = New-Object System.Collections.Generic.List[string]',
       '  foreach ($a in @($argv)) {',
@@ -1359,6 +1360,7 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '    $need = $false',
       '    foreach ($ch in $s.ToCharArray()) {',
       "      if ($ch -eq ' ' -or $ch -eq ([char]9) -or $ch -eq [char]34) { $need = $true; break }",
+      "      if ($cmdmeta -and ($ch -eq '&' -or $ch -eq '|' -or $ch -eq '(' -or $ch -eq ')' -or $ch -eq '<' -or $ch -eq '>' -or $ch -eq '^')) { $need = $true; break }",
       '    }',
       '    if (-not $need) { $parts.Add($s); continue }',
       '    $sb = New-Object System.Text.StringBuilder',
@@ -1405,6 +1407,8 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '  $psi = New-Object System.Diagnostics.ProcessStartInfo',
       '  $ext = [IO.Path]::GetExtension([string]$app.Source)',
       // CreateProcess cannot launch .cmd/.bat with UseShellExecute=false (npm.cmd).
+      // /s strips one outer quote pair from the /c tail; CRT-quote cmd
+      // metacharacters so `&`/`|`/`()` do not start a second command.
       "  if ($ext -eq '.cmd' -or $ext -eq '.bat') {",
       '    $comspec = Get-Command -Name cmd -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1',
       '    if ($null -eq $comspec) {',
@@ -1413,8 +1417,10 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '      return',
       '    }',
       '    $psi.FileName = $comspec.Source',
-      '    $fx_rest = fx-winargv $argv',
-      "    if ($fx_rest.Length -gt 0) { $psi.Arguments = '/d /s /c ' + (fx-winargv $app.Source) + ' ' + $fx_rest } else { $psi.Arguments = '/d /s /c ' + (fx-winargv $app.Source) }",
+      '    $fx_app = fx-winargv $app.Source $true',
+      '    $fx_rest = fx-winargv $argv $true',
+      "    if ($fx_rest.Length -gt 0) { $fx_tail = $fx_app + ' ' + $fx_rest } else { $fx_tail = $fx_app }",
+      '    $psi.Arguments = \'/d /s /c "\' + $fx_tail + \'"\'',
       '  } else {',
       '    $psi.FileName = $app.Source',
       '    $psi.Arguments = fx-winargv $argv',

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -31,6 +31,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
       'utf8',
     );
     writeFileSync(join(dir, 'hit.cmd'), '@echo off\r\necho CMDHIT\r\n');
+    writeFileSync(join(dir, 'dump-args.cmd'), '@echo off\r\necho ARGS:%*\r\necho DONE\r\n');
     writeFileSync(join(dir, 'letters.txt'), 'a\nb\nc\n', 'utf8');
     writeFileSync(join(dir, 'nums.txt'), '1 2\n3 4\n5 6\n', 'utf8');
     writeFileSync(join(dir, 'dups.txt'), 'aaa\naaa\nbbb\n', 'utf8');
@@ -1132,6 +1133,22 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     const r = await run('./hit.cmd');
     expect(r.exitCode).toBe(0);
     expect(r.stdout.trim()).toBe('CMDHIT');
+  });
+
+  it('native .cmd args keep cmd metacharacters without splitting', async () => {
+    const amp = await run("./dump-args.cmd 'a&b'");
+    expect(amp.exitCode).toBe(0);
+    expect(amp.stdout).toContain('a&b');
+    expect(amp.stdout).toContain('DONE');
+    const flag = await run("./dump-args.cmd '--flag=a&b'");
+    expect(flag.exitCode).toBe(0);
+    expect(flag.stdout).toContain('--flag=a&b');
+    expect(flag.stdout).toContain('DONE');
+    const inject = await run("./dump-args.cmd 'a&echo INJECTED'");
+    expect(inject.exitCode).toBe(0);
+    expect(inject.stdout).toContain('a&echo INJECTED');
+    expect(inject.stdout).toContain('DONE');
+    expect(inject.stdout).not.toMatch(/^INJECTED$/m);
   });
 
   it('xargs runs native commands', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -556,6 +556,19 @@ describe('translator', () => {
     expect(script).toContain("if ($null -eq $argv) { $argv = @() }");
   });
 
+  it('quotes cmd metacharacters on the .cmd /c tail', () => {
+    const script = translateCommandList(parse('node --version'))[0].script;
+    expect(script).toContain('fx-winargv $argv $true');
+    expect(script).toContain('/d /s /c "');
+    expect(script).toContain("'&'");
+    expect(script).toContain("'|'");
+    const list = parse("./hit.cmd 'a&b'");
+    expect(list.segments).toHaveLength(1);
+    const body = translateCommandList(list)[0].body;
+    expect(body).toContain('fx-native');
+    expect(body).toContain('a&b');
+  });
+
   it('re-splits printf-style stdin for grep and other text-filters', () => {
     const split = 'fx-splitlines $fx_it';
     const cmds = ['grep b', "sed 's/a/A/'", "awk '{print}'", 'sort', 'uniq', 'tr a b'];


### PR DESCRIPTION
## Why

Codex P2 on #155 (discussion r3891636701): when fx-native launches `.cmd`/`.bat` via `cmd.exe /d /s /c` + CRT-quoted args, an argument like `--flag=a&b` (no spaces, has `&`) is passed raw. `&` `|` `()` are cmd metacharacters, so the `/c` tail can split and run trailing text.

## What

Quoted, not fail-loud.

- `fx-winargv` takes `$cmdmeta`: also CRT-quote args that contain `& | ( ) < > ^` (exe path still uses CRT-only quoting).
- The `/c` tail is wrapped in extra quotes (`/s` strips that pair), matching Node/Azure cmd spawn.
- RFC `docs/rfc-native-argv-fidelity.md`: contract note for that quoting; `%VAR%` / delayed-expansion `!` stay non-goals.

## Tests

- Unit: wrap helper emits `fx-winargv $argv $true` and `/d /s /c "`; `'a&b'` stays one list segment.
- Integration: `./hit.cmd` still prints `CMDHIT`; `./dump-args.cmd 'a&b'` / `'--flag=a&b'` / `'a&echo INJECTED'` — `%*` contains the `&`, `DONE` prints, `INJECTED` is not a second command.

`npx vitest run --dir test test/unit.test.ts` — 120 passed
`npx vitest run --dir test test/integration.windows.test.ts -t "native .cmd"` — 2 passed

Not merging.
