### PR TITLE
feat: translate $(cmd1; cmd2) lists through translateListInline (C-4)

### DIFF
--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1,7 +1,6 @@
 import {
   Assignment,
   CommandList,
-  FauxnixParseError,
   Redirect,
   ShellCommand,
   SimpleCommand,
@@ -382,16 +381,11 @@ export function argListExpr(words: Word[], fn: (w: Word) => string = exprOfWord)
  * Unquoted command words join non-empty lines with a space (IFS
  * word-split approximation). Handlers often emit one string object, so
  * a bare `$(…)` interpolation would keep those newlines.
+ * Lists (`;` `&&` `||`) reuse translateListInline inside the fx-csub
+ * scriptblock so the newline contract is unchanged.
  */
 export function translateCmdSub(cmdText: string, keepNl = false): string {
-  const list = parseCommand(cmdText);
-  if (list.segments.length !== 1) {
-    throw new FauxnixParseError(
-      'fauxnix: command substitution with ; && || is not supported yet',
-    );
-  }
-  const { defs, call } = translatePipelineBody(list.segments[0].pipeline);
-  const inner = defs ? defs + '\n' + call : call;
+  const inner = translateListInline(parseCommand(cmdText));
   const collected = '(fx-csub { ' + inner + ' })';
   if (keepNl) return collected;
   return (
@@ -1191,7 +1185,16 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '  $script:fx_csub = $true',
       '  try { $fx_o = @(& $b | ForEach-Object { [string]$_ }) }',
       '  finally { $script:fx_csub = $fx_prevcs }',
-      '  $fx_s = ($fx_o -join [string][char]10)',
+      // Line items (no trailing NL) get a NL between them. Chunks that
+      // already end in NL concatenate, so $(echo a; echo b) is a\nb.
+      "  $fx_s = ''",
+      '  foreach ($fx_x in $fx_o) {',
+      '    $fx_t = [string]$fx_x',
+      '    if ($fx_s.Length -gt 0 -and $fx_s[$fx_s.Length - 1] -ne [char]10) {',
+      '      $fx_s += [string][char]10',
+      '    }',
+      '    $fx_s += $fx_t',
+      '  }',
       '  while ($fx_s.Length -gt 0 -and $fx_s[$fx_s.Length - 1] -eq [char]10) {',
       '    $fx_s = $fx_s.Substring(0, $fx_s.Length - 1)',
       '  }',

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -746,6 +746,11 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run("echo \"[$(printf 'a\\n')]\"")).stdout).toBe('[a]\n');
     // Unquoted $(...) approximates IFS split (PS space-join), matching pre-#88.
     expect((await run("echo $(printf 'a\\nb')")).stdout.trim()).toBe('a b');
+    // C-4: list inside $(...) — unquoted IFS-joins; quoted keeps the newline.
+    expect((await run('echo $(echo a; echo b)')).stdout.trim()).toBe('a b');
+    expect((await run('echo "$(echo a; echo b)"')).stdout).toBe('a\nb\n');
+    expect((await run('echo $(false; echo x)')).stdout.trim()).toBe('x');
+    expect((await run('echo $(true && echo y)')).stdout.trim()).toBe('y');
   });
 
   it('VAR=value prefixes do not leak past the command', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -90,6 +90,26 @@ describe('parser', () => {
     expect(exprOfWord(a.assignments[0].value, { preserveCmdSub: true })).not.toContain("-join ' '");
   });
 
+  it('translates multi-segment command substitution (C-4)', () => {
+    expect(() => translateCommandList(parse('echo $(echo a; echo b)'))).not.toThrow();
+    const body = translateCommandList(parse('echo $(echo a; echo b)'))[0].body;
+    expect(body).toContain('fx-csub');
+    expect(body).toContain("'a'");
+    expect(body).toContain("'b'");
+    expect(body).toContain('-split [string][char]10');
+    const quoted = exprOfWord(
+      parse('echo "$(echo a; echo b)"').segments[0].pipeline.commands[0].args[0],
+    );
+    expect(quoted).toContain('fx-csub');
+    expect(quoted).toContain("'a'");
+    expect(quoted).toContain("'b'");
+    expect(quoted).not.toContain('-split [string][char]10');
+    const andBody = translateCommandList(parse('echo $(true && echo y)'))[0].body;
+    expect(andBody).toContain('fx-csub');
+    expect(andBody).toContain('if ($script:fx_exit -eq 0)');
+    expect(andBody).toContain("'y'");
+  });
+
   it('set -e is a loud usage error, not a silent no-op', () => {
     const script = translateCommandList(parse('set -e'))[0].script;
     expect(script).toMatch(/set -e\/-u\/-x is not supported/);


### PR DESCRIPTION
RFC 1.0 item **C-4** (#118): multi-segment command substitution `$(cmd1; cmd2)`.

`translateCmdSub` threw on `;` `&&` `||`. `translateListInline` already handles those operators — recurse through it inside `fx-csub { ... }`. Quoted vs unquoted newline contract unchanged.

- `echo $(echo a; echo b)` → `a b` (unquoted IFS join)
- `echo "$(echo a; echo b)"` → `a\nb`
- `echo $(false; echo x)` / `echo $(true && echo y)`

`fx-csub` concatenates chunks that already end in NL so two echoes are `a\nb`, not a blank line. Line items without a trailing NL still get a NL between them.

Not merging.
