### PR TITLE
fix: accept ls --color as an implemented no-op

### DIFF
--- a/docs/command-specs.md
+++ b/docs/command-specs.md
@@ -74,6 +74,7 @@ Effects: `read`
 | `-S` | flag | implemented |
 | `-r` | flag | implemented |
 | `-R`, `--recursive` | flag | unsupported (recursive listing) |
+| `--color` | required | implemented |
 
 ## `mkdir`
 

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -71,7 +71,7 @@ function psIsLink(it: string): string {
 /* ------------------------------------------------------------------ */
 
 const ls: Handler = (args) => {
-  const { flags, longs, values, operandWords } = parseWords(args, [], ['--format']);
+  const { flags, longs, values, operandWords } = parseWords(args, [], ['--format', '--color']);
   const long =
     flags.has('l') || longs.has('--long') || values.get('--format') === 'long';
   const all = flags.has('a') || longs.has('--all');
@@ -1083,6 +1083,8 @@ export const specs: CommandSpec[] = [
       opt('S', undefined),
       opt('r', undefined),
       opt('R', '--recursive', 'unsupported', { reason: 'recursive listing' }),
+      // GNU optional WHEN; takesValue so --color=auto is valid. No ANSI.
+      opt(undefined, '--color', 'implemented', { takesValue: true }),
     ],
     ls,
   ),

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -913,6 +913,16 @@ describe('CommandSpec files leftovers (#130)', () => {
     expect(bodyOf('ls --recursive')).toContain('not supported by fauxnix');
   });
 
+  it('ls --color=auto is an implemented no-op; still lists; -Z still fails loud', () => {
+    const color = bodyOf('ls --color=auto');
+    expect(color).not.toContain('invalid option');
+    expect(color).not.toContain('unrecognized option');
+    expect(color).toContain('Get-ChildItem');
+    expect(color).not.toContain('\u001b');
+    expect(color).not.toContain('[0;');
+    expect(bodyOf('ls -Z')).toContain("invalid option -- ''Z''");
+  });
+
   it('chmod -R is unsupported; find stays unspec\'d so -name still compiles', () => {
     expect(bodyOf('chmod -R 644 x')).toContain('not supported by fauxnix');
     expect(bodyOf("find . -name '*.ts'")).toContain('-clike');


### PR DESCRIPTION
After CommandSpec, `ls --color=auto` was a usage error. Agents emit `--color` constantly. GNU `ls --color` already strips color on a pipe unless `always`.

Accept `--color` / `--color=WHEN` as an **implemented no-op** (no ANSI). No colorizer.

- `ls` CommandSpec: `--color` with `takesValue: true` so `--color=auto` is valid
- Handler `parseWords` consumes `--color` (long with value) so it is not an operand
- `docs/command-specs.md` regenerated from `specsMarkdown()`

Tests: `ls --color=auto` is not invalid/unrecognized and still lists; `ls -Z` still fails loud; docs lockstep. `npx vitest run --dir test`: 224 passed.