### PR TITLE
fix: reject stdout redirects on non-last pipeline stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   an unbounded `yes | head` would hang.
 - `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`,
   `env -i`/`--ignore-environment`,
-  and background `&` are rejected with actionable error messages instead of misbehaving.
+  background `&`, and stdout redirects (`>` `>>` `&>` `&>>`) on a non-last
+  pipeline stage (`echo hi >f | cat`) are rejected with actionable error
+  messages instead of misbehaving.
   (`if/then/elif/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
   dotenv-style `source`, and word-level `$((...))` arithmetic expansion are supported.)
 - `command -v <builtin>` prints `/usr/bin/<name>` where bash prints the bare builtin name;

--- a/docs/rfc-redirect-fd-ownership.md
+++ b/docs/rfc-redirect-fd-ownership.md
@@ -10,9 +10,9 @@ focused implementation RFC the audit asked for.
 segment-level list. The executor then applies that list to the **whole**
 pipeline after capture.
 
-Two independently reproduced failures:
+Two independently reproduced failures (fixed in #147):
 
-| Command | bash | fauxnix today |
+| Command | bash | fauxnix before #147 |
 |---|---|---|
 | `echo hi >/dev/null` | no output | prints `hi` (`devNull` is set and never applied) |
 | `printf x \| cat < README.md \| head -1` | first line of README | `x` (`<` is fed to stage 0) |
@@ -21,6 +21,11 @@ A correct model is bash's: each pipeline stage owns its fds. A stdin redirect
 on a middle stage **replaces** the pipe, it does not move to the first stage.
 `>/dev/null` discards that stage's stdout; for a one-command segment that is
 the caller's stdout.
+
+#147 applied last-stage output and per-stage `<`. That made a previously
+accidental identity-pipe look wrong (`echo hi >f | cat` truncated `f` empty
+and printed `hi`). C-6 first slice (#157): **fail loud** at translate time
+for non-last `>` `>>` `&>` `&>>`. Full in-stage writes remain the follow-up.
 
 ## Contract
 
@@ -36,9 +41,11 @@ the caller's stdout.
 - Successive stdout redirects last-win: `>/dev/null >file` writes the command
   output to `file`; `>file >/dev/null` truncates `file` and discards output.
   `2>/dev/null` must not undo a prior `>/dev/null`.
-- Non-last-stage **stdout** redirects (`echo hi >f \| cat`) stay a documented
-  follow-up: they need the stage to write the file inside PowerShell instead of
-  the pipe. Not silent-wrong for the audit's two cases.
+- Non-last-stage **stdout** redirects (`echo hi >f \| cat`) **fail at
+  translate time** with an actionable alternative (`cmd >f; cat f` or wait
+  for per-stage fds). In-stage writes (the stage writes the file inside
+  PowerShell instead of the pipe) stay the #157 follow-up. `2>` on a
+  non-last stage is still silently wrong and is not rejected in this slice.
 
 ## Non-goals
 
@@ -53,3 +60,5 @@ the caller's stdout.
 - `cat missing.txt &>/dev/null` → empty stderr.
 - `printf x | cat < fruits.txt | head -1` → `apple`.
 - Existing `> >> 2>/dev/null 2>&1` and failed-`>` order tests stay green.
+- `echo hi >f | cat` → translate-time `FauxnixParseError` (C-6 first slice).
+- `echo hi >f` and last-stage `echo hi | cat >f` still write.

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -897,9 +897,29 @@ function stdinReadExpr(target: string): string {
   return '@(fx-readlines ' + pathExpr(n) + ')';
 }
 
+/** `>` `>>` `&>` `&>>` — Node last-stage apply cannot honor these on earlier stages. */
+function isStdoutFileRedirect(op: Redirect['op']): boolean {
+  return op === '>' || op === '>>' || op === '&>' || op === '&>>';
+}
+
+const NONLAST_STDOUT_REDIRECT_MSG =
+  'fauxnix: stdout redirect on a non-last pipeline stage is not supported yet; write the file in a previous list segment (cmd >f; cat f) or wait for per-stage fds (#157)';
+
+function rejectNonLastStdoutRedirects(commands: ShellCommand[]): void {
+  if (commands.length < 2) return;
+  for (let i = 0; i < commands.length - 1; i++) {
+    if (commands[i].redirects.some((r) => isStdoutFileRedirect(r.op))) {
+      throw new FauxnixParseError(NONLAST_STDOUT_REDIRECT_MSG);
+    }
+  }
+}
+
 export function translatePipelineBody(p: {
   commands: Array<SimpleCommand | IfCommand | ForCommand>;
 }): PipelineParts {
+  // Last-stage `>` is Node apply; a non-last `>` would truncate the file and
+  // still feed the pipe. Fail loud until in-stage writes (#157).
+  rejectNonLastStdoutRedirects(p.commands);
   // Every pipeline stage needs its own status slot. Handlers deliberately use
   // `$script:fx_exit` because their helper functions run in child scopes; in a
   // pipeline that shared flag lets an earlier failure leak into a successful

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -369,6 +369,21 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout.trim()).toBe('apple');
   });
 
+  it('rejects stdout redirect on a non-last pipeline stage', () => {
+    expect(() => translateCommandList(parseCommand('echo hi >f | cat'))).toThrow(
+      'fauxnix: stdout redirect on a non-last pipeline stage is not supported yet; write the file in a previous list segment (cmd >f; cat f) or wait for per-stage fds (#157)',
+    );
+  });
+
+  it('last-stage stdout redirect still writes', async () => {
+    const r = await run('echo hi | cat > lastpipe.txt');
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(join(dir, 'lastpipe.txt'), 'utf8').trim()).toBe('hi');
+    const single = await run('echo hi > singleout.txt');
+    expect(single.exitCode).toBe(0);
+    expect(readFileSync(join(dir, 'singleout.txt'), 'utf8').trim()).toBe('hi');
+  });
+
   it(
     '[[ ]] file and string tests, including =~',
     async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -667,6 +667,33 @@ describe('translator', () => {
     expect(plan.body).not.toContain('fx-readlines $env:FAUXNIX_STDIN_FILE');
   });
 
+  it('rejects stdout redirect on a non-last pipeline stage', () => {
+    const msg =
+      'fauxnix: stdout redirect on a non-last pipeline stage is not supported yet; write the file in a previous list segment (cmd >f; cat f) or wait for per-stage fds (#157)';
+    const bad = [
+      'echo hi >f | cat',
+      'echo hi >>f | cat',
+      'echo hi &>f | cat',
+      'echo hi &>>f | cat',
+      'echo hi >/dev/null | cat',
+      'echo hi | cat >mid | wc -l',
+    ];
+    for (const cmd of bad) {
+      expect(() => translateCommandList(parse(cmd)), cmd).toThrow(FauxnixParseError);
+      expect(() => translateCommandList(parse(cmd)), cmd).toThrow(msg);
+    }
+  });
+
+  it('allows last-stage stdout redirect and does not reject 2> on a non-last stage', () => {
+    const single = translateCommandList(parse('echo hi >f'))[0];
+    expect(single.outputRedirects).toEqual([{ op: '>', target: 'f' }]);
+    const disc = translateCommandList(parse('echo hi >/dev/null'))[0];
+    expect(disc.outputRedirects).toEqual([{ op: '>', target: '/dev/null' }]);
+    const last = translateCommandList(parse('echo hi | cat >f'))[0];
+    expect(last.outputRedirects).toEqual([{ op: '>', target: 'f' }]);
+    expect(() => translateCommandList(parse('echo hi 2>e | cat'))).not.toThrow();
+  });
+
   it('uses functions for multi-stage pipelines (PS 5.1 rule)', () => {
     const plan = translateCommandList(parse('a | b | c'))[0];
     expect(plan.script).toMatch(/function __fx_s\d+/);


### PR DESCRIPTION
## Why

C-6 / #157 first slice (tracking #118). `echo hi >f | cat` is silently wrong today: prep truncates `f` empty and last-stage apply leaves stdout on the pipe, so `cat` prints `hi`. Full in-stage writes are M-sized.

## What

Fail loud at translate time if a **non-last** pipeline stage has `>` `>>` `&>` `&>>`.

Do **not** reject last-stage `>`. Do **not** reject `<` (already per-stage). `2>` on a non-last stage is still silently wrong and is not rejected in this slice.

Message (U-3): `fauxnix: stdout redirect on a non-last pipeline stage is not supported yet; write the file in a previous list segment (cmd >f; cat f) or wait for per-stage fds (#157)`.

RFC: `docs/rfc-redirect-fd-ownership.md` (#157).

## Tests

- Unit: `echo hi >f | cat` throws `FauxnixParseError` with that message (also `>>` `&>` `&>>`).
- `echo hi >f` still translates; last-stage `echo hi | cat >f` still translates.
- `printf x | cat < fruits.txt | head -1` still middle-stdin.
- `echo hi >/dev/null` still last-stage discard.
- Integration: the fail path + last-stage `>` still writes.

`npx vitest run --dir test`: 255 passed (141 unit + 114 integration).

I will not merge.