### PR TITLE
test: scaffold C-7 differential corpus (skip-safe Git Bash oracle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ npm run build
 npx tsx scratch/run.mjs "any bash command"   # quick live check
 ```
 
+Differential vs Git Bash is opt-in (`FAUXNIX_DIFF_ORACLE=1`; skips if unset or `bash.exe` is missing — Git Bash is not required). See [`test/differential/README.md`](test/differential/README.md). This is the RFC C-7 scaffold, not the 200-case 1.0 gate.
+
 Architecture map: `src/parser.ts` (bash subset → AST) · `src/translator.ts` (AST → PowerShell +
 executor wrapper) · `src/executor.ts` (spawn, redirects, session persistence) ·
 `src/commands/*.ts` (per-command generators) · `src/mcp.ts` (MCP server) · `src/cli.ts`.

--- a/test/differential.test.ts
+++ b/test/differential.test.ts
@@ -1,0 +1,54 @@
+/**
+ * RFC C-7 scaffold: curated fauxnix vs Git Bash identity.
+ *
+ * Default `npm test` imports this file and runs the corpus-shape check, then
+ * skipIf's the oracle unless FAUXNIX_DIFF_ORACLE is set and git-bash bash.exe
+ * exists. Missing Git Bash never fails CI.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  canRunOracle,
+  loadCorpus,
+  oracleSkipReason,
+  resolveGitBash,
+  runCorpus,
+  formatSummary,
+} from './differential/run.js';
+
+const corpus = loadCorpus();
+const skipOracle = !canRunOracle();
+const skipWhy = oracleSkipReason();
+
+describe('differential corpus scaffold (C-7 / #118)', () => {
+  it('loads the curated scaffold, not the 200-case 1.0 gate', () => {
+    expect(corpus.gate.targetCases).toBe(200);
+    expect(corpus.gate.identity).toBe(0.95);
+    expect(corpus.cases.length).toBeGreaterThanOrEqual(15);
+    expect(corpus.cases.length).toBeLessThanOrEqual(40);
+    const ids = corpus.cases.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(expect.arrayContaining([
+      'echo-dev-null',
+      'printf-grep-split',
+      'head-lines-neg',
+      'grep-e-or',
+    ]));
+    expect(corpus.files['three.txt']?.split('\n').filter(Boolean)).toHaveLength(3);
+    if (skipOracle) console.log(`differential oracle skipped: ${skipWhy}`);
+  });
+});
+
+describe.skipIf(skipOracle)('differential vs Git Bash oracle', { timeout: 180_000 }, () => {
+  it('identity is ≥95% of this small corpus', async () => {
+    const bashPath = resolveGitBash();
+    expect(bashPath).toBeTruthy();
+    const run = await runCorpus({ corpus, bashPath: bashPath! });
+    const summary = formatSummary(run);
+    console.log(summary);
+    expect(run.total).toBe(corpus.cases.length);
+    expect(
+      run.identity,
+      `${summary}\nidentity ${(run.identity * 100).toFixed(1)}% < ${(run.gate * 100).toFixed(0)}% gate`,
+    ).toBeGreaterThanOrEqual(run.gate);
+  });
+});

--- a/test/differential/README.md
+++ b/test/differential/README.md
@@ -1,0 +1,72 @@
+# Differential corpus (RFC C-7 scaffold)
+
+Institutional home for fauxnix vs Git Bash identity checks. Tracking:
+[RFC 1.0 C-7](../../docs/rfc-1.0-completeness-usability.md) / [#118](https://github.com/20000419/fauxnix/issues/118).
+
+## This is a scaffold, not the 1.0 gate
+
+The **1.0.0 hard gate** is:
+
+- ≥ **200** curated cases
+- ≥ **95%** byte-identical (stdout / stderr / exit, newlines normalized)
+- two consecutive green **scheduled** oracle runs
+
+`corpus.json` is a **high-value subset** (15–40 cases) sourced from already-shipped
+audit repros and integration tests (`echo hi >/dev/null`, `printf … | grep`,
+`head --lines=-1`, `grep -e a -e c`, …). It does **not** claim the 200-case gate.
+Grow it from benchmark transcripts, audit repros, and each merged completeness PR.
+
+A weekly GitHub Actions cron is **not** added here. The oracle is opt-in
+(`FAUXNIX_DIFF_ORACLE`) and Git Bash is **not** required on developer machines or
+assumed on GH Windows. Default `npm test` imports `test/differential.test.ts` and
+**skips** the comparison. A commented / `if: false` workflow would be worse than
+this note; add a scheduled job later only when it is skip-safe or the image
+explicitly provides the oracle.
+
+## Running the oracle
+
+Git Bash is optional. If `FAUXNIX_DIFF_ORACLE` is unset **or** `bash.exe` is
+missing, the runner skips (CI stays green).
+
+```powershell
+$env:FAUXNIX_DIFF_ORACLE = '1'
+npx vitest run test/differential.test.ts
+```
+
+Point the env at `bash.exe` when Git for Windows is not in a default location:
+
+```powershell
+$env:FAUXNIX_DIFF_ORACLE = 'C:\Program Files\Git\bin\bash.exe'
+npx vitest run test/differential.test.ts
+```
+
+Unset, empty, `0`, `false`, `no`, or `off` → skip. `bash.exe` missing → skip.
+
+## Adding a case
+
+1. Append an object to `cases` in [`corpus.json`](corpus.json). `id` must be unique.
+2. Cite the audit / PR / RFC in `source`.
+3. Put shared fixtures in `files` (written into a temp cwd). A case may add
+   its own `files` overlay.
+4. Keep the command self-contained; one fauxnix session runs the whole corpus.
+5. Prefer cases that already have integration coverage so identity is plausible.
+6. Stay under the 1.0 gate until you are deliberately growing toward 200.
+
+```json
+{
+  "id": "grep-e-or",
+  "cmd": "grep -e a -e c letters.txt",
+  "source": "#152"
+}
+```
+
+Do **not** add documented deviations (`uname -r`, `command -v echo`, `pwd` drive
+letters). The comparison is newline-normalized stdout + stderr + exit.
+
+## Runner contract
+
+[`../differential.test.ts`](../differential.test.ts) always sanity-checks this
+corpus (so CI imports the file). The oracle `describe` is `skipIf` when the env
+is unset or git-bash `bash.exe` is missing. When the oracle runs, each case goes
+through a fauxnix session **and** `bash.exe`; a summary is printed; the test
+fails if identity is below 95% of **this** small corpus.

--- a/test/differential/corpus.json
+++ b/test/differential/corpus.json
@@ -1,0 +1,215 @@
+{
+  "gate": {
+    "targetCases": 200,
+    "identity": 0.95,
+    "note": "RFC 1.0 C-7 / #118. The 1.0 hard gate is ≥200 curated cases at ≥95% byte-identical on scheduled oracle runs. This file is a high-value scaffold sourced from already-shipped audit repros, not that gate."
+  },
+  "files": {
+    "fruits.txt": "apple\nBanana\napple pie\ncherry\n",
+    "letters.txt": "a\nb\nc\n",
+    "three.txt": "one\ntwo\nthree\n",
+    "abc.txt": "abc"
+  },
+  "cases": [
+    {
+      "id": "echo-dev-null",
+      "cmd": "echo hi >/dev/null",
+      "source": "#147 / docs/rfc-redirect-fd-ownership.md"
+    },
+    {
+      "id": "printf-grep-split",
+      "cmd": "printf 'a\\nb\\n' | grep b",
+      "source": "#153"
+    },
+    {
+      "id": "head-lines-neg",
+      "cmd": "head --lines=-1 three.txt",
+      "source": "#151"
+    },
+    {
+      "id": "grep-e-or",
+      "cmd": "grep -e a -e c letters.txt",
+      "source": "#152"
+    },
+    {
+      "id": "middle-stdin-redirect",
+      "cmd": "printf x | cat < fruits.txt | head -1",
+      "source": "#147 / docs/rfc-redirect-fd-ownership.md"
+    },
+    {
+      "id": "lastwins-null-then-file",
+      "cmd": "echo hi >/dev/null > lastwins.txt; cat lastwins.txt",
+      "source": "#147"
+    },
+    {
+      "id": "stderr-to-null",
+      "cmd": "cat missing.txt 2>/dev/null; echo OK",
+      "source": "#147"
+    },
+    {
+      "id": "dup-then-null",
+      "cmd": "echo hi 2>&1 >/dev/null",
+      "source": "#164"
+    },
+    {
+      "id": "both-to-null",
+      "cmd": "cat missing.txt >/dev/null 2>&1; echo OK",
+      "source": "#164"
+    },
+    {
+      "id": "amp-null",
+      "cmd": "cat missing.txt &>/dev/null; echo OK",
+      "source": "#147"
+    },
+    {
+      "id": "pipe-last-true",
+      "cmd": "false | true",
+      "source": "#124"
+    },
+    {
+      "id": "pipe-last-false",
+      "cmd": "true | false",
+      "source": "#124"
+    },
+    {
+      "id": "pipe-and-after-empty",
+      "cmd": "grep NO fruits.txt | head -1 && echo AFTER",
+      "source": "#124"
+    },
+    {
+      "id": "pipe-or-last-fail",
+      "cmd": "true | false || echo FALLBACK",
+      "source": "#124"
+    },
+    {
+      "id": "grep-m1",
+      "cmd": "grep -m1 apple fruits.txt",
+      "source": "#141"
+    },
+    {
+      "id": "grep-v-or",
+      "cmd": "grep -v -e a -e c letters.txt",
+      "source": "#152"
+    },
+    {
+      "id": "grep-regexp-or",
+      "cmd": "grep --regexp a --regexp c letters.txt",
+      "source": "#152"
+    },
+    {
+      "id": "grep-Fo-multi-e",
+      "cmd": "printf 'ba\\n' | grep -F -o -e a -e b",
+      "source": "#162"
+    },
+    {
+      "id": "grep-match",
+      "cmd": "grep apple fruits.txt",
+      "source": "integration: grep + exit codes"
+    },
+    {
+      "id": "grep-nomatch",
+      "cmd": "grep zz fruits.txt",
+      "source": "integration: grep + exit codes"
+    },
+    {
+      "id": "head-1",
+      "cmd": "head -1 fruits.txt",
+      "source": "#141"
+    },
+    {
+      "id": "sed-sub",
+      "cmd": "sed 's/apple/MANGO/g' fruits.txt",
+      "source": "integration: sed substitution"
+    },
+    {
+      "id": "pipeline-grep-sort",
+      "cmd": "cat fruits.txt | grep -i apple | sort",
+      "source": "integration: cat | grep | sort"
+    },
+    {
+      "id": "head-bytes-neg",
+      "cmd": "head --bytes=-1 abc.txt",
+      "source": "#151"
+    },
+    {
+      "id": "head-bytes-2",
+      "cmd": "head --bytes=2 abc.txt",
+      "source": "#151"
+    },
+    {
+      "id": "bracket-file",
+      "cmd": "[[ -f fruits.txt ]] && echo yes",
+      "source": "#80"
+    },
+    {
+      "id": "echo-n",
+      "cmd": "echo -n abc",
+      "source": "integration: echo/printf semantics"
+    },
+    {
+      "id": "printf-fmt",
+      "cmd": "printf '%s=%d\\n' x 42",
+      "source": "integration: echo/printf semantics"
+    },
+    {
+      "id": "arith-add",
+      "cmd": "echo $((1+1))",
+      "source": "#119"
+    },
+    {
+      "id": "arith-mul-quoted",
+      "cmd": "echo \"$((2*3))\"",
+      "source": "#119"
+    },
+    {
+      "id": "arith-assign",
+      "cmd": "i=3; i=$((i+1)); echo $i",
+      "source": "#119"
+    },
+    {
+      "id": "if-true",
+      "cmd": "if true; then echo YES; fi",
+      "source": "#112"
+    },
+    {
+      "id": "elif-true",
+      "cmd": "if false; then echo A; elif true; then echo B; else echo C; fi",
+      "source": "#120"
+    },
+    {
+      "id": "for-words",
+      "cmd": "for x in a b c; do echo $x; done",
+      "source": "#112"
+    },
+    {
+      "id": "status-false",
+      "cmd": "false; echo $?",
+      "source": "integration: $? reflects the previous segment"
+    },
+    {
+      "id": "param-default",
+      "cmd": "unset X; echo ${X:-def}",
+      "source": "#112"
+    },
+    {
+      "id": "strlen",
+      "cmd": "X=abcd; echo ${#X}",
+      "source": "#112"
+    },
+    {
+      "id": "cmdsub",
+      "cmd": "echo $(echo nested)",
+      "source": "#112"
+    },
+    {
+      "id": "or-fallback",
+      "cmd": "cat missing.txt || echo FELLBACK",
+      "source": "integration: && and || short-circuit"
+    },
+    {
+      "id": "echo-pipe-grep",
+      "cmd": "echo hi | grep hi",
+      "source": "#153"
+    }
+  ]
+}

--- a/test/differential/run.ts
+++ b/test/differential/run.ts
@@ -1,0 +1,245 @@
+/**
+ * C-7 differential runner: fauxnix session vs Git Bash.
+ * Opt-in via FAUXNIX_DIFF_ORACLE; skips when the env is unset or bash.exe is missing.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseCommand } from '../../src/parser.js';
+import { translateCommandList } from '../../src/translator.js';
+import { FauxnixSession } from '../../src/executor.js';
+import '../../src/commands/install-all.js';
+
+export interface CorpusCase {
+  id: string;
+  cmd: string;
+  source?: string;
+  files?: Record<string, string>;
+}
+
+export interface Corpus {
+  gate: { targetCases: number; identity: number; note: string };
+  files: Record<string, string>;
+  cases: CorpusCase[];
+}
+
+export interface Streams {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface CaseResult {
+  id: string;
+  cmd: string;
+  identical: boolean;
+  fauxnix: Streams;
+  bash: Streams;
+  error?: string;
+}
+
+export interface CorpusRun {
+  total: number;
+  identical: number;
+  identity: number;
+  gate: number;
+  bashPath: string;
+  results: CaseResult[];
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+export const CORPUS_PATH = join(here, 'corpus.json');
+
+export function loadCorpus(path = CORPUS_PATH): Corpus {
+  return JSON.parse(readFileSync(path, 'utf8')) as Corpus;
+}
+
+/** True when the caller asked for the Git Bash oracle (any truthy value except 0/false/no/off). */
+export function isOracleRequested(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.FAUXNIX_DIFF_ORACLE;
+  if (raw == null) return false;
+  const v = raw.trim();
+  if (v === '') return false;
+  return !/^(0|false|no|off)$/i.test(v);
+}
+
+function gitBashCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
+  const pf = env.ProgramFiles || env.PROGRAMFILES || 'C:\\Program Files';
+  const pf86 = env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
+  const local = env.LOCALAPPDATA || '';
+  return [
+    join(pf, 'Git', 'bin', 'bash.exe'),
+    join(pf, 'Git', 'usr', 'bin', 'bash.exe'),
+    join(pf86, 'Git', 'bin', 'bash.exe'),
+    local ? join(local, 'Programs', 'Git', 'bin', 'bash.exe') : '',
+  ].filter(Boolean);
+}
+
+/**
+ * Resolve git-bash `bash.exe`. If FAUXNIX_DIFF_ORACLE is a path to an existing
+ * executable, that wins; otherwise the usual Git for Windows locations.
+ */
+export function resolveGitBash(env: NodeJS.ProcessEnv = process.env): string | null {
+  const raw = env.FAUXNIX_DIFF_ORACLE?.trim();
+  if (raw && existsSync(raw) && /bash(\.exe)?$/i.test(raw)) return raw;
+  for (const p of gitBashCandidates(env)) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+export function hasPowerShell(): boolean {
+  if (process.platform !== 'win32') return false;
+  return spawnSync('powershell.exe', ['-NoProfile', '-Command', 'exit 0'], { shell: false }).status === 0;
+}
+
+/** Oracle runs only when requested *and* git-bash bash.exe is present (and we can execute). */
+export function canRunOracle(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isOracleRequested(env) && resolveGitBash(env) !== null && hasPowerShell();
+}
+
+export function oracleSkipReason(env: NodeJS.ProcessEnv = process.env): string | null {
+  if (!isOracleRequested(env)) {
+    return 'FAUXNIX_DIFF_ORACLE is unset; Git Bash is not required on developer machines';
+  }
+  if (resolveGitBash(env) === null) {
+    return 'FAUXNIX_DIFF_ORACLE is set but git-bash bash.exe was not found';
+  }
+  if (!hasPowerShell()) {
+    return 'PowerShell is unavailable; fauxnix execution is Windows-only';
+  }
+  return null;
+}
+
+export function normalizeNewlines(s: string): string {
+  return s.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+export function sameIdentity(a: Streams, b: Streams): boolean {
+  return (
+    normalizeNewlines(a.stdout) === normalizeNewlines(b.stdout) &&
+    normalizeNewlines(a.stderr) === normalizeNewlines(b.stderr) &&
+    a.exitCode === b.exitCode
+  );
+}
+
+function writeTree(root: string, files: Record<string, string>): void {
+  for (const [rel, body] of Object.entries(files)) {
+    const dest = join(root, rel);
+    mkdirSync(dirname(dest), { recursive: true });
+    writeFileSync(dest, body, 'utf8');
+  }
+}
+
+function bashEnv(bashPath: string): NodeJS.ProcessEnv {
+  const gitRoot = dirname(dirname(bashPath));
+  const extra = [join(gitRoot, 'usr', 'bin'), dirname(bashPath)];
+  const pathKey = Object.keys(process.env).find((k) => k.toLowerCase() === 'path') ?? 'PATH';
+  return {
+    ...process.env,
+    [pathKey]: [...extra, process.env[pathKey] ?? ''].join(';'),
+    LANG: 'C',
+    LC_ALL: 'C',
+  };
+}
+
+function runBash(bashPath: string, cwd: string, cmd: string): Streams {
+  const r = spawnSync(bashPath, ['--noprofile', '--norc', '-c', cmd], {
+    cwd,
+    env: bashEnv(bashPath),
+    encoding: 'utf8',
+    shell: false,
+    windowsHide: true,
+    timeout: 30_000,
+  });
+  if (r.error) {
+    return { stdout: '', stderr: r.error.message, exitCode: 127 };
+  }
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    exitCode: r.status ?? 1,
+  };
+}
+
+function inspect(s: string): string {
+  const n = normalizeNewlines(s);
+  if (n.length <= 120) return JSON.stringify(n);
+  return JSON.stringify(n.slice(0, 117) + '...');
+}
+
+export function formatSummary(run: CorpusRun): string {
+  const pct = (run.identity * 100).toFixed(1);
+  const lines = [
+    `differential: ${run.identical}/${run.total} identical (${pct}%) vs ${run.bashPath}`,
+    `gate for this corpus: ≥${(run.gate * 100).toFixed(0)}%  |  1.0 gate: ≥200 cases at ≥95% (not this scaffold)`,
+  ];
+  const mismatches = run.results.filter((r) => !r.identical);
+  for (const m of mismatches) {
+    lines.push(`  FAIL ${m.id}: ${m.cmd}`);
+    if (m.error) lines.push(`        error: ${m.error}`);
+    if (normalizeNewlines(m.fauxnix.stdout) !== normalizeNewlines(m.bash.stdout)) {
+      lines.push(`        stdout fauxnix=${inspect(m.fauxnix.stdout)} bash=${inspect(m.bash.stdout)}`);
+    }
+    if (normalizeNewlines(m.fauxnix.stderr) !== normalizeNewlines(m.bash.stderr)) {
+      lines.push(`        stderr fauxnix=${inspect(m.fauxnix.stderr)} bash=${inspect(m.bash.stderr)}`);
+    }
+    if (m.fauxnix.exitCode !== m.bash.exitCode) {
+      lines.push(`        exit  fauxnix=${m.fauxnix.exitCode} bash=${m.bash.exitCode}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export async function runCorpus(opts: {
+  corpus?: Corpus;
+  bashPath: string;
+}): Promise<CorpusRun> {
+  const corpus = opts.corpus ?? loadCorpus();
+  const dir = mkdtempSync(join(tmpdir(), 'fauxnix-diff-'));
+  const session = new FauxnixSession();
+  const results: CaseResult[] = [];
+  try {
+    writeTree(dir, corpus.files ?? {});
+    await session.prewarm();
+    await session.run(translateCommandList(parseCommand('cd "' + dir + '"')));
+
+    for (const c of corpus.cases) {
+      if (c.files) writeTree(dir, c.files);
+      let fauxnix: Streams;
+      let error: string | undefined;
+      try {
+        const r = await session.run(translateCommandList(parseCommand(c.cmd)));
+        fauxnix = { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode };
+      } catch (e) {
+        error = e instanceof Error ? e.message : String(e);
+        fauxnix = { stdout: '', stderr: error, exitCode: 2 };
+      }
+      const bash = runBash(opts.bashPath, dir, c.cmd);
+      results.push({
+        id: c.id,
+        cmd: c.cmd,
+        identical: !error && sameIdentity(fauxnix, bash),
+        fauxnix,
+        bash,
+        error,
+      });
+    }
+  } finally {
+    await session.dispose();
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  const identical = results.filter((r) => r.identical).length;
+  const total = results.length;
+  return {
+    total,
+    identical,
+    identity: total === 0 ? 1 : identical / total,
+    gate: corpus.gate.identity,
+    bashPath: opts.bashPath,
+    results,
+  };
+}


### PR DESCRIPTION
## Why

RFC 1.0 **C-7** (#118): the correctness institution is still a maintainer scratch battery. 1.0 needs `test/differential/` with a `FAUXNIX_DIFF_ORACLE`-gated runner.

This PR is the **scaffold**, not the 200-case gate.

## What

- `test/differential/corpus.json` — 40 high-value cases from shipped audit repros (`echo hi >/dev/null`, `printf 'a\nb\n' | grep b`, `head --lines=-1` on a 3-line fixture, `grep -e a -e c`, …)
- `test/differential/run.ts` + `test/differential.test.ts` — `describe.skipIf` unless `FAUXNIX_DIFF_ORACLE` is set **and** git-bash `bash.exe` exists; each case through a fauxnix session **and** bash; compare stdout/stderr/exit with newlines normalized; print a summary; fail below 95% of *this* corpus
- `test/differential/README.md` — how to run, how to add cases, 200-case 1.0 gate documented
- Pointer from the README Development section
- **No** weekly cron: Git Bash is not required on developer machines, and a commented / `if: false` workflow would be worse than the README note. Default `npm test` imports the file (corpus-shape check) and skips the oracle

## Tests

- `npx vitest run test/differential.test.ts` without the env: 1 passed, 1 skipped
- `FAUXNIX_DIFF_ORACLE=1` vs Git Bash: **39/40 identical (97.5%)** — one stderr trailing-newline delta on `cat missing.txt || echo FELLBACK`

C-7 / #118