### PR TITLE
docs: native passthrough is fx-native / CRT quoting, not argv-style quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ fauxnix check
 fauxnix mcp
 ```
 
-Unknown commands (git, node, npm, python, cargo, gh, docker, ...) are **passed through natively**
-with argv-style quoting — no string re-parsing, no quoting bugs.
+Unknown commands (git, node, npm, python, cargo…) are passed through via Win32 argv
+(`fx-native`, CRT quoting) so empty args and embedded quotes survive. No string re-parsing.
 
 ## Use with your agent harness
 

--- a/docs/promotion/blog-benchmark-en.md
+++ b/docs/promotion/blog-benchmark-en.md
@@ -53,8 +53,9 @@ errors (`cat: x: No such file or directory`, not a CategoryInfo dump),
 coreutils exit codes, per-file UTF-8/GBK sniffing (Chinese Windows' GBK
 files break every default config — ours just work), POSIX path mapping.
 
-Unknown commands (git, node, npm, python...) pass through natively with
-argv-style quoting. Unsupported bash constructs fail loudly with the
+Unknown commands (git, node, npm, python, cargo…) are passed through via Win32 argv
+(`fx-native`, CRT quoting) so empty args and embedded quotes survive. No string re-parsing.
+Unsupported bash constructs fail loudly with the
 construct named — never silently misbehave. ~105 commands translated;
 correctness is verified differentially against real Git Bash (52/53
 byte-identical on our battery; the one divergence is documented).

--- a/docs/promotion/blog-benchmark-zh.md
+++ b/docs/promotion/blog-benchmark-zh.md
@@ -47,7 +47,7 @@ npm install -g fauxnix-cli
 - **逐文件编码嗅探**：GBK 和 UTF-8 的中文文件 grep 都正确——这个是
   Git Bash 都做不到的（实测 GBK 文件 `grep 连接` Git Bash 0 命中、fauxnix 1）
 - 会话持久：cd/环境变量跨调用保持
-- 不认识的命令（git/node/npm）argv 透传；不支持的 bash 构造**大声报错**
+- 不认识的命令（git/node/npm）经 Win32 argv（`fx-native`，CRT quoting）透传，空参数和内嵌引号都会保留；不支持的 bash 构造**大声报错**
   并给替代方案，绝不静默出错
 - 正确性对照真实 Git Bash 差分验证：53 例中 52 例逐字一致
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -38,7 +38,7 @@ Commands are deterministically translated to PowerShell and executed natively �
 Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), errors look like bash errors, and text encoding (UTF-8/GBK) is handled automatically.
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
-Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
+Unknown commands (git, node, npm, python, cargo…) are passed through via Win32 argv (`fx-native`, CRT quoting) so empty args and embedded quotes survive. No string re-parsing.
 Not supported: heredocs, while/until/case, env -i/--ignore-environment, background jobs. if/then/elif/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is started when the MCP session begins (and after reset), so the first bash tool call is already warm.

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -38,7 +38,7 @@ Commands are deterministically translated to PowerShell and executed natively �
 Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), errors look like bash errors, and text encoding (UTF-8/GBK) is handled automatically.
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
-Unknown commands (git, node, npm, python, cargo…) are passed through via Win32 argv (`fx-native`, CRT quoting) so empty args and embedded quotes survive. No string re-parsing.
+Unknown commands (git, node, npm, python, cargo…) are passed through via Win32 argv (fx-native, CRT quoting) so empty args and embedded quotes survive. No string re-parsing.
 Not supported: heredocs, while/until/case, env -i/--ignore-environment, background jobs. if/then/elif/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is started when the MCP session begins (and after reset), so the first bash tool call is already warm.


### PR DESCRIPTION
After #148, native passthrough is `fx-native` / CRT quoting, not the old `& name @array` "argv-style quoting" slogan.

Replace that stale phrase in the surfaces agents and readers actually see:

- README.md
- `src/mcp.ts` `TOOL_DESCRIPTION` (what MCP clients read)
- docs/promotion/blog-benchmark-en.md and the zh twin

Unknown commands (git, node, npm, python, cargo…) are passed through via Win32 argv (`fx-native`, CRT quoting) so empty args and embedded quotes survive. No string re-parsing.

No version bump.