### PR TITLE
fix: hint python3 and .sh on Windows command-not-found

### DIFF
--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -803,7 +803,9 @@ const find: Handler = (args) => {
   if (preds.includes('-exec') || preds.includes('-execdir')) {
     return (
       '[Console]::Error.WriteLine(' +
-      psStr('find: -exec is not supported by fauxnix; pipe into the command instead (e.g. `find . -name "*.log" | xargs rm`)') +
+      psStr(
+        'find: -exec is not supported by fauxnix; use `find . -name "*.log" -delete` or grep -r instead',
+      ) +
       '); $script:fx_exit = 1'
     );
   }

--- a/src/commands/text-io.ts
+++ b/src/commands/text-io.ts
@@ -1244,7 +1244,9 @@ const xargs: Handler = (args) => {
         const ch = body[c];
         if (ch === 'r') noRunIfEmpty = true;
         else if (ch === 't') trace = true;
-        else if (ch === 'n' || ch === 'I' || ch === 'L') {
+        else if (ch === '0') {
+          return psErrExpr(psStr('xargs: -0 is not supported by fauxnix'));
+        } else if (ch === 'n' || ch === 'I' || ch === 'L') {
           const restv = body.slice(c + 1);
           let val: string;
           if (restv) val = restv;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,20 @@
  * so agents can pattern-match on familiar Linux error styles.
  */
 
+/** Missing `python3` on Windows (Mac/Linux agents emit this; do not alias). */
+export const PYTHON3_WINDOWS_HINT = ' (fauxnix: try `python` or `py` on Windows)';
+
+/** `.sh` cannot be CreateProcess'd; fx-native never emits the PS not-recognized line. */
+export const SH_SCRIPT_WINDOWS_HINT = ' (fauxnix: .sh scripts cannot run natively on Windows)';
+
+function commandNotFound(name: string): string {
+  const msg = 'bash: ' + name + ': command not found';
+  const base = name.replace(/^.*[/\\]/, '');
+  if (/^python3(\.exe)?$/i.test(base)) return msg + PYTHON3_WINDOWS_HINT;
+  if (/\.sh$/i.test(name)) return msg + SH_SCRIPT_WINDOWS_HINT;
+  return msg;
+}
+
 /** Lines produced by PowerShell error formatting that bash would never show. */
 const PS_NOISE = [
   /^\s*\+ CategoryInfo\s*:/,
@@ -63,15 +77,15 @@ export function normalizeStderr(stderr: string): string {
   const out = lines.map((line) => {
     // "The term 'x' is not recognized as a name of a cmdlet, function, ..."
     let m = line.match(/^The term '(.+?)' is not recognized/);
-    if (m) return 'bash: ' + m[1] + ': command not found';
+    if (m) return commandNotFound(m[1]);
 
     // zh-CN: 无法将"x"项识别为 cmdlet、函数、脚本文件或可运行程序的名称
     m = line.match(/^无法将["'”]?([^"'”]+)["'”]?项识别为/);
-    if (m) return 'bash: ' + m[1] + ': command not found';
+    if (m) return commandNotFound(m[1]);
 
     // "x : The term 'y' is not recognized ..." (with source prefix)
     m = line.match(/^(\S+)\s*:\s*The term '(.+?)' is not recognized/);
-    if (m) return 'bash: ' + m[2] + ': command not found';
+    if (m) return commandNotFound(m[2]);
 
     // "cat : Cannot find path 'D:\x' because it does not exist."
     m = line.match(/^(\S+)\s*:\s*Cannot find path '(.+?)' because it does not exist\.?$/);
@@ -99,9 +113,9 @@ export function normalizeStderr(stderr: string): string {
     m = line.match(/^(\S+)\s*:\s*(.*)Access to the path '(.+?)' is denied\.?$/);
     if (m) return m[1].toLowerCase() + ': cannot remove \'' + m[3] + '\': Permission denied';
 
-    // helpful hint for bash scripts
+    // leftover PS not-recognized lines that the rewrites above did not catch
     if (/\.sh'?/.test(line) && /is not recognized/.test(line)) {
-      return line + ' (fauxnix: .sh scripts cannot run natively on Windows)';
+      return line + SH_SCRIPT_WINDOWS_HINT;
     }
 
     return line;

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -13,6 +13,7 @@ import {
 } from './ast.js';
 import { parseCommand } from './parser.js';
 import { PipelineCtx, lookup, psStr } from './registry.js';
+import { PYTHON3_WINDOWS_HINT, SH_SCRIPT_WINDOWS_HINT } from './errors.js';
 
 /* ------------------------------------------------------------------ */
 /* Variable mapping                                                    */
@@ -1392,7 +1393,14 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       // operator is only for names that are not executables.
       '    $cmd = Get-Command -Name $name -ErrorAction SilentlyContinue | Select-Object -First 1',
       '    if ($null -eq $cmd) {',
-      "      [Console]::Error.WriteLine('bash: ' + $name + ': command not found')",
+      "      $fx_nf = 'bash: ' + $name + ': command not found'",
+      "      $fx_n = [string]$name",
+      // Hint only — never alias python3→python (wrong interpreter).
+      "      if ($fx_n -eq 'python3' -or $fx_n -eq 'python3.exe') { $fx_nf += '" +
+        PYTHON3_WINDOWS_HINT +
+        "' }",
+      "      elseif ($fx_n -like '*.sh') { $fx_nf += '" + SH_SCRIPT_WINDOWS_HINT + "' }",
+      '      [Console]::Error.WriteLine($fx_nf)',
       '      $script:fx_exit = 127',
       '      return',
       '    }',

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1111,6 +1111,33 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout.trim()).toMatch(/^v\d+\.\d+/);
   });
 
+  it('python3 --version hints python/py when missing (no alias)', async () => {
+    const r = await run('python3 --version');
+    if (r.exitCode === 0) {
+      expect(r.stdout + r.stderr).toMatch(/Python/i);
+      return;
+    }
+    expect(r.exitCode).toBe(127);
+    expect(r.stderr).toContain('bash: python3: command not found');
+    expect(r.stderr).toContain('try `python` or `py` on Windows');
+    expect(r.stderr).not.toMatch(/Python \d/i);
+  });
+
+  it('foo.sh not-found includes the .sh native hint', async () => {
+    const r = await run('foo.sh');
+    expect(r.exitCode).toBe(127);
+    expect(r.stderr).toContain('bash: foo.sh: command not found');
+    expect(r.stderr).toContain('.sh scripts cannot run natively on Windows');
+  });
+
+  it('python --version still works via fx-native when python exists', async () => {
+    const probe = spawnSync('python', ['--version'], { encoding: 'utf8', shell: false });
+    if (probe.status !== 0) return;
+    const r = await run('python --version');
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout + r.stderr).toMatch(/Python\s+\d/);
+  });
+
   it('native argv keeps empty strings, spaces, and embedded quotes', async () => {
     // A script file (not `node -e`) so user args are always argv.slice(2) on
     // Windows too — `node -e` omits `-e` from process.argv here.

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -14,7 +14,11 @@ import {
 } from '../src/translator.js';
 import { listCommandsJson, lookup, lookupSpec, parseWords, psStr } from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
-import { normalizeStderr } from '../src/errors.js';
+import {
+  normalizeStderr,
+  PYTHON3_WINDOWS_HINT,
+  SH_SCRIPT_WINDOWS_HINT,
+} from '../src/errors.js';
 import { decodeHostResponse, encodeHostRequest, parseHostLine } from '../src/ps-host.js';
 import { bashToolResult, formatBashText } from '../src/mcp.js';
 import '../src/commands/install-all.js';
@@ -556,6 +560,32 @@ describe('translator', () => {
     expect(script).toContain("if ($null -eq $argv) { $argv = @() }");
   });
 
+  it('python3 --version fx-native miss hints python/py and exits 127 (no alias)', () => {
+    const plan = translateCommandList(parse('python3 --version'))[0];
+    expect(plan.body).toContain("fx-native 'python3' $fx_na");
+    expect(plan.body).not.toContain("fx-native 'python' $fx_na");
+    expect(plan.script).toContain("if ($fx_n -eq 'python3' -or $fx_n -eq 'python3.exe')");
+    expect(plan.script).toContain(PYTHON3_WINDOWS_HINT);
+    expect(plan.script).toContain('$script:fx_exit = 127');
+    const exe = translateCommandList(parse('python3.exe --version'))[0];
+    expect(exe.body).toContain("fx-native 'python3.exe' $fx_na");
+    expect(exe.script).toContain(PYTHON3_WINDOWS_HINT);
+  });
+
+  it('foo.sh fx-native miss includes the .sh Windows hint and 127', () => {
+    const plan = translateCommandList(parse('foo.sh'))[0];
+    expect(plan.body).toContain("fx-native 'foo.sh' $fx_na");
+    expect(plan.script).toContain("$fx_n -like '*.sh'");
+    expect(plan.script).toContain(SH_SCRIPT_WINDOWS_HINT);
+    expect(plan.script).toContain('$script:fx_exit = 127');
+  });
+
+  it('python --version still uses fx-native (not rewritten to python3)', () => {
+    const plan = translateCommandList(parse('python --version'))[0];
+    expect(plan.body).toContain("fx-native 'python' $fx_na");
+    expect(plan.script).toContain('function fx-native');
+  });
+
   it('re-splits printf-style stdin for grep and other text-filters', () => {
     const split = 'fx-splitlines $fx_it';
     const cmds = ['grep b', "sed 's/a/A/'", "awk '{print}'", 'sort', 'uniq', 'tr a b'];
@@ -719,6 +749,15 @@ describe('normalizeStderr', () => {
   it('rewrites command-not-found (en)', () => {
     expect(normalizeStderr("The term 'foo' is not recognized as a name of a cmdlet")).toBe(
       'bash: foo: command not found',
+    );
+  });
+
+  it('appends python3 / .sh hints on not-recognized rewrites', () => {
+    expect(normalizeStderr("The term 'python3' is not recognized as a name of a cmdlet")).toBe(
+      'bash: python3: command not found' + PYTHON3_WINDOWS_HINT,
+    );
+    expect(normalizeStderr("The term 'foo.sh' is not recognized as a name of a cmdlet")).toBe(
+      'bash: foo.sh: command not found' + SH_SCRIPT_WINDOWS_HINT,
     );
   });
 
@@ -980,6 +1019,23 @@ describe('find predicates (#130)', () => {
     throws('find . -o -name a', "find: invalid expression; you have used a binary operator '-o' with nothing before it.");
     throws('find . -name a -o', "find: expected an expression after '-o'");
     throws("find . -name '*.ts' extra", "find: paths must precede expression: 'extra'");
+  });
+
+  it('find -exec fails loud with -delete / grep -r, not xargs rm', () => {
+    const body = bodyOf("find . -name '*.log' -exec rm {} +");
+    expect(body).toContain('-exec is not supported by fauxnix');
+    expect(body).toContain('-delete');
+    expect(body).toContain('grep -r');
+    expect(body).not.toContain('xargs rm');
+    expect(body).toContain('$script:fx_exit = 1');
+  });
+});
+
+describe('xargs -0', () => {
+  it('fails loud instead of silently ignoring -0', () => {
+    const body = translateCommandList(parse('xargs -0 rm'))[0].body;
+    expect(body).toContain('xargs: -0 is not supported by fauxnix');
+    expect(body).toContain('$script:fx_exit = 1');
   });
 });
 


### PR DESCRIPTION
## Why

Computer-use agents trained on Mac emit `python3`. Windows has `python` / `py`. fx-native 127 is currently just `bash: python3: command not found` with no hint.

The existing `.sh` hint in `src/errors.ts` (`fauxnix: .sh scripts cannot run natively on Windows`) only fired after a PowerShell "is not recognized" line. fx-native never produces that line — it writes the bash-style 127 itself.

Do **not** silently alias `python3` to `python` (wrong interpreter). Hint + 127 only.

Related: #156.

## What

In `fx-native`, when `Get-Command -CommandType Application` and `Get-Command` both miss:

- still `$script:fx_exit = 127`
- `python3` / `python3.exe`: one-line hint `try python or py on Windows`
- name ending in `.sh`: the existing errors.ts hint

`normalizeStderr` attaches the same hints when rewriting PS not-recognized lines.

Also (same fail-loud agent friction, tiny):

- `xargs -0` was silently ignored in the short parser → `xargs: -0 is not supported by fauxnix`
- `find -exec` suggested `xargs rm`, which then hits `XARGS_BUILTIN_MSG` → example is now `find . -name "*.log" -delete` / `grep -r`

## Tests

- Unit: `python3 --version` body is `fx-native 'python3'` (not aliased to `python`); script contains the python/py hint and `$script:fx_exit = 127`
- Unit: `foo.sh` script contains the `.sh` hint and 127
- Unit: `python --version` still goes through `fx-native 'python'`
- Integration (this host): `python3 --version` → 127 + hint; `foo.sh` → 127 + `.sh` hint; `python --version` still works (Python 3.14 present)
- Unit: `xargs -0 rm` fails loud; `find -exec` example has `-delete` / `grep -r`, not `xargs rm`

`npx vitest run --dir test` — 232 passed (125 unit + 107 integration).

Not merging.
