### PR TITLE
feat: CommandSpec for text-filters leftovers (sort/uniq/cut/tr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,10 @@ development:
 
 `cp` / `mv` / `rm` / `touch` / `du` / `ls` / `ll` / `mkdir` / `rmdir` / `mktemp` / `ln` /
 `readlink` / `realpath` / `basename` / `dirname` / `stat` / `file` / `df` / `chmod` / `chown` /
-`diff` / `tee` / `grep` / `head` / `echo` / `printf` / `cat` / `tail` / `wc` carry a `CommandSpec`: unknown options fail with a GNU-style
+`diff` / `tee` / `grep` / `head` / `echo` / `printf` / `cat` / `tail` / `wc` / `sort` / `uniq` /
+`cut` / `tr` carry a `CommandSpec`: unknown options fail with a GNU-style
 usage error instead of being ignored (`find` stays unspec'd so predicates like `-name` still
-compile). Implemented GNU holes: `cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` /
+compile; `sed`/`awk`/`egrep` stay unspec'd). Implemented GNU holes: `cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` /
 `head --lines` / `du --max-depth`. `fauxnix list --json` and `docs/command-specs.md` dump the
 same metadata.
 - **shell/system**: `cd pwd export unset env printenv ps kill pkill pgrep sleep which type whoami

--- a/docs/command-specs.md
+++ b/docs/command-specs.md
@@ -285,6 +285,56 @@ Effects: `read`
 | `--exclude` | required | implemented |
 | `--exclude-dir` | required | implemented |
 
+## `sort`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-r`, `--reverse` | flag | implemented |
+| `-n`, `--numeric-sort` | flag | implemented |
+| `-u`, `--unique` | flag | implemented |
+| `-f`, `--ignore-case` | flag | implemented |
+| `-b`, `--ignore-leading-blanks` | flag | implemented |
+| `-t` | required | implemented |
+| `-k` | required | implemented |
+| `-z`, `--zero-terminated` | flag | unsupported (NUL-terminated records) |
+
+## `uniq`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-c` | flag | implemented |
+| `-d` | flag | implemented |
+| `-u` | flag | implemented |
+| `-i` | flag | implemented |
+
+## `cut`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-d` | required | implemented |
+| `-f` | required | implemented |
+| `-c` | required | implemented |
+| `-b` | required | implemented |
+| `-s` | flag | implemented |
+| `--complement` | flag | implemented |
+
+## `tr`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-d` | flag | implemented |
+| `-s` | flag | implemented |
+| `-c`, `--complement` | flag | unsupported (complement) |
+| `-C` | flag | unsupported (complement) |
+
 ## Unspec'd commands
 
-`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `cd`, `clear`, `command`, `curl`, `cut`, `date`, `dig`, `dirs`, `egrep`, `env`, `eval`, `exit`, `export`, `false`, `find`, `free`, `groups`, `gunzip`, `gzip`, `history`, `host`, `hostname`, `id`, `ifconfig`, `ip`, `kill`, `less`, `man`, `md5sum`, `more`, `netstat`, `nl`, `nproc`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `printenv`, `ps`, `pushd`, `pwd`, `read`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `sleep`, `sort`, `source`, `ss`, `sudo`, `tac`, `tar`, `test`, `timeout`, `tr`, `true`, `type`, `uname`, `uniq`, `unset`, `unzip`, `uptime`, `wget`, `which`, `whoami`, `xargs`, `yes`, `zcat`, `zip`
+`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `cd`, `clear`, `command`, `curl`, `date`, `dig`, `dirs`, `egrep`, `env`, `eval`, `exit`, `export`, `false`, `find`, `free`, `groups`, `gunzip`, `gzip`, `history`, `host`, `hostname`, `id`, `ifconfig`, `ip`, `kill`, `less`, `man`, `md5sum`, `more`, `netstat`, `nl`, `nproc`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `printenv`, `ps`, `pushd`, `pwd`, `read`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `sleep`, `source`, `ss`, `sudo`, `tac`, `tar`, `test`, `timeout`, `true`, `type`, `uname`, `unset`, `unzip`, `uptime`, `wget`, `which`, `whoami`, `xargs`, `yes`, `zcat`, `zip`

--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -2572,8 +2572,9 @@ function parseCutList(list: string): CutRange[] {
 const cut: Handler = (args) => {
   const { flags, longs, values, operandWords } = parseWords(args, ['d', 'f', 'c', 'b'], []);
   const complement = longs.has('--complement');
-  const charsMode = flags.has('c') || flags.has('b');
-  const fieldsMode = flags.has('f');
+  // -f/-c/-b are value-taking; parseWords records them in `values`, not `flags`.
+  const charsMode = values.has('-c') || values.has('-b');
+  const fieldsMode = values.has('-f');
   const suppress = flags.has('s');
 
   if (charsMode && fieldsMode) {
@@ -2826,8 +2827,68 @@ export const specs: CommandSpec[] = [
     usageExit: 2,
     handler: grep,
   },
+  {
+    names: ['sort'],
+    options: [
+      { short: 'r', long: '--reverse', support: 'implemented' },
+      { short: 'n', long: '--numeric-sort', support: 'implemented' },
+      { short: 'u', long: '--unique', support: 'implemented' },
+      { short: 'f', long: '--ignore-case', support: 'implemented' },
+      { short: 'b', long: '--ignore-leading-blanks', support: 'implemented' },
+      { short: 't', takesValue: true, support: 'implemented' },
+      { short: 'k', takesValue: true, support: 'implemented' },
+      { short: 'z', long: '--zero-terminated', support: 'unsupported', reason: 'NUL-terminated records' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    usageExit: 2,
+    handler: sort,
+  },
+  {
+    names: ['uniq'],
+    options: [
+      { short: 'c', support: 'implemented' },
+      { short: 'd', support: 'implemented' },
+      { short: 'u', support: 'implemented' },
+      { short: 'i', support: 'implemented' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: uniq,
+  },
+  {
+    names: ['cut'],
+    options: [
+      { short: 'd', takesValue: true, support: 'implemented' },
+      { short: 'f', takesValue: true, support: 'implemented' },
+      { short: 'c', takesValue: true, support: 'implemented' },
+      { short: 'b', takesValue: true, support: 'implemented' },
+      { short: 's', support: 'implemented' },
+      { long: '--complement', support: 'implemented' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: cut,
+  },
+  {
+    names: ['tr'],
+    options: [
+      { short: 'd', support: 'implemented' },
+      { short: 's', support: 'implemented' },
+      { short: 'c', long: '--complement', support: 'unsupported', reason: 'complement' },
+      { short: 'C', support: 'unsupported', reason: 'complement' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: tr,
+  },
 ];
 
+/** sed/awk stay unspec'd (custom script parsers). egrep injects -E and stays its own handler. */
 export const handlers: Record<string, Handler> = {
   egrep: (args, ctx) => grep([[{ kind: 'Text', text: '-E' }], ...args], ctx), // egrep = grep -E
   sed,

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -216,6 +216,27 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     const r = await run('sort dups.txt | uniq -c');
     expect(r.stdout).toMatch(/2 aaa/);
     expect(r.stdout).toMatch(/1 bbb/);
+    expect((await run("printf '10\\n2\\n1\\n' | sort -n")).stdout.trim().split(/\r?\n/)).toEqual([
+      '1',
+      '2',
+      '10',
+    ]);
+  });
+
+  it('cut -d -f and tr -d still work', async () => {
+    expect((await run("cut -d ' ' -f1 nums.txt")).stdout.trim().split(/\r?\n/)).toEqual([
+      '1',
+      '3',
+      '5',
+    ]);
+    expect((await run('printf abc | tr -d b')).stdout.trim()).toBe('ac');
+  });
+
+  it('sort -z is unsupported', async () => {
+    const r = await run('sort -z dups.txt');
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("option '-z' is not supported by fauxnix");
+    expect(r.stdout).toBe('');
   });
 
   it('head/tail/wc', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1137,6 +1137,75 @@ describe('CommandSpec text-io leftovers (#143)', () => {
   });
 });
 
+describe('CommandSpec text-filters leftovers (#143)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+
+  it('sort/uniq/cut/tr are spec\'d; sed/awk/egrep stay unspec\'d', () => {
+    expect(lookupSpec('sort')).toBeTruthy();
+    expect(lookupSpec('uniq')).toBeTruthy();
+    expect(lookupSpec('cut')).toBeTruthy();
+    expect(lookupSpec('tr')).toBeTruthy();
+    expect(lookupSpec('sed')).toBeUndefined();
+    expect(lookupSpec('awk')).toBeUndefined();
+    expect(lookupSpec('egrep')).toBeUndefined();
+    expect(lookupSpec('find')).toBeUndefined();
+  });
+
+  it('sort -z is unsupported; unknown flags fail usage', () => {
+    const z = bodyOf('sort -z');
+    expect(z).toContain("option ''-z'' is not supported by fauxnix");
+    expect(z).toContain('NUL-terminated records');
+    expect(z).toContain('$script:fx_exit = 2');
+    expect(z).toContain("Try ''sort --help'' for more information.");
+    expect(z).not.toContain('[array]::Sort');
+    const unknown = bodyOf('sort -Q');
+    expect(unknown).toContain("invalid option -- ''Q''");
+    expect(unknown).not.toContain('[array]::Sort');
+  });
+
+  it('implemented sort -n/-r/-k and longs still compile', () => {
+    expect(bodyOf('sort -n f')).toContain('fx-numkey');
+    expect(bodyOf('sort -n f')).not.toContain('invalid option');
+    expect(bodyOf('sort --numeric-sort f')).toContain('fx-numkey');
+    expect(bodyOf('sort -r f')).toContain('[array]::Reverse');
+    expect(bodyOf('sort --reverse f')).toContain('[array]::Reverse');
+    expect(bodyOf('sort -k 2 f')).toContain('fx-keyof');
+    expect(bodyOf('sort -nr f')).toContain('fx-numkey');
+  });
+
+  it('uniq -c/-d/-u/-i still compile; unknown flags fail', () => {
+    expect(bodyOf('uniq -c f')).toContain("'{0,7} {1}'");
+    expect(bodyOf('uniq -c f')).not.toContain('invalid option');
+    expect(bodyOf('uniq -d f')).toContain('if ($c -gt 1)');
+    expect(bodyOf('uniq -u f')).toContain('if ($c -eq 1)');
+    expect(bodyOf('uniq -i f')).toContain('.ToLower()');
+    expect(bodyOf('uniq -z f')).toContain("invalid option -- ''z''");
+    expect(bodyOf('uniq -z f')).not.toContain('fx-uemit');
+  });
+
+  it('cut -d -f / -c still compile; unknown flags fail', () => {
+    const fields = bodyOf("cut -d, -f1 f");
+    expect(fields).toContain('.Split([char]44)');
+    expect(fields).not.toContain('invalid option');
+    expect(bodyOf('cut -c1-2 f')).toContain('.ToCharArray()');
+    expect(bodyOf('cut --complement -f1 f')).toContain('-not (');
+    expect(bodyOf('cut -z -f1 f')).toContain("invalid option -- ''z''");
+    expect(bodyOf('cut -z -f1 f')).not.toContain('.Split');
+  });
+
+  it('tr -d/-s still compile; -c is unsupported', () => {
+    const del = bodyOf('tr -d a');
+    expect(del).toContain('$fx_dl.ContainsKey');
+    expect(del).not.toContain('invalid option');
+    expect(bodyOf('tr -s a')).toContain('$fx_sq.ContainsKey');
+    const complement = bodyOf('tr -c a b');
+    expect(complement).toContain("option ''-c'' is not supported by fauxnix");
+    expect(complement).toContain('complement');
+    expect(complement).not.toContain('$fx_map');
+    expect(bodyOf('tr --complement a b')).toContain('not supported by fauxnix');
+  });
+});
+
 describe('find predicates (#130)', () => {
   const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
   const throws = (cmd: string, msg: string) => {


### PR DESCRIPTION
## Why

#143 family 3 / RFC 1.0 C-5 (#118): after files leftovers (#144) and text-io leftovers (#161), `sort`/`uniq`/`cut`/`tr` still used unchecked `parseWords`, so unknown flags were ignored.

`grep` is already spec'd. This PR does **not** spec `sed`/`awk`/`egrep` (custom script parsers; skipSpec). `find` stays unspec'd.

## What

CommandSpec for:

- `sort`: `-r`/`--reverse` `-n`/`--numeric-sort` `-u`/`--unique` `-f`/`--ignore-case` `-b`/`--ignore-leading-blanks` `-t` `-k` (what the handler actually reads). `-z`/`--zero-terminated` unsupported (NUL-terminated records). Usage exit 2.
- `uniq`: `-c` `-d` `-u` `-i`.
- `cut`: `-d` `-f` `-c` `-b` `-s` `--complement`. Mode detection for `-f`/`-c`/`-b` reads `parseWords` `values` so `cut -d -f` works.
- `tr`: `-d` `-s`. `-c`/`-C`/`--complement` unsupported (complement). Do not invent GNU complement behavior.

`docs/command-specs.md` regenerated from `specsMarkdown()`. README CommandSpec sentence lists the new names.

## Tests

- `lookupSpec('sort')` defined; `lookupSpec('sed')` / `lookupSpec('awk')` / `lookupSpec('egrep')` undefined
- `sort -z` unsupported usage/exit 2; unknown `sort -Q` usage error
- implemented `sort -n` / `uniq -c` / `cut -d -f` / `tr -d` still work
- `docs/command-specs.md === specsMarkdown()`
- unit 145 passed; integration 114 passed (`npx vitest run --dir test`)

Not merging.