### PR TITLE
feat: add fauxnix doctor extending check (U-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ fauxnix translate "find . -name '*.log' -mtime +7 -delete"
 
 # check your environment
 fauxnix check
+fauxnix doctor                   # check + encoding, harness config, MCP
 
 # run the MCP stdio server (what agent harnesses connect to)
 fauxnix mcp

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,10 +5,11 @@ import { translateCommandList } from './translator.js';
 import { listCommandsJson, registeredNames, specsMarkdown } from './registry.js';
 import { encodeCommand } from './encoding.js';
 import { startMcpServer } from './mcp.js';
+import { collectDoctorReport } from './doctor.js';
 import { packageVersion } from './version.js';
 import './commands/install-all.js';
 
-const USAGE = `fauxnix — run Linux-style commands on Windows via PowerShell translation
+export const USAGE = `fauxnix — run Linux-style commands on Windows via PowerShell translation
 
 Usage:
   fauxnix "ls -la | head -5"        translate + execute a bash-style command
@@ -19,6 +20,7 @@ Usage:
   fauxnix list --json                same list as machine-readable capability metadata
   fauxnix list --markdown            CommandSpec tables (same text as docs/command-specs.md)
   fauxnix check                      verify the local PowerShell environment
+  fauxnix doctor                     check + encoding, harness config, MCP readiness
   fauxnix --version
 
 Notes:
@@ -58,6 +60,11 @@ export async function runCli(argv: string[]): Promise<void> {
     return;
   }
 
+  if (verb === 'doctor') {
+    await runDoctor();
+    return;
+  }
+
   if (verb === 'mcp') {
     await startMcpServer();
     return;
@@ -88,6 +95,13 @@ export async function runCli(argv: string[]): Promise<void> {
 }
 
 const PS_ARGS = ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass'];
+
+async function runDoctor(): Promise<void> {
+  await runCheck();
+  const report = await collectDoctorReport();
+  for (const line of report.lines) console.log(line);
+  if (!report.ok) process.exitCode = 1;
+}
 
 async function runCheck(): Promise<void> {
   console.log('powershell : powershell.exe (Windows built-in)');

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,257 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export type DoctorOptions = {
+  home?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  nodeVersion?: string;
+  /** Injected MCP-module loader. Default: dynamic import of ./mcp.js (does not start the server). */
+  loadMcp?: () => Promise<unknown>;
+};
+
+export type DoctorReport = {
+  lines: string[];
+  ok: boolean;
+};
+
+const VALUE_INDENT = '             ';
+
+export async function collectDoctorReport(opts: DoctorOptions = {}): Promise<DoctorReport> {
+  const home = opts.home ?? homedir();
+  const cwd = opts.cwd ?? process.cwd();
+  const env = opts.env ?? process.env;
+  const nodeVersion = opts.nodeVersion ?? process.version;
+
+  const lines: string[] = [''];
+  lines.push(...encodingLines(env));
+  lines.push('');
+  lines.push(field('claude', detectClaude(home, cwd, env)));
+  lines.push(field('codex', detectCodex(home, env)));
+  lines.push(field('opencode', detectOpenCode(home, env)));
+  lines.push('');
+
+  const mcp = await mcpLines(nodeVersion, opts.loadMcp);
+  lines.push(...mcp.lines);
+  return { lines, ok: mcp.ok };
+}
+
+function field(label: string, value: string): string {
+  return `${label.padEnd(10)} : ${value}`;
+}
+
+function encodingLines(env: NodeJS.ProcessEnv): string[] {
+  const raw = env.FAUXNIX_NATIVE_ENCODING;
+  const current =
+    raw === undefined || raw === ''
+      ? 'unset → utf8 (default)'
+      : raw === 'ansi'
+        ? 'ansi → GBK-native admin tools'
+        : `${raw} → utf8 (only ansi selects GBK)`;
+  return [
+    field('encoding', 'UTF-8 default for native-tool pipelines'),
+    VALUE_INDENT + `current FAUXNIX_NATIVE_ENCODING=${current}`,
+    VALUE_INDENT + 'set FAUXNIX_NATIVE_ENCODING=ansi for GBK-native admin tools (ipconfig, tasklist)',
+  ];
+}
+
+function detectClaude(home: string, cwd: string, env: NodeJS.ProcessEnv): string {
+  const userPath = claudeUserConfigPath(home, env);
+  const projectPath = join(cwd, '.mcp.json');
+  const userExists = existsSync(userPath);
+  const projectExists = existsSync(projectPath);
+
+  let user: ReturnType<typeof inspectClaudeJson> | undefined;
+  let project: ReturnType<typeof inspectClaudeJson> | undefined;
+  if (userExists) user = inspectClaudeJson(userPath);
+  if (projectExists) {
+    const inspected = inspectClaudeJson(projectPath);
+    // Project-scope Claude MCP is always a top-level mcpServers object.
+    if (!inspected.parseError && inspected.hasTopLevelMcpServers) project = inspected;
+  }
+
+  if (!userExists && !project) return 'not detected — see README';
+
+  if (user?.hasFauxnix) return `fauxnix MCP configured (${userPath})`;
+  if (project?.hasFauxnix) return `fauxnix MCP configured (${projectPath})`;
+
+  if (userExists && user?.parseError) {
+    return `found ${userPath} (unreadable JSON) — see README`;
+  }
+  if (userExists) {
+    return `found ${userPath}, fauxnix MCP not listed — run: claude mcp add fauxnix -- fauxnix mcp`;
+  }
+  return `found ${projectPath}, fauxnix MCP not listed — see README`;
+}
+
+function claudeUserConfigPath(home: string, env: NodeJS.ProcessEnv): string {
+  const dir = env.CLAUDE_CONFIG_DIR?.trim();
+  if (dir) return join(dir, '.claude.json');
+  return join(home, '.claude.json');
+}
+
+function inspectClaudeJson(path: string): {
+  parseError: boolean;
+  hasTopLevelMcpServers: boolean;
+  hasFauxnix: boolean;
+} {
+  const text = readText(path);
+  if (text === undefined) {
+    return { parseError: true, hasTopLevelMcpServers: false, hasFauxnix: false };
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(stripBom(text));
+  } catch {
+    return { parseError: true, hasTopLevelMcpServers: false, hasFauxnix: false };
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return { parseError: true, hasTopLevelMcpServers: false, hasFauxnix: false };
+  }
+  const rec = data as Record<string, unknown>;
+  const hasTopLevelMcpServers = isServerMap(rec.mcpServers);
+  let hasFauxnix = hasTopLevelMcpServers && serverMapHasFauxnix(rec.mcpServers);
+  const projects = rec.projects;
+  if (projects && typeof projects === 'object' && !Array.isArray(projects)) {
+    for (const proj of Object.values(projects as Record<string, unknown>)) {
+      if (!proj || typeof proj !== 'object' || Array.isArray(proj)) continue;
+      const servers = (proj as Record<string, unknown>).mcpServers;
+      if (isServerMap(servers) && serverMapHasFauxnix(servers)) hasFauxnix = true;
+    }
+  }
+  return { parseError: false, hasTopLevelMcpServers, hasFauxnix };
+}
+
+function detectCodex(home: string, env: NodeJS.ProcessEnv): string {
+  const codexHome = env.CODEX_HOME?.trim() || join(home, '.codex');
+  const path = join(codexHome, 'config.toml');
+  if (!existsSync(path)) return 'not detected — see README';
+  const text = readText(path);
+  if (text === undefined) return `found ${path} (unreadable) — see README`;
+  if (hasCodexFauxnix(stripBom(text))) return `fauxnix MCP configured (${path})`;
+  return `found ${path}, fauxnix MCP not listed — run: codex mcp add fauxnix -- fauxnix mcp`;
+}
+
+function hasCodexFauxnix(text: string): boolean {
+  if (/^\s*\[mcp_servers\.(?:fauxnix|"fauxnix"|'fauxnix')\]/im.test(text)) return true;
+  const tables = text.split(/^\s*\[/m);
+  for (const table of tables) {
+    if (!/^mcp_servers\./i.test(table)) continue;
+    const header = (table.split(/[\]\r\n]/, 1)[0] ?? '').trim();
+    if (/^mcp_servers\.(?:fauxnix|"fauxnix"|'fauxnix')$/i.test(header)) return true;
+    const cmd = /^\s*command\s*=\s*(?:"([^"]*)"|'([^']*)')/im.exec(table);
+    const command = cmd?.[1] ?? cmd?.[2];
+    if (command && isFauxnixExecutable(command)) return true;
+    const args = /^\s*args\s*=\s*\[([^\]]*)\]/im.exec(table);
+    if (args) {
+      const items = [...args[1].matchAll(/"([^"]*)"|'([^']*)'/g)].map((m) => m[1] ?? m[2] ?? '');
+      if (items.some(isFauxnixExecutable)) return true;
+    }
+  }
+  return false;
+}
+
+function detectOpenCode(home: string, env: NodeJS.ProcessEnv): string {
+  const xdg = env.XDG_CONFIG_HOME?.trim() || join(home, '.config');
+  const path = join(xdg, 'opencode', 'opencode.json');
+  if (!existsSync(path)) return 'not detected — see README';
+  const text = readText(path);
+  if (text === undefined) return `found ${path} (unreadable) — see README`;
+  let data: unknown;
+  try {
+    data = JSON.parse(stripBom(text));
+  } catch {
+    return `found ${path} (unreadable JSON) — see README`;
+  }
+  if (hasOpenCodeFauxnix(data)) return `fauxnix MCP configured (${path})`;
+  return `found ${path}, fauxnix MCP not listed — add mcp.fauxnix (see README)`;
+}
+
+function hasOpenCodeFauxnix(data: unknown): boolean {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  const mcp = (data as Record<string, unknown>).mcp;
+  if (!isServerMap(mcp)) return false;
+  if (serverMapHasFauxnix(mcp)) return true;
+  const nested = (mcp as Record<string, unknown>).servers;
+  return isServerMap(nested) && serverMapHasFauxnix(nested);
+}
+
+function isServerMap(value: unknown): boolean {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function serverMapHasFauxnix(value: unknown): boolean {
+  if (!isServerMap(value)) return false;
+  for (const [name, cfg] of Object.entries(value as Record<string, unknown>)) {
+    if (name === 'servers') continue;
+    if (looksLikeFauxnixServer(name, cfg)) return true;
+  }
+  return false;
+}
+
+function looksLikeFauxnixServer(name: string, cfg: unknown): boolean {
+  if (/^fauxnix(-cli)?$/i.test(name)) return true;
+  if (!cfg || typeof cfg !== 'object' || Array.isArray(cfg)) return false;
+  const rec = cfg as Record<string, unknown>;
+  const chunks: string[] = [];
+  if (typeof rec.command === 'string') chunks.push(rec.command);
+  if (Array.isArray(rec.command)) {
+    for (const part of rec.command) if (typeof part === 'string') chunks.push(part);
+  }
+  if (Array.isArray(rec.args)) {
+    for (const part of rec.args) if (typeof part === 'string') chunks.push(part);
+  }
+  return chunks.some(isFauxnixExecutable);
+}
+
+function isFauxnixExecutable(s: string): boolean {
+  const base = s.replace(/\\/g, '/').split('/').pop()?.trim() ?? '';
+  return /^fauxnix(-cli)?(\.cmd|\.exe)?$/i.test(base);
+}
+
+async function mcpLines(
+  nodeVersion: string,
+  loadMcp?: () => Promise<unknown>,
+): Promise<{ lines: string[]; ok: boolean }> {
+  const major = nodeMajor(nodeVersion);
+  const nodeOk = major >= 18;
+  let moduleOk = false;
+  let moduleDetail = '';
+  try {
+    const mod = await (loadMcp ?? defaultLoadMcp)();
+    moduleOk =
+      !!mod && typeof (mod as { startMcpServer?: unknown }).startMcpServer === 'function';
+    if (!moduleOk) moduleDetail = 'startMcpServer export missing';
+  } catch (e) {
+    moduleDetail = e instanceof Error ? e.message : String(e);
+  }
+
+  const lines = [
+    field('node', `${nodeVersion.startsWith('v') ? nodeVersion : 'v' + nodeVersion}${nodeOk ? ' (>=18 required)' : '  FAILED (requires >=18)'}`),
+    field('mcp', moduleOk ? 'module loads' : `FAILED to load${moduleDetail ? ': ' + moduleDetail : ''}`),
+    VALUE_INDENT + 'start with: fauxnix mcp',
+  ];
+  return { lines, ok: nodeOk && moduleOk };
+}
+
+async function defaultLoadMcp(): Promise<unknown> {
+  return import('./mcp.js');
+}
+
+function nodeMajor(version: string): number {
+  const m = /^v?(\d+)/.exec(version);
+  return m ? Number(m[1]) : 0;
+}
+
+function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+function readText(path: string): string | undefined {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return undefined;
+  }
+}

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,5 +1,10 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { runCli, USAGE } from '../src/cli.js';
+import { collectDoctorReport } from '../src/doctor.js';
 import { FauxnixParseError, isUnquotedLiteral, wordToString } from '../src/ast.js';
 import { parseCommand as parse, tokenize } from '../src/parser.js';
 import {
@@ -1270,5 +1275,217 @@ describe('cli check spawn error', () => {
     expect(check).toContain("probe.on('error'");
     expect(check).toMatch(/FAILED to run powershell\.exe:.*e\.message/);
     expect(check).toContain('process.exit(1)');
+  });
+});
+
+describe('cli doctor', () => {
+  it('USAGE lists doctor', async () => {
+    expect(USAGE).toMatch(/fauxnix doctor/);
+    const src = readFileSync('src/cli.ts', 'utf8');
+    expect(src).toContain("verb === 'doctor'");
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(' '));
+    };
+    try {
+      await runCli([]);
+    } finally {
+      console.log = orig;
+    }
+    expect(lines.join('\n')).toContain('fauxnix doctor');
+  });
+
+  it('collectDoctorReport does not throw when no harness configs exist', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-doctor-'));
+    try {
+      const report = await collectDoctorReport({
+        home: dir,
+        cwd: dir,
+        env: {},
+        nodeVersion: 'v20.11.0',
+      });
+      const text = report.lines.join('\n');
+      expect(text).toContain('UTF-8 default');
+      expect(text).toContain('FAUXNIX_NATIVE_ENCODING=unset → utf8 (default)');
+      expect(text).toMatch(/claude\s+: not detected — see README/);
+      expect(text).toMatch(/codex\s+: not detected — see README/);
+      expect(text).toMatch(/opencode\s+: not detected — see README/);
+      expect(text).toContain('start with: fauxnix mcp');
+      expect(text).toContain('module loads');
+      expect(text).toContain('v20.11.0');
+      expect(report.ok).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports encoding override and Node/MCP failures', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-doctor-'));
+    try {
+      const ansi = await collectDoctorReport({
+        home: dir,
+        cwd: dir,
+        env: { FAUXNIX_NATIVE_ENCODING: 'ansi' },
+        nodeVersion: 'v22.0.0',
+      });
+      expect(ansi.lines.join('\n')).toContain('ansi → GBK-native admin tools');
+      expect(ansi.ok).toBe(true);
+
+      const oldNode = await collectDoctorReport({
+        home: dir,
+        cwd: dir,
+        env: {},
+        nodeVersion: 'v16.20.0',
+        loadMcp: async () => ({ startMcpServer: async () => {} }),
+      });
+      expect(oldNode.ok).toBe(false);
+      expect(oldNode.lines.join('\n')).toContain('FAILED (requires >=18)');
+
+      const badMcp = await collectDoctorReport({
+        home: dir,
+        cwd: dir,
+        env: {},
+        nodeVersion: 'v20.0.0',
+        loadMcp: async () => {
+          throw new Error('boom');
+        },
+      });
+      expect(badMcp.ok).toBe(false);
+      expect(badMcp.lines.join('\n')).toContain('FAILED to load: boom');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('detects harness configs conservatively', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-doctor-'));
+    try {
+      const empty = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(empty.lines.join('\n')).toMatch(/claude\s+: not detected — see README/);
+
+      writeFileSync(
+        join(dir, '.claude.json'),
+        JSON.stringify({
+          notes: 'I cloned fauxnix',
+          projects: { 'C:\\repos\\fauxnix': { allowedTools: ['Bash'] } },
+        }),
+      );
+      const mention = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(mention.lines.join('\n')).toContain('fauxnix MCP not listed');
+      expect(mention.lines.join('\n')).not.toContain('fauxnix MCP configured');
+
+      writeFileSync(
+        join(dir, '.claude.json'),
+        JSON.stringify({
+          projects: {
+            'C:\\work\\app': { mcpServers: { fauxnix: { command: 'fauxnix', args: ['mcp'] } } },
+          },
+        }),
+      );
+      const claudeLocal = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(claudeLocal.lines.join('\n')).toMatch(/claude\s+: fauxnix MCP configured/);
+
+      writeFileSync(
+        join(dir, '.claude.json'),
+        JSON.stringify({ mcpServers: { fauxnix: { command: 'fauxnix', args: ['mcp'] } } }),
+      );
+      const claude = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(claude.lines.join('\n')).toMatch(/claude\s+: fauxnix MCP configured/);
+
+      const homeDir = join(dir, 'home');
+      const cwdDir = join(dir, 'cwd');
+      mkdirSync(homeDir);
+      mkdirSync(cwdDir);
+      writeFileSync(
+        join(cwdDir, '.claude.json'),
+        JSON.stringify({ mcpServers: { fauxnix: { command: 'fauxnix', args: ['mcp'] } } }),
+      );
+      const cwdClaude = await collectDoctorReport({
+        home: homeDir,
+        cwd: cwdDir,
+        env: {},
+        nodeVersion: 'v20.0.0',
+      });
+      expect(cwdClaude.lines.join('\n')).toMatch(/claude\s+: not detected — see README/);
+
+      rmSync(join(dir, '.claude.json'));
+      writeFileSync(
+        join(dir, '.mcp.json'),
+        JSON.stringify({ mcpServers: { fauxnix: { command: 'fauxnix', args: ['mcp'] } } }),
+      );
+      const project = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(project.lines.join('\n')).toMatch(/claude\s+: fauxnix MCP configured/);
+      expect(project.lines.join('\n')).toContain('.mcp.json');
+
+      writeFileSync(join(dir, '.mcp.json'), JSON.stringify({ name: 'unrelated', fauxnix: true }));
+      const unrelatedMcp = await collectDoctorReport({
+        home: dir,
+        cwd: dir,
+        env: {},
+        nodeVersion: 'v20.0.0',
+      });
+      expect(unrelatedMcp.lines.join('\n')).toMatch(/claude\s+: not detected — see README/);
+
+      mkdirSync(join(dir, '.codex'));
+      writeFileSync(join(dir, '.codex', 'config.toml'), '[model]\nmodel = "gpt-5"\n');
+      const codexBare = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(codexBare.lines.join('\n')).toContain('codex mcp add fauxnix');
+
+      writeFileSync(
+        join(dir, '.codex', 'config.toml'),
+        '[mcp_servers.fauxnix]\ncommand = "fauxnix"\nargs = ["mcp"]\n',
+      );
+      const codex = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(codex.lines.join('\n')).toMatch(/codex\s+: fauxnix MCP configured/);
+
+      mkdirSync(join(dir, '.config', 'opencode'), { recursive: true });
+      writeFileSync(
+        join(dir, '.config', 'opencode', 'opencode.json'),
+        JSON.stringify({ mcp: { fauxnix: { type: 'local', command: ['fauxnix', 'mcp'] } } }),
+      );
+      const opencode = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(opencode.lines.join('\n')).toMatch(/opencode\s+: fauxnix MCP configured/);
+
+      writeFileSync(
+        join(dir, '.config', 'opencode', 'opencode.json'),
+        JSON.stringify({
+          mcp: { servers: { fauxnix: { type: 'local', command: ['fauxnix', 'mcp'] } } },
+        }),
+      );
+      const opencodeV2 = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(opencodeV2.lines.join('\n')).toMatch(/opencode\s+: fauxnix MCP configured/);
+
+      rmSync(join(dir, '.config'), { recursive: true, force: true });
+      writeFileSync(
+        join(dir, 'opencode.json'),
+        JSON.stringify({ mcp: { fauxnix: { type: 'local', command: ['fauxnix', 'mcp'] } } }),
+      );
+      const cwdOnly = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(cwdOnly.lines.join('\n')).toMatch(/opencode\s+: not detected — see README/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe.skipIf(process.platform !== 'win32')('cli doctor spawn', () => {
+  it('node src/index.ts doctor does not throw', () => {
+    const tsx = join(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs');
+    expect(existsSync(tsx)).toBe(true);
+    const r = spawnSync(process.execPath, [tsx, 'src/index.ts', 'doctor'], {
+      encoding: 'utf8',
+      timeout: 30000,
+      env: process.env,
+    });
+    expect(r.error).toBeUndefined();
+    expect(r.stdout).toContain('powershell');
+    expect(r.stdout).toContain('encoding');
+    expect(r.stdout).toContain('FAUXNIX_NATIVE_ENCODING');
+    expect(r.stdout).toContain('start with: fauxnix mcp');
+    expect(r.stdout).toMatch(/claude\s+:/);
+    expect(r.stdout).toMatch(/codex\s+:/);
+    expect(r.stdout).toMatch(/opencode\s+:/);
+    expect(r.status).toBe(0);
   });
 });


### PR DESCRIPTION
RFC 1.0 item **U-2** (#118): `fauxnix doctor` extends `fauxnix check`.

- PowerShell present/version: same probe + spawn error listener as `check`
- Encoding: UTF-8 default / `FAUXNIX_NATIVE_ENCODING`
- Harness config: Claude (`.claude.json` / project `.mcp.json`), Codex (`~/.codex/config.toml`), OpenCode (`~/.config/opencode/opencode.json`). Missing files print `not detected — see README`. Does not write configs. False positives avoided (cwd `opencode.json` / cwd `.claude.json` ignored; `fauxnix` mentioned outside MCP maps is not treated as configured)
- MCP: Node `process.version` (>=18) + dry-load of the MCP module. Does not spawn `fauxnix mcp`
- `fauxnix check` unchanged. USAGE lists `doctor`

Tests: `collectDoctorReport` (exported) + `runCli([])` USAGE + Windows spawn of `src/index.ts doctor`. `npx vitest run --dir test`: 256 passed.

Not merging. Does not implement U-1 `install --harness`.