### PR TITLE
release: v0.10.0 — roadmap v2 wave 1 (#172-#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.10.0 — 2026-09-02
+
+First wave claimed against the 1.0 roadmap v2 (all by r3wretrhy):
+
+- **C-4**: multi-segment command substitution `$(cmd1; cmd2)` (#179)
+- **C-5 (partial)**: CommandSpec for the text-filters family — sort/uniq/
+  cut/tr and friends fail loud on unknown options (#177)
+- **C-6 (interim)**: stdout redirects on non-last pipeline stages reject
+  loudly with the #157 workaround in the message (#175)
+- **C-7 scaffold**: `test/differential/` corpus + oracle-gated runner
+  (`FAUXNIX_DIFF_ORACLE=1`, skip-safe without Git Bash); 25-seed corpus,
+  ≥95% identity gate; the 200-case 1.0 target grows from here (#176)
+- **T-1**: SECURITY.md — trust model, host protocol, kill semantics,
+  network guard, reporting policy (#174)
+- **T-2**: CONTRIBUTING gains the RFC rule (#173)
+- **U-2**: `fauxnix doctor` — PowerShell/encoding checks plus harness
+  config detection with fix hints (verified detecting real Claude/Codex/
+  OpenCode configs) (#178)
+- C-3 mini-RFC: session-scoped positional parameters proposed
+  (docs/rfc-positional-params.md) — implementation awaits #118 discussion
+
+271 tests (251 + differential corpus suite).
 ## v0.9.3 — 2026-08-31
 
 Windows computer-use parity wave #1 (RFC #156, #158-#167 by r3wretrhy):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,11 +38,35 @@ Never push a hand-resolved merge directly to `main`, even when the result
 tests green locally. (Post-hoc CI on `main` detects problems but does not
 make the delta reviewable — that's detection, not gating.)
 
+## RFC process
+
+An RFC is required before implementation when the change is any of:
+
+- a new language surface (syntax, builtins, or session-visible features)
+- a host protocol change
+- a semantic change to redirects, argv, or session env
+
+Template: a short `docs/rfc-*.md` (see [docs/rfc-template.md](docs/rfc-template.md))
+plus a tracking issue. Implementation PRs stay independently reviewable
+per the checklist above.
+
+Existing RFCs (shape to copy):
+
+- [docs/rfc-1.0-completeness-usability.md](docs/rfc-1.0-completeness-usability.md)
+- [docs/rfc-computer-use-windows.md](docs/rfc-computer-use-windows.md)
+- [docs/rfc-redirect-fd-ownership.md](docs/rfc-redirect-fd-ownership.md)
+- [docs/rfc-native-argv-fidelity.md](docs/rfc-native-argv-fidelity.md)
+- [docs/rfc-bounded-cancellable-execution.md](docs/rfc-bounded-cancellable-execution.md)
+
+Expect review on the integration tree per the checklist above; do not merge
+your own PRs. There is no SLA.
+
 ## Releases
 
 1. Version-bump PR (`package.json` + `src/cli.ts` + `src/mcp.ts`), CI green, merge.
 2. Tag `vX.Y.Z`, push tag.
-3. `npm publish` (requires maintainer 2FA).
+3. `npm run test:package` green.
+4. `npm publish` (requires maintainer 2FA).
 
 ## Attribution note
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,11 @@ executor wrapper) · `src/executor.ts` (spawn, redirects, session persistence) �
 Roadmap: [docs/rfc-roadmap-to-1.0.md](docs/rfc-roadmap-to-1.0.md) — tracks, milestones,
 and the RFC process for proposing waves.
 
+## Security
+
+Trust model, host protocol, kill semantics, network guard, and reporting:
+[SECURITY.md](SECURITY.md).
+
 ## License
 
 MIT © 20000419

--- a/README.md
+++ b/README.md
@@ -164,9 +164,10 @@ development:
 
 `cp` / `mv` / `rm` / `touch` / `du` / `ls` / `ll` / `mkdir` / `rmdir` / `mktemp` / `ln` /
 `readlink` / `realpath` / `basename` / `dirname` / `stat` / `file` / `df` / `chmod` / `chown` /
-`diff` / `tee` / `grep` / `head` / `echo` / `printf` / `cat` / `tail` / `wc` carry a `CommandSpec`: unknown options fail with a GNU-style
+`diff` / `tee` / `grep` / `head` / `echo` / `printf` / `cat` / `tail` / `wc` / `sort` / `uniq` /
+`cut` / `tr` carry a `CommandSpec`: unknown options fail with a GNU-style
 usage error instead of being ignored (`find` stays unspec'd so predicates like `-name` still
-compile). Implemented GNU holes: `cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` /
+compile; `sed`/`awk`/`egrep` stay unspec'd). Implemented GNU holes: `cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` /
 `head --lines` / `du --max-depth`. `fauxnix list --json` and `docs/command-specs.md` dump the
 same metadata.
 - **shell/system**: `cd pwd export unset env printenv ps kill pkill pgrep sleep which type whoami

--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   an unbounded `yes | head` would hang.
 - `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`,
   `env -i`/`--ignore-environment`,
-  and background `&` are rejected with actionable error messages instead of misbehaving.
+  background `&`, and stdout redirects (`>` `>>` `&>` `&>>`) on a non-last
+  pipeline stage (`echo hi >f | cat`) are rejected with actionable error
+  messages instead of misbehaving.
   (`if/then/elif/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
   dotenv-style `source`, and word-level `$((...))` arithmetic expansion are supported.)
 - `command -v <builtin>` prints `/usr/bin/<name>` where bash prints the bare builtin name;

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ npm run build
 npx tsx scratch/run.mjs "any bash command"   # quick live check
 ```
 
+Differential vs Git Bash is opt-in (`FAUXNIX_DIFF_ORACLE=1`; skips if unset or `bash.exe` is missing — Git Bash is not required). See [`test/differential/README.md`](test/differential/README.md). This is the RFC C-7 scaffold, not the 200-case 1.0 gate.
+
 Architecture map: `src/parser.ts` (bash subset → AST) · `src/translator.ts` (AST → PowerShell +
 executor wrapper) · `src/executor.ts` (spawn, redirects, session persistence) ·
 `src/commands/*.ts` (per-command generators) · `src/mcp.ts` (MCP server) · `src/cli.ts`.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ fauxnix translate "find . -name '*.log' -mtime +7 -delete"
 
 # check your environment
 fauxnix check
+fauxnix doctor                   # check + encoding, harness config, MCP
 
 # run the MCP stdio server (what agent harnesses connect to)
 fauxnix mcp

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,116 @@
+# Security
+
+fauxnix is a local shell translator. Pointing an agent at `fauxnix mcp` is
+the same trust decision as giving that agent a Bash tool: it runs **as you,
+on this machine, with no sandbox**.
+
+This is not a security product. Isolation and approval belong to the
+harness (Claude Code, Codex, OpenCode, …), not to fauxnix. The 1.0 RFC
+lists sandboxing policy as a non-goal.
+
+## Trust model
+
+- **Same user, same privileges.** `fauxnix` and `fauxnix mcp` spawn
+  `powershell.exe` as the logged-in user. Translated commands (`rm`,
+  `chmod`, `kill`, …) and native passthrough (`git`, `node`, `npm`,
+  `python`, `cargo`, … via `fx-native`) inherit that identity.
+- **No isolation.** There is no container, AppContainer, filesystem jail,
+  or Windows Job Object around the session. MCP `bash` persists cwd,
+  `export`/`unset`, and environment across calls like a logged-in shell.
+- **MCP annotations are honest.** The `bash` tool is `destructiveHint: true`,
+  `openWorldHint: true`, `readOnlyHint: false`. `fauxnix_translate` never
+  executes. `fauxnix_session` can inspect or reset the host.
+- **Approval is the harness's job.** Codex non-interactive `exec` auto-denies
+  MCP tools unless `--dangerously-bypass-approvals-and-sandbox`. fauxnix
+  does not add a second prompt.
+
+## Host-protocol surface
+
+One `FauxnixSession` owns one resident `powershell.exe` 5.1 process
+(`src/ps-host.ts`; RFC
+[`docs/rfc-persistent-powershell-host.md`](docs/rfc-persistent-powershell-host.md)).
+
+The host is started as:
+
+```
+powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File <temp>/fauxnix-<id>-host.ps1
+```
+
+Frames are UTF-8 JSON lines on the process stdin/stdout pipes (raw
+`OpenStandardInput`/`OpenStandardOutput`, not PS 5.1's default UTF-16LE
+pipe encoding). Command stdout/stderr travel as base64 so the pipe
+encoding cannot scramble bytes.
+
+Handshake (protocol v2; v1 `{"ready":true}` is still accepted):
+
+```json
+{"v":2,"type":"ready","capabilities":{"cancel":false,"maxChunkBytes":65536,"stderrMarker":true}}
+```
+
+Node → host, per segment:
+
+```json
+{"v":2,"type":"run","id":"…","scriptB64":"…","env":{"FAUXNIX_CWD":"…","FAUXNIX_PREV_EXIT":"0","FAUXNIX_STDIN_FILE":""},"stdoutLimit":8388608,"stderrLimit":1048576}
+```
+
+`scriptB64` is decoded to UTF-8 and invoked as a scriptblock in that
+process. `env` values are strings; an empty string unsets the variable
+(so a missing `<` redirect cannot leak `FAUXNIX_STDIN_FILE`). The host
+emits chunked `stdout`/`stderr` frames plus an `end` frame. Native exe
+stderr on the OS pipe is delimited with `FAUXNIX_ERR_END:<id>`.
+
+`capabilities.cancel` is **false**: the host cannot stop an in-flight
+`& $fx_sb` without killing the process. `fauxnix translate` never starts
+a host. Session sidecars live under `%TEMP%`
+(`fauxnix-<id>-host.ps1`, `-cwd.txt`, `-env.json`, `-script.ps1`).
+
+## Kill semantics
+
+Cancel and timeout **kill the host process**. The next `run()`
+cold-starts a new `powershell.exe`. This is the RFC #129 leftover:
+per-frame runspace `Stop()` (roadmap B3) is not implemented.
+
+| Event | What happens |
+|---|---|
+| MCP `extra.signal` abort | `ChildProcess.kill()` on `powershell.exe`. Result: `cancelled: true`, exit **130**. Later list segments do not run. |
+| `timeout_ms` / `ExecOptions.timeoutMs` (default 120s) | Same kill. Result: `timedOut: true`, exit **124**. |
+| `fauxnix_session reset` / `dispose()` | Kill host, unlink temp files. Reset re-prewarms the same session object. |
+| Stdio EOF / SIGINT / SIGTERM | Idempotent dispose. |
+| Host dies mid-frame | That frame fails; the script is **not** retried. Next `run()` cold-starts. |
+
+`ChildProcess.kill()` does **not** assign a Windows Job Object.
+Grandchildren the script spawned may survive the host. Job-object tree
+kill is roadmap B4, not shipped. Details:
+[`docs/rfc-bounded-cancellable-execution.md`](docs/rfc-bounded-cancellable-execution.md).
+
+## Network guard
+
+`curl` and `wget` run `fx-netguard` (`src/commands/net.ts`) over every
+argv element that starts with `http://` or `https://` **before**
+`curl.exe` / `wget.exe` is launched. Matching destinations are refused
+with `curl: fauxnix refused private/loopback address …` (exit 1).
+
+Refused hosts: `localhost`, `::1`, `127.x`, `10.x`, `192.168.x`,
+`169.254.x`, `172.16–31.x`.
+
+This is a **safety default for agent-driven HTTP**, not a sandbox and
+not a complete SSRF defense:
+
+- Only `curl` / `wget`. `ping`, `nslookup`, `dig`, `host`, and native
+  passthrough are unguarded.
+- Hostname strings are not DNS-resolved; a public name that points at a
+  private address is not blocked.
+- Non-`http(s)` URLs, post-connect redirects, IPv6 ULA/link-local besides
+  `::1`, and decimal/hex IP encodings are out of scope.
+
+## Reporting
+
+Report vulnerabilities via
+[GitHub Security Advisories](https://github.com/20000419/fauxnix/security/advisories/new)
+(private). Public [issues](https://github.com/20000419/fauxnix/issues)
+are fine when the finding is already obvious from this document (for
+example “there is no sandbox”) or you cannot open an advisory.
+
+Include `fauxnix --version` (npm package `fauxnix-cli`), a local
+reproducer, and impact. Pre-1.0, the supported target is the latest
+npm release.

--- a/docs/command-specs.md
+++ b/docs/command-specs.md
@@ -285,6 +285,56 @@ Effects: `read`
 | `--exclude` | required | implemented |
 | `--exclude-dir` | required | implemented |
 
+## `sort`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-r`, `--reverse` | flag | implemented |
+| `-n`, `--numeric-sort` | flag | implemented |
+| `-u`, `--unique` | flag | implemented |
+| `-f`, `--ignore-case` | flag | implemented |
+| `-b`, `--ignore-leading-blanks` | flag | implemented |
+| `-t` | required | implemented |
+| `-k` | required | implemented |
+| `-z`, `--zero-terminated` | flag | unsupported (NUL-terminated records) |
+
+## `uniq`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-c` | flag | implemented |
+| `-d` | flag | implemented |
+| `-u` | flag | implemented |
+| `-i` | flag | implemented |
+
+## `cut`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-d` | required | implemented |
+| `-f` | required | implemented |
+| `-c` | required | implemented |
+| `-b` | required | implemented |
+| `-s` | flag | implemented |
+| `--complement` | flag | implemented |
+
+## `tr`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-d` | flag | implemented |
+| `-s` | flag | implemented |
+| `-c`, `--complement` | flag | unsupported (complement) |
+| `-C` | flag | unsupported (complement) |
+
 ## Unspec'd commands
 
-`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `cd`, `clear`, `command`, `curl`, `cut`, `date`, `dig`, `dirs`, `egrep`, `env`, `eval`, `exit`, `export`, `false`, `find`, `free`, `groups`, `gunzip`, `gzip`, `history`, `host`, `hostname`, `id`, `ifconfig`, `ip`, `kill`, `less`, `man`, `md5sum`, `more`, `netstat`, `nl`, `nproc`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `printenv`, `ps`, `pushd`, `pwd`, `read`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `sleep`, `sort`, `source`, `ss`, `sudo`, `tac`, `tar`, `test`, `timeout`, `tr`, `true`, `type`, `uname`, `uniq`, `unset`, `unzip`, `uptime`, `wget`, `which`, `whoami`, `xargs`, `yes`, `zcat`, `zip`
+`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `cd`, `clear`, `command`, `curl`, `date`, `dig`, `dirs`, `egrep`, `env`, `eval`, `exit`, `export`, `false`, `find`, `free`, `groups`, `gunzip`, `gzip`, `history`, `host`, `hostname`, `id`, `ifconfig`, `ip`, `kill`, `less`, `man`, `md5sum`, `more`, `netstat`, `nl`, `nproc`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `printenv`, `ps`, `pushd`, `pwd`, `read`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `sleep`, `source`, `ss`, `sudo`, `tac`, `tar`, `test`, `timeout`, `true`, `type`, `uname`, `unset`, `unzip`, `uptime`, `wget`, `which`, `whoami`, `xargs`, `yes`, `zcat`, `zip`

--- a/docs/rfc-positional-params.md
+++ b/docs/rfc-positional-params.md
@@ -1,0 +1,45 @@
+# RFC: positional parameters (`$1`, `$#`, `$@`, `set --`)
+
+Tracking: [#118](https://github.com/20000419/fauxnix/issues/118) item **C-3**.
+Status: proposed mini-RFC (discussion on #118 before implementation).
+
+## Why
+
+Agent scripts use `$1` / `"$@"` constantly (`grep -n "$1"`, `set -- "$@" extra`).
+fauxnix’s MCP `bash` tool has **no argv**: each call is one command string, not
+`bash script.sh a b c`. Inventing `$1` from the chat would be silently wrong.
+
+## Contract (proposed)
+
+- **Source of truth is the session**, not the MCP JSON-RPC frame.
+- `set -- a b c` stores a session-scoped positional list (persist like
+  `export` / `cd` via the host env sidecar).
+- `$1`..`$n`, `$#`, `$*`, `"$@"` expand from that list. Unset list ⇒ empty
+  (`$#` = 0), not a crash.
+- `$0` is the string `fauxnix` (CLI) or the MCP tool name (`bash` by default).
+  Not the Windows executable path.
+- `shift` drops `$1`. `set --` with no words clears the list.
+- CLI one-shot `fauxnix "echo $1"` has empty positionals unless the command
+  itself runs `set --`.
+- No `FAUXNIX_ARGV` smuggling from the harness unless a later MCP tool
+  (`fauxnix_session`) is specified in a follow-up. Out of this RFC.
+
+## Non-goals
+
+- Real `bash script.sh args` invocation (no script file runner).
+- Functions’ local `$1` (functions are 1.0 wontfix).
+- `getopts`.
+- Version bump.
+
+## Tests (when implemented)
+
+- `set -- a b; echo $1 $#` → `a 2`
+- `set -- a b; echo "$@"` → `a b`
+- `set -- a 'x y'; echo "$2"` → `x y`
+- MCP: two tool calls; second `echo $1` still sees the first call’s `set --`
+  in the same session; `reset` clears it.
+
+## Ask
+
+Confirm `set --` as the only writer for v0.10. If a harness needs to inject
+argv, that is a new MCP tool, not a hidden env.

--- a/docs/rfc-redirect-fd-ownership.md
+++ b/docs/rfc-redirect-fd-ownership.md
@@ -10,9 +10,9 @@ focused implementation RFC the audit asked for.
 segment-level list. The executor then applies that list to the **whole**
 pipeline after capture.
 
-Two independently reproduced failures:
+Two independently reproduced failures (fixed in #147):
 
-| Command | bash | fauxnix today |
+| Command | bash | fauxnix before #147 |
 |---|---|---|
 | `echo hi >/dev/null` | no output | prints `hi` (`devNull` is set and never applied) |
 | `printf x \| cat < README.md \| head -1` | first line of README | `x` (`<` is fed to stage 0) |
@@ -21,6 +21,11 @@ A correct model is bash's: each pipeline stage owns its fds. A stdin redirect
 on a middle stage **replaces** the pipe, it does not move to the first stage.
 `>/dev/null` discards that stage's stdout; for a one-command segment that is
 the caller's stdout.
+
+#147 applied last-stage output and per-stage `<`. That made a previously
+accidental identity-pipe look wrong (`echo hi >f | cat` truncated `f` empty
+and printed `hi`). C-6 first slice (#157): **fail loud** at translate time
+for non-last `>` `>>` `&>` `&>>`. Full in-stage writes remain the follow-up.
 
 ## Contract
 
@@ -36,9 +41,11 @@ the caller's stdout.
 - Successive stdout redirects last-win: `>/dev/null >file` writes the command
   output to `file`; `>file >/dev/null` truncates `file` and discards output.
   `2>/dev/null` must not undo a prior `>/dev/null`.
-- Non-last-stage **stdout** redirects (`echo hi >f \| cat`) stay a documented
-  follow-up: they need the stage to write the file inside PowerShell instead of
-  the pipe. Not silent-wrong for the audit's two cases.
+- Non-last-stage **stdout** redirects (`echo hi >f \| cat`) **fail at
+  translate time** with an actionable alternative (`cmd >f; cat f` or wait
+  for per-stage fds). In-stage writes (the stage writes the file inside
+  PowerShell instead of the pipe) stay the #157 follow-up. `2>` on a
+  non-last stage is still silently wrong and is not rejected in this slice.
 
 ## Non-goals
 
@@ -53,3 +60,5 @@ the caller's stdout.
 - `cat missing.txt &>/dev/null` → empty stderr.
 - `printf x | cat < fruits.txt | head -1` → `apple`.
 - Existing `> >> 2>/dev/null 2>&1` and failed-`>` order tests stay green.
+- `echo hi >f | cat` → translate-time `FauxnixParseError` (C-6 first slice).
+- `echo hi >f` and last-stage `echo hi | cat >f` still write.

--- a/docs/rfc-template.md
+++ b/docs/rfc-template.md
@@ -1,0 +1,21 @@
+# RFC: one-line title
+
+Tracking: #NNN.
+
+## Why
+
+The gap, and why the current tree is silently wrong, fail-loud, or blocked.
+
+## Contract
+
+- Observable behavior after this lands.
+- What stays fail-loud / unchanged.
+
+## Non-goals
+
+Out of scope for this wave (and what would need its own RFC).
+
+## Tests
+
+Translate-time + real-PowerShell integration. Differential vs Git Bash
+when the claim is "same as bash."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fauxnix-cli",
-      "version": "0.9.3",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauxnix-cli",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "Fauxnix — run Linux-style commands on Windows via deterministic PowerShell translation. No VM, no WSL. MCP server + CLI for AI agents.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,10 +5,11 @@ import { translateCommandList } from './translator.js';
 import { listCommandsJson, registeredNames, specsMarkdown } from './registry.js';
 import { encodeCommand } from './encoding.js';
 import { startMcpServer } from './mcp.js';
+import { collectDoctorReport } from './doctor.js';
 import { packageVersion } from './version.js';
 import './commands/install-all.js';
 
-const USAGE = `fauxnix — run Linux-style commands on Windows via PowerShell translation
+export const USAGE = `fauxnix — run Linux-style commands on Windows via PowerShell translation
 
 Usage:
   fauxnix "ls -la | head -5"        translate + execute a bash-style command
@@ -19,6 +20,7 @@ Usage:
   fauxnix list --json                same list as machine-readable capability metadata
   fauxnix list --markdown            CommandSpec tables (same text as docs/command-specs.md)
   fauxnix check                      verify the local PowerShell environment
+  fauxnix doctor                     check + encoding, harness config, MCP readiness
   fauxnix --version
 
 Notes:
@@ -58,6 +60,11 @@ export async function runCli(argv: string[]): Promise<void> {
     return;
   }
 
+  if (verb === 'doctor') {
+    await runDoctor();
+    return;
+  }
+
   if (verb === 'mcp') {
     await startMcpServer();
     return;
@@ -88,6 +95,13 @@ export async function runCli(argv: string[]): Promise<void> {
 }
 
 const PS_ARGS = ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass'];
+
+async function runDoctor(): Promise<void> {
+  await runCheck();
+  const report = await collectDoctorReport();
+  for (const line of report.lines) console.log(line);
+  if (!report.ok) process.exitCode = 1;
+}
 
 async function runCheck(): Promise<void> {
   console.log('powershell : powershell.exe (Windows built-in)');

--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -2572,8 +2572,9 @@ function parseCutList(list: string): CutRange[] {
 const cut: Handler = (args) => {
   const { flags, longs, values, operandWords } = parseWords(args, ['d', 'f', 'c', 'b'], []);
   const complement = longs.has('--complement');
-  const charsMode = flags.has('c') || flags.has('b');
-  const fieldsMode = flags.has('f');
+  // -f/-c/-b are value-taking; parseWords records them in `values`, not `flags`.
+  const charsMode = values.has('-c') || values.has('-b');
+  const fieldsMode = values.has('-f');
   const suppress = flags.has('s');
 
   if (charsMode && fieldsMode) {
@@ -2826,8 +2827,68 @@ export const specs: CommandSpec[] = [
     usageExit: 2,
     handler: grep,
   },
+  {
+    names: ['sort'],
+    options: [
+      { short: 'r', long: '--reverse', support: 'implemented' },
+      { short: 'n', long: '--numeric-sort', support: 'implemented' },
+      { short: 'u', long: '--unique', support: 'implemented' },
+      { short: 'f', long: '--ignore-case', support: 'implemented' },
+      { short: 'b', long: '--ignore-leading-blanks', support: 'implemented' },
+      { short: 't', takesValue: true, support: 'implemented' },
+      { short: 'k', takesValue: true, support: 'implemented' },
+      { short: 'z', long: '--zero-terminated', support: 'unsupported', reason: 'NUL-terminated records' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    usageExit: 2,
+    handler: sort,
+  },
+  {
+    names: ['uniq'],
+    options: [
+      { short: 'c', support: 'implemented' },
+      { short: 'd', support: 'implemented' },
+      { short: 'u', support: 'implemented' },
+      { short: 'i', support: 'implemented' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: uniq,
+  },
+  {
+    names: ['cut'],
+    options: [
+      { short: 'd', takesValue: true, support: 'implemented' },
+      { short: 'f', takesValue: true, support: 'implemented' },
+      { short: 'c', takesValue: true, support: 'implemented' },
+      { short: 'b', takesValue: true, support: 'implemented' },
+      { short: 's', support: 'implemented' },
+      { long: '--complement', support: 'implemented' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: cut,
+  },
+  {
+    names: ['tr'],
+    options: [
+      { short: 'd', support: 'implemented' },
+      { short: 's', support: 'implemented' },
+      { short: 'c', long: '--complement', support: 'unsupported', reason: 'complement' },
+      { short: 'C', support: 'unsupported', reason: 'complement' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: tr,
+  },
 ];
 
+/** sed/awk stay unspec'd (custom script parsers). egrep injects -E and stays its own handler. */
 export const handlers: Record<string, Handler> = {
   egrep: (args, ctx) => grep([[{ kind: 'Text', text: '-E' }], ...args], ctx), // egrep = grep -E
   sed,

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,257 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export type DoctorOptions = {
+  home?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  nodeVersion?: string;
+  /** Injected MCP-module loader. Default: dynamic import of ./mcp.js (does not start the server). */
+  loadMcp?: () => Promise<unknown>;
+};
+
+export type DoctorReport = {
+  lines: string[];
+  ok: boolean;
+};
+
+const VALUE_INDENT = '             ';
+
+export async function collectDoctorReport(opts: DoctorOptions = {}): Promise<DoctorReport> {
+  const home = opts.home ?? homedir();
+  const cwd = opts.cwd ?? process.cwd();
+  const env = opts.env ?? process.env;
+  const nodeVersion = opts.nodeVersion ?? process.version;
+
+  const lines: string[] = [''];
+  lines.push(...encodingLines(env));
+  lines.push('');
+  lines.push(field('claude', detectClaude(home, cwd, env)));
+  lines.push(field('codex', detectCodex(home, env)));
+  lines.push(field('opencode', detectOpenCode(home, env)));
+  lines.push('');
+
+  const mcp = await mcpLines(nodeVersion, opts.loadMcp);
+  lines.push(...mcp.lines);
+  return { lines, ok: mcp.ok };
+}
+
+function field(label: string, value: string): string {
+  return `${label.padEnd(10)} : ${value}`;
+}
+
+function encodingLines(env: NodeJS.ProcessEnv): string[] {
+  const raw = env.FAUXNIX_NATIVE_ENCODING;
+  const current =
+    raw === undefined || raw === ''
+      ? 'unset → utf8 (default)'
+      : raw === 'ansi'
+        ? 'ansi → GBK-native admin tools'
+        : `${raw} → utf8 (only ansi selects GBK)`;
+  return [
+    field('encoding', 'UTF-8 default for native-tool pipelines'),
+    VALUE_INDENT + `current FAUXNIX_NATIVE_ENCODING=${current}`,
+    VALUE_INDENT + 'set FAUXNIX_NATIVE_ENCODING=ansi for GBK-native admin tools (ipconfig, tasklist)',
+  ];
+}
+
+function detectClaude(home: string, cwd: string, env: NodeJS.ProcessEnv): string {
+  const userPath = claudeUserConfigPath(home, env);
+  const projectPath = join(cwd, '.mcp.json');
+  const userExists = existsSync(userPath);
+  const projectExists = existsSync(projectPath);
+
+  let user: ReturnType<typeof inspectClaudeJson> | undefined;
+  let project: ReturnType<typeof inspectClaudeJson> | undefined;
+  if (userExists) user = inspectClaudeJson(userPath);
+  if (projectExists) {
+    const inspected = inspectClaudeJson(projectPath);
+    // Project-scope Claude MCP is always a top-level mcpServers object.
+    if (!inspected.parseError && inspected.hasTopLevelMcpServers) project = inspected;
+  }
+
+  if (!userExists && !project) return 'not detected — see README';
+
+  if (user?.hasFauxnix) return `fauxnix MCP configured (${userPath})`;
+  if (project?.hasFauxnix) return `fauxnix MCP configured (${projectPath})`;
+
+  if (userExists && user?.parseError) {
+    return `found ${userPath} (unreadable JSON) — see README`;
+  }
+  if (userExists) {
+    return `found ${userPath}, fauxnix MCP not listed — run: claude mcp add fauxnix -- fauxnix mcp`;
+  }
+  return `found ${projectPath}, fauxnix MCP not listed — see README`;
+}
+
+function claudeUserConfigPath(home: string, env: NodeJS.ProcessEnv): string {
+  const dir = env.CLAUDE_CONFIG_DIR?.trim();
+  if (dir) return join(dir, '.claude.json');
+  return join(home, '.claude.json');
+}
+
+function inspectClaudeJson(path: string): {
+  parseError: boolean;
+  hasTopLevelMcpServers: boolean;
+  hasFauxnix: boolean;
+} {
+  const text = readText(path);
+  if (text === undefined) {
+    return { parseError: true, hasTopLevelMcpServers: false, hasFauxnix: false };
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(stripBom(text));
+  } catch {
+    return { parseError: true, hasTopLevelMcpServers: false, hasFauxnix: false };
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return { parseError: true, hasTopLevelMcpServers: false, hasFauxnix: false };
+  }
+  const rec = data as Record<string, unknown>;
+  const hasTopLevelMcpServers = isServerMap(rec.mcpServers);
+  let hasFauxnix = hasTopLevelMcpServers && serverMapHasFauxnix(rec.mcpServers);
+  const projects = rec.projects;
+  if (projects && typeof projects === 'object' && !Array.isArray(projects)) {
+    for (const proj of Object.values(projects as Record<string, unknown>)) {
+      if (!proj || typeof proj !== 'object' || Array.isArray(proj)) continue;
+      const servers = (proj as Record<string, unknown>).mcpServers;
+      if (isServerMap(servers) && serverMapHasFauxnix(servers)) hasFauxnix = true;
+    }
+  }
+  return { parseError: false, hasTopLevelMcpServers, hasFauxnix };
+}
+
+function detectCodex(home: string, env: NodeJS.ProcessEnv): string {
+  const codexHome = env.CODEX_HOME?.trim() || join(home, '.codex');
+  const path = join(codexHome, 'config.toml');
+  if (!existsSync(path)) return 'not detected — see README';
+  const text = readText(path);
+  if (text === undefined) return `found ${path} (unreadable) — see README`;
+  if (hasCodexFauxnix(stripBom(text))) return `fauxnix MCP configured (${path})`;
+  return `found ${path}, fauxnix MCP not listed — run: codex mcp add fauxnix -- fauxnix mcp`;
+}
+
+function hasCodexFauxnix(text: string): boolean {
+  if (/^\s*\[mcp_servers\.(?:fauxnix|"fauxnix"|'fauxnix')\]/im.test(text)) return true;
+  const tables = text.split(/^\s*\[/m);
+  for (const table of tables) {
+    if (!/^mcp_servers\./i.test(table)) continue;
+    const header = (table.split(/[\]\r\n]/, 1)[0] ?? '').trim();
+    if (/^mcp_servers\.(?:fauxnix|"fauxnix"|'fauxnix')$/i.test(header)) return true;
+    const cmd = /^\s*command\s*=\s*(?:"([^"]*)"|'([^']*)')/im.exec(table);
+    const command = cmd?.[1] ?? cmd?.[2];
+    if (command && isFauxnixExecutable(command)) return true;
+    const args = /^\s*args\s*=\s*\[([^\]]*)\]/im.exec(table);
+    if (args) {
+      const items = [...args[1].matchAll(/"([^"]*)"|'([^']*)'/g)].map((m) => m[1] ?? m[2] ?? '');
+      if (items.some(isFauxnixExecutable)) return true;
+    }
+  }
+  return false;
+}
+
+function detectOpenCode(home: string, env: NodeJS.ProcessEnv): string {
+  const xdg = env.XDG_CONFIG_HOME?.trim() || join(home, '.config');
+  const path = join(xdg, 'opencode', 'opencode.json');
+  if (!existsSync(path)) return 'not detected — see README';
+  const text = readText(path);
+  if (text === undefined) return `found ${path} (unreadable) — see README`;
+  let data: unknown;
+  try {
+    data = JSON.parse(stripBom(text));
+  } catch {
+    return `found ${path} (unreadable JSON) — see README`;
+  }
+  if (hasOpenCodeFauxnix(data)) return `fauxnix MCP configured (${path})`;
+  return `found ${path}, fauxnix MCP not listed — add mcp.fauxnix (see README)`;
+}
+
+function hasOpenCodeFauxnix(data: unknown): boolean {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  const mcp = (data as Record<string, unknown>).mcp;
+  if (!isServerMap(mcp)) return false;
+  if (serverMapHasFauxnix(mcp)) return true;
+  const nested = (mcp as Record<string, unknown>).servers;
+  return isServerMap(nested) && serverMapHasFauxnix(nested);
+}
+
+function isServerMap(value: unknown): boolean {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function serverMapHasFauxnix(value: unknown): boolean {
+  if (!isServerMap(value)) return false;
+  for (const [name, cfg] of Object.entries(value as Record<string, unknown>)) {
+    if (name === 'servers') continue;
+    if (looksLikeFauxnixServer(name, cfg)) return true;
+  }
+  return false;
+}
+
+function looksLikeFauxnixServer(name: string, cfg: unknown): boolean {
+  if (/^fauxnix(-cli)?$/i.test(name)) return true;
+  if (!cfg || typeof cfg !== 'object' || Array.isArray(cfg)) return false;
+  const rec = cfg as Record<string, unknown>;
+  const chunks: string[] = [];
+  if (typeof rec.command === 'string') chunks.push(rec.command);
+  if (Array.isArray(rec.command)) {
+    for (const part of rec.command) if (typeof part === 'string') chunks.push(part);
+  }
+  if (Array.isArray(rec.args)) {
+    for (const part of rec.args) if (typeof part === 'string') chunks.push(part);
+  }
+  return chunks.some(isFauxnixExecutable);
+}
+
+function isFauxnixExecutable(s: string): boolean {
+  const base = s.replace(/\\/g, '/').split('/').pop()?.trim() ?? '';
+  return /^fauxnix(-cli)?(\.cmd|\.exe)?$/i.test(base);
+}
+
+async function mcpLines(
+  nodeVersion: string,
+  loadMcp?: () => Promise<unknown>,
+): Promise<{ lines: string[]; ok: boolean }> {
+  const major = nodeMajor(nodeVersion);
+  const nodeOk = major >= 18;
+  let moduleOk = false;
+  let moduleDetail = '';
+  try {
+    const mod = await (loadMcp ?? defaultLoadMcp)();
+    moduleOk =
+      !!mod && typeof (mod as { startMcpServer?: unknown }).startMcpServer === 'function';
+    if (!moduleOk) moduleDetail = 'startMcpServer export missing';
+  } catch (e) {
+    moduleDetail = e instanceof Error ? e.message : String(e);
+  }
+
+  const lines = [
+    field('node', `${nodeVersion.startsWith('v') ? nodeVersion : 'v' + nodeVersion}${nodeOk ? ' (>=18 required)' : '  FAILED (requires >=18)'}`),
+    field('mcp', moduleOk ? 'module loads' : `FAILED to load${moduleDetail ? ': ' + moduleDetail : ''}`),
+    VALUE_INDENT + 'start with: fauxnix mcp',
+  ];
+  return { lines, ok: nodeOk && moduleOk };
+}
+
+async function defaultLoadMcp(): Promise<unknown> {
+  return import('./mcp.js');
+}
+
+function nodeMajor(version: string): number {
+  const m = /^v?(\d+)/.exec(version);
+  return m ? Number(m[1]) : 0;
+}
+
+function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+function readText(path: string): string | undefined {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return undefined;
+  }
+}

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -897,9 +897,29 @@ function stdinReadExpr(target: string): string {
   return '@(fx-readlines ' + pathExpr(n) + ')';
 }
 
+/** `>` `>>` `&>` `&>>` — Node last-stage apply cannot honor these on earlier stages. */
+function isStdoutFileRedirect(op: Redirect['op']): boolean {
+  return op === '>' || op === '>>' || op === '&>' || op === '&>>';
+}
+
+const NONLAST_STDOUT_REDIRECT_MSG =
+  'fauxnix: stdout redirect on a non-last pipeline stage is not supported yet; write the file in a previous list segment (cmd >f; cat f) or wait for per-stage fds (#157)';
+
+function rejectNonLastStdoutRedirects(commands: ShellCommand[]): void {
+  if (commands.length < 2) return;
+  for (let i = 0; i < commands.length - 1; i++) {
+    if (commands[i].redirects.some((r) => isStdoutFileRedirect(r.op))) {
+      throw new FauxnixParseError(NONLAST_STDOUT_REDIRECT_MSG);
+    }
+  }
+}
+
 export function translatePipelineBody(p: {
   commands: Array<SimpleCommand | IfCommand | ForCommand>;
 }): PipelineParts {
+  // Last-stage `>` is Node apply; a non-last `>` would truncate the file and
+  // still feed the pipe. Fail loud until in-stage writes (#157).
+  rejectNonLastStdoutRedirects(p.commands);
   // Every pipeline stage needs its own status slot. Handlers deliberately use
   // `$script:fx_exit` because their helper functions run in child scopes; in a
   // pipeline that shared flag lets an earlier failure leak into a successful

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1,7 +1,6 @@
 import {
   Assignment,
   CommandList,
-  FauxnixParseError,
   Redirect,
   ShellCommand,
   SimpleCommand,
@@ -382,16 +381,11 @@ export function argListExpr(words: Word[], fn: (w: Word) => string = exprOfWord)
  * Unquoted command words join non-empty lines with a space (IFS
  * word-split approximation). Handlers often emit one string object, so
  * a bare `$(…)` interpolation would keep those newlines.
+ * Lists (`;` `&&` `||`) reuse translateListInline inside the fx-csub
+ * scriptblock so the newline contract is unchanged.
  */
 export function translateCmdSub(cmdText: string, keepNl = false): string {
-  const list = parseCommand(cmdText);
-  if (list.segments.length !== 1) {
-    throw new FauxnixParseError(
-      'fauxnix: command substitution with ; && || is not supported yet',
-    );
-  }
-  const { defs, call } = translatePipelineBody(list.segments[0].pipeline);
-  const inner = defs ? defs + '\n' + call : call;
+  const inner = translateListInline(parseCommand(cmdText));
   const collected = '(fx-csub { ' + inner + ' })';
   if (keepNl) return collected;
   return (
@@ -1191,7 +1185,16 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '  $script:fx_csub = $true',
       '  try { $fx_o = @(& $b | ForEach-Object { [string]$_ }) }',
       '  finally { $script:fx_csub = $fx_prevcs }',
-      '  $fx_s = ($fx_o -join [string][char]10)',
+      // Line items (no trailing NL) get a NL between them. Chunks that
+      // already end in NL concatenate, so $(echo a; echo b) is a\nb.
+      "  $fx_s = ''",
+      '  foreach ($fx_x in $fx_o) {',
+      '    $fx_t = [string]$fx_x',
+      '    if ($fx_s.Length -gt 0 -and $fx_s[$fx_s.Length - 1] -ne [char]10) {',
+      '      $fx_s += [string][char]10',
+      '    }',
+      '    $fx_s += $fx_t',
+      '  }',
       '  while ($fx_s.Length -gt 0 -and $fx_s[$fx_s.Length - 1] -eq [char]10) {',
       '    $fx_s = $fx_s.Substring(0, $fx_s.Length - 1)',
       '  }',

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1,6 +1,7 @@
 import {
   Assignment,
   CommandList,
+  FauxnixParseError,
   Redirect,
   ShellCommand,
   SimpleCommand,

--- a/test/differential.test.ts
+++ b/test/differential.test.ts
@@ -1,0 +1,54 @@
+/**
+ * RFC C-7 scaffold: curated fauxnix vs Git Bash identity.
+ *
+ * Default `npm test` imports this file and runs the corpus-shape check, then
+ * skipIf's the oracle unless FAUXNIX_DIFF_ORACLE is set and git-bash bash.exe
+ * exists. Missing Git Bash never fails CI.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  canRunOracle,
+  loadCorpus,
+  oracleSkipReason,
+  resolveGitBash,
+  runCorpus,
+  formatSummary,
+} from './differential/run.js';
+
+const corpus = loadCorpus();
+const skipOracle = !canRunOracle();
+const skipWhy = oracleSkipReason();
+
+describe('differential corpus scaffold (C-7 / #118)', () => {
+  it('loads the curated scaffold, not the 200-case 1.0 gate', () => {
+    expect(corpus.gate.targetCases).toBe(200);
+    expect(corpus.gate.identity).toBe(0.95);
+    expect(corpus.cases.length).toBeGreaterThanOrEqual(15);
+    expect(corpus.cases.length).toBeLessThanOrEqual(40);
+    const ids = corpus.cases.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(expect.arrayContaining([
+      'echo-dev-null',
+      'printf-grep-split',
+      'head-lines-neg',
+      'grep-e-or',
+    ]));
+    expect(corpus.files['three.txt']?.split('\n').filter(Boolean)).toHaveLength(3);
+    if (skipOracle) console.log(`differential oracle skipped: ${skipWhy}`);
+  });
+});
+
+describe.skipIf(skipOracle)('differential vs Git Bash oracle', { timeout: 180_000 }, () => {
+  it('identity is ≥95% of this small corpus', async () => {
+    const bashPath = resolveGitBash();
+    expect(bashPath).toBeTruthy();
+    const run = await runCorpus({ corpus, bashPath: bashPath! });
+    const summary = formatSummary(run);
+    console.log(summary);
+    expect(run.total).toBe(corpus.cases.length);
+    expect(
+      run.identity,
+      `${summary}\nidentity ${(run.identity * 100).toFixed(1)}% < ${(run.gate * 100).toFixed(0)}% gate`,
+    ).toBeGreaterThanOrEqual(run.gate);
+  });
+});

--- a/test/differential/README.md
+++ b/test/differential/README.md
@@ -1,0 +1,72 @@
+# Differential corpus (RFC C-7 scaffold)
+
+Institutional home for fauxnix vs Git Bash identity checks. Tracking:
+[RFC 1.0 C-7](../../docs/rfc-1.0-completeness-usability.md) / [#118](https://github.com/20000419/fauxnix/issues/118).
+
+## This is a scaffold, not the 1.0 gate
+
+The **1.0.0 hard gate** is:
+
+- ≥ **200** curated cases
+- ≥ **95%** byte-identical (stdout / stderr / exit, newlines normalized)
+- two consecutive green **scheduled** oracle runs
+
+`corpus.json` is a **high-value subset** (15–40 cases) sourced from already-shipped
+audit repros and integration tests (`echo hi >/dev/null`, `printf … | grep`,
+`head --lines=-1`, `grep -e a -e c`, …). It does **not** claim the 200-case gate.
+Grow it from benchmark transcripts, audit repros, and each merged completeness PR.
+
+A weekly GitHub Actions cron is **not** added here. The oracle is opt-in
+(`FAUXNIX_DIFF_ORACLE`) and Git Bash is **not** required on developer machines or
+assumed on GH Windows. Default `npm test` imports `test/differential.test.ts` and
+**skips** the comparison. A commented / `if: false` workflow would be worse than
+this note; add a scheduled job later only when it is skip-safe or the image
+explicitly provides the oracle.
+
+## Running the oracle
+
+Git Bash is optional. If `FAUXNIX_DIFF_ORACLE` is unset **or** `bash.exe` is
+missing, the runner skips (CI stays green).
+
+```powershell
+$env:FAUXNIX_DIFF_ORACLE = '1'
+npx vitest run test/differential.test.ts
+```
+
+Point the env at `bash.exe` when Git for Windows is not in a default location:
+
+```powershell
+$env:FAUXNIX_DIFF_ORACLE = 'C:\Program Files\Git\bin\bash.exe'
+npx vitest run test/differential.test.ts
+```
+
+Unset, empty, `0`, `false`, `no`, or `off` → skip. `bash.exe` missing → skip.
+
+## Adding a case
+
+1. Append an object to `cases` in [`corpus.json`](corpus.json). `id` must be unique.
+2. Cite the audit / PR / RFC in `source`.
+3. Put shared fixtures in `files` (written into a temp cwd). A case may add
+   its own `files` overlay.
+4. Keep the command self-contained; one fauxnix session runs the whole corpus.
+5. Prefer cases that already have integration coverage so identity is plausible.
+6. Stay under the 1.0 gate until you are deliberately growing toward 200.
+
+```json
+{
+  "id": "grep-e-or",
+  "cmd": "grep -e a -e c letters.txt",
+  "source": "#152"
+}
+```
+
+Do **not** add documented deviations (`uname -r`, `command -v echo`, `pwd` drive
+letters). The comparison is newline-normalized stdout + stderr + exit.
+
+## Runner contract
+
+[`../differential.test.ts`](../differential.test.ts) always sanity-checks this
+corpus (so CI imports the file). The oracle `describe` is `skipIf` when the env
+is unset or git-bash `bash.exe` is missing. When the oracle runs, each case goes
+through a fauxnix session **and** `bash.exe`; a summary is printed; the test
+fails if identity is below 95% of **this** small corpus.

--- a/test/differential/corpus.json
+++ b/test/differential/corpus.json
@@ -1,0 +1,215 @@
+{
+  "gate": {
+    "targetCases": 200,
+    "identity": 0.95,
+    "note": "RFC 1.0 C-7 / #118. The 1.0 hard gate is ≥200 curated cases at ≥95% byte-identical on scheduled oracle runs. This file is a high-value scaffold sourced from already-shipped audit repros, not that gate."
+  },
+  "files": {
+    "fruits.txt": "apple\nBanana\napple pie\ncherry\n",
+    "letters.txt": "a\nb\nc\n",
+    "three.txt": "one\ntwo\nthree\n",
+    "abc.txt": "abc"
+  },
+  "cases": [
+    {
+      "id": "echo-dev-null",
+      "cmd": "echo hi >/dev/null",
+      "source": "#147 / docs/rfc-redirect-fd-ownership.md"
+    },
+    {
+      "id": "printf-grep-split",
+      "cmd": "printf 'a\\nb\\n' | grep b",
+      "source": "#153"
+    },
+    {
+      "id": "head-lines-neg",
+      "cmd": "head --lines=-1 three.txt",
+      "source": "#151"
+    },
+    {
+      "id": "grep-e-or",
+      "cmd": "grep -e a -e c letters.txt",
+      "source": "#152"
+    },
+    {
+      "id": "middle-stdin-redirect",
+      "cmd": "printf x | cat < fruits.txt | head -1",
+      "source": "#147 / docs/rfc-redirect-fd-ownership.md"
+    },
+    {
+      "id": "lastwins-null-then-file",
+      "cmd": "echo hi >/dev/null > lastwins.txt; cat lastwins.txt",
+      "source": "#147"
+    },
+    {
+      "id": "stderr-to-null",
+      "cmd": "cat missing.txt 2>/dev/null; echo OK",
+      "source": "#147"
+    },
+    {
+      "id": "dup-then-null",
+      "cmd": "echo hi 2>&1 >/dev/null",
+      "source": "#164"
+    },
+    {
+      "id": "both-to-null",
+      "cmd": "cat missing.txt >/dev/null 2>&1; echo OK",
+      "source": "#164"
+    },
+    {
+      "id": "amp-null",
+      "cmd": "cat missing.txt &>/dev/null; echo OK",
+      "source": "#147"
+    },
+    {
+      "id": "pipe-last-true",
+      "cmd": "false | true",
+      "source": "#124"
+    },
+    {
+      "id": "pipe-last-false",
+      "cmd": "true | false",
+      "source": "#124"
+    },
+    {
+      "id": "pipe-and-after-empty",
+      "cmd": "grep NO fruits.txt | head -1 && echo AFTER",
+      "source": "#124"
+    },
+    {
+      "id": "pipe-or-last-fail",
+      "cmd": "true | false || echo FALLBACK",
+      "source": "#124"
+    },
+    {
+      "id": "grep-m1",
+      "cmd": "grep -m1 apple fruits.txt",
+      "source": "#141"
+    },
+    {
+      "id": "grep-v-or",
+      "cmd": "grep -v -e a -e c letters.txt",
+      "source": "#152"
+    },
+    {
+      "id": "grep-regexp-or",
+      "cmd": "grep --regexp a --regexp c letters.txt",
+      "source": "#152"
+    },
+    {
+      "id": "grep-Fo-multi-e",
+      "cmd": "printf 'ba\\n' | grep -F -o -e a -e b",
+      "source": "#162"
+    },
+    {
+      "id": "grep-match",
+      "cmd": "grep apple fruits.txt",
+      "source": "integration: grep + exit codes"
+    },
+    {
+      "id": "grep-nomatch",
+      "cmd": "grep zz fruits.txt",
+      "source": "integration: grep + exit codes"
+    },
+    {
+      "id": "head-1",
+      "cmd": "head -1 fruits.txt",
+      "source": "#141"
+    },
+    {
+      "id": "sed-sub",
+      "cmd": "sed 's/apple/MANGO/g' fruits.txt",
+      "source": "integration: sed substitution"
+    },
+    {
+      "id": "pipeline-grep-sort",
+      "cmd": "cat fruits.txt | grep -i apple | sort",
+      "source": "integration: cat | grep | sort"
+    },
+    {
+      "id": "head-bytes-neg",
+      "cmd": "head --bytes=-1 abc.txt",
+      "source": "#151"
+    },
+    {
+      "id": "head-bytes-2",
+      "cmd": "head --bytes=2 abc.txt",
+      "source": "#151"
+    },
+    {
+      "id": "bracket-file",
+      "cmd": "[[ -f fruits.txt ]] && echo yes",
+      "source": "#80"
+    },
+    {
+      "id": "echo-n",
+      "cmd": "echo -n abc",
+      "source": "integration: echo/printf semantics"
+    },
+    {
+      "id": "printf-fmt",
+      "cmd": "printf '%s=%d\\n' x 42",
+      "source": "integration: echo/printf semantics"
+    },
+    {
+      "id": "arith-add",
+      "cmd": "echo $((1+1))",
+      "source": "#119"
+    },
+    {
+      "id": "arith-mul-quoted",
+      "cmd": "echo \"$((2*3))\"",
+      "source": "#119"
+    },
+    {
+      "id": "arith-assign",
+      "cmd": "i=3; i=$((i+1)); echo $i",
+      "source": "#119"
+    },
+    {
+      "id": "if-true",
+      "cmd": "if true; then echo YES; fi",
+      "source": "#112"
+    },
+    {
+      "id": "elif-true",
+      "cmd": "if false; then echo A; elif true; then echo B; else echo C; fi",
+      "source": "#120"
+    },
+    {
+      "id": "for-words",
+      "cmd": "for x in a b c; do echo $x; done",
+      "source": "#112"
+    },
+    {
+      "id": "status-false",
+      "cmd": "false; echo $?",
+      "source": "integration: $? reflects the previous segment"
+    },
+    {
+      "id": "param-default",
+      "cmd": "unset X; echo ${X:-def}",
+      "source": "#112"
+    },
+    {
+      "id": "strlen",
+      "cmd": "X=abcd; echo ${#X}",
+      "source": "#112"
+    },
+    {
+      "id": "cmdsub",
+      "cmd": "echo $(echo nested)",
+      "source": "#112"
+    },
+    {
+      "id": "or-fallback",
+      "cmd": "cat missing.txt || echo FELLBACK",
+      "source": "integration: && and || short-circuit"
+    },
+    {
+      "id": "echo-pipe-grep",
+      "cmd": "echo hi | grep hi",
+      "source": "#153"
+    }
+  ]
+}

--- a/test/differential/run.ts
+++ b/test/differential/run.ts
@@ -1,0 +1,245 @@
+/**
+ * C-7 differential runner: fauxnix session vs Git Bash.
+ * Opt-in via FAUXNIX_DIFF_ORACLE; skips when the env is unset or bash.exe is missing.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseCommand } from '../../src/parser.js';
+import { translateCommandList } from '../../src/translator.js';
+import { FauxnixSession } from '../../src/executor.js';
+import '../../src/commands/install-all.js';
+
+export interface CorpusCase {
+  id: string;
+  cmd: string;
+  source?: string;
+  files?: Record<string, string>;
+}
+
+export interface Corpus {
+  gate: { targetCases: number; identity: number; note: string };
+  files: Record<string, string>;
+  cases: CorpusCase[];
+}
+
+export interface Streams {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface CaseResult {
+  id: string;
+  cmd: string;
+  identical: boolean;
+  fauxnix: Streams;
+  bash: Streams;
+  error?: string;
+}
+
+export interface CorpusRun {
+  total: number;
+  identical: number;
+  identity: number;
+  gate: number;
+  bashPath: string;
+  results: CaseResult[];
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+export const CORPUS_PATH = join(here, 'corpus.json');
+
+export function loadCorpus(path = CORPUS_PATH): Corpus {
+  return JSON.parse(readFileSync(path, 'utf8')) as Corpus;
+}
+
+/** True when the caller asked for the Git Bash oracle (any truthy value except 0/false/no/off). */
+export function isOracleRequested(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.FAUXNIX_DIFF_ORACLE;
+  if (raw == null) return false;
+  const v = raw.trim();
+  if (v === '') return false;
+  return !/^(0|false|no|off)$/i.test(v);
+}
+
+function gitBashCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
+  const pf = env.ProgramFiles || env.PROGRAMFILES || 'C:\\Program Files';
+  const pf86 = env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
+  const local = env.LOCALAPPDATA || '';
+  return [
+    join(pf, 'Git', 'bin', 'bash.exe'),
+    join(pf, 'Git', 'usr', 'bin', 'bash.exe'),
+    join(pf86, 'Git', 'bin', 'bash.exe'),
+    local ? join(local, 'Programs', 'Git', 'bin', 'bash.exe') : '',
+  ].filter(Boolean);
+}
+
+/**
+ * Resolve git-bash `bash.exe`. If FAUXNIX_DIFF_ORACLE is a path to an existing
+ * executable, that wins; otherwise the usual Git for Windows locations.
+ */
+export function resolveGitBash(env: NodeJS.ProcessEnv = process.env): string | null {
+  const raw = env.FAUXNIX_DIFF_ORACLE?.trim();
+  if (raw && existsSync(raw) && /bash(\.exe)?$/i.test(raw)) return raw;
+  for (const p of gitBashCandidates(env)) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+export function hasPowerShell(): boolean {
+  if (process.platform !== 'win32') return false;
+  return spawnSync('powershell.exe', ['-NoProfile', '-Command', 'exit 0'], { shell: false }).status === 0;
+}
+
+/** Oracle runs only when requested *and* git-bash bash.exe is present (and we can execute). */
+export function canRunOracle(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isOracleRequested(env) && resolveGitBash(env) !== null && hasPowerShell();
+}
+
+export function oracleSkipReason(env: NodeJS.ProcessEnv = process.env): string | null {
+  if (!isOracleRequested(env)) {
+    return 'FAUXNIX_DIFF_ORACLE is unset; Git Bash is not required on developer machines';
+  }
+  if (resolveGitBash(env) === null) {
+    return 'FAUXNIX_DIFF_ORACLE is set but git-bash bash.exe was not found';
+  }
+  if (!hasPowerShell()) {
+    return 'PowerShell is unavailable; fauxnix execution is Windows-only';
+  }
+  return null;
+}
+
+export function normalizeNewlines(s: string): string {
+  return s.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+export function sameIdentity(a: Streams, b: Streams): boolean {
+  return (
+    normalizeNewlines(a.stdout) === normalizeNewlines(b.stdout) &&
+    normalizeNewlines(a.stderr) === normalizeNewlines(b.stderr) &&
+    a.exitCode === b.exitCode
+  );
+}
+
+function writeTree(root: string, files: Record<string, string>): void {
+  for (const [rel, body] of Object.entries(files)) {
+    const dest = join(root, rel);
+    mkdirSync(dirname(dest), { recursive: true });
+    writeFileSync(dest, body, 'utf8');
+  }
+}
+
+function bashEnv(bashPath: string): NodeJS.ProcessEnv {
+  const gitRoot = dirname(dirname(bashPath));
+  const extra = [join(gitRoot, 'usr', 'bin'), dirname(bashPath)];
+  const pathKey = Object.keys(process.env).find((k) => k.toLowerCase() === 'path') ?? 'PATH';
+  return {
+    ...process.env,
+    [pathKey]: [...extra, process.env[pathKey] ?? ''].join(';'),
+    LANG: 'C',
+    LC_ALL: 'C',
+  };
+}
+
+function runBash(bashPath: string, cwd: string, cmd: string): Streams {
+  const r = spawnSync(bashPath, ['--noprofile', '--norc', '-c', cmd], {
+    cwd,
+    env: bashEnv(bashPath),
+    encoding: 'utf8',
+    shell: false,
+    windowsHide: true,
+    timeout: 30_000,
+  });
+  if (r.error) {
+    return { stdout: '', stderr: r.error.message, exitCode: 127 };
+  }
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    exitCode: r.status ?? 1,
+  };
+}
+
+function inspect(s: string): string {
+  const n = normalizeNewlines(s);
+  if (n.length <= 120) return JSON.stringify(n);
+  return JSON.stringify(n.slice(0, 117) + '...');
+}
+
+export function formatSummary(run: CorpusRun): string {
+  const pct = (run.identity * 100).toFixed(1);
+  const lines = [
+    `differential: ${run.identical}/${run.total} identical (${pct}%) vs ${run.bashPath}`,
+    `gate for this corpus: ≥${(run.gate * 100).toFixed(0)}%  |  1.0 gate: ≥200 cases at ≥95% (not this scaffold)`,
+  ];
+  const mismatches = run.results.filter((r) => !r.identical);
+  for (const m of mismatches) {
+    lines.push(`  FAIL ${m.id}: ${m.cmd}`);
+    if (m.error) lines.push(`        error: ${m.error}`);
+    if (normalizeNewlines(m.fauxnix.stdout) !== normalizeNewlines(m.bash.stdout)) {
+      lines.push(`        stdout fauxnix=${inspect(m.fauxnix.stdout)} bash=${inspect(m.bash.stdout)}`);
+    }
+    if (normalizeNewlines(m.fauxnix.stderr) !== normalizeNewlines(m.bash.stderr)) {
+      lines.push(`        stderr fauxnix=${inspect(m.fauxnix.stderr)} bash=${inspect(m.bash.stderr)}`);
+    }
+    if (m.fauxnix.exitCode !== m.bash.exitCode) {
+      lines.push(`        exit  fauxnix=${m.fauxnix.exitCode} bash=${m.bash.exitCode}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export async function runCorpus(opts: {
+  corpus?: Corpus;
+  bashPath: string;
+}): Promise<CorpusRun> {
+  const corpus = opts.corpus ?? loadCorpus();
+  const dir = mkdtempSync(join(tmpdir(), 'fauxnix-diff-'));
+  const session = new FauxnixSession();
+  const results: CaseResult[] = [];
+  try {
+    writeTree(dir, corpus.files ?? {});
+    await session.prewarm();
+    await session.run(translateCommandList(parseCommand('cd "' + dir + '"')));
+
+    for (const c of corpus.cases) {
+      if (c.files) writeTree(dir, c.files);
+      let fauxnix: Streams;
+      let error: string | undefined;
+      try {
+        const r = await session.run(translateCommandList(parseCommand(c.cmd)));
+        fauxnix = { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode };
+      } catch (e) {
+        error = e instanceof Error ? e.message : String(e);
+        fauxnix = { stdout: '', stderr: error, exitCode: 2 };
+      }
+      const bash = runBash(opts.bashPath, dir, c.cmd);
+      results.push({
+        id: c.id,
+        cmd: c.cmd,
+        identical: !error && sameIdentity(fauxnix, bash),
+        fauxnix,
+        bash,
+        error,
+      });
+    }
+  } finally {
+    await session.dispose();
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  const identical = results.filter((r) => r.identical).length;
+  const total = results.length;
+  return {
+    total,
+    identical,
+    identity: total === 0 ? 1 : identical / total,
+    gate: corpus.gate.identity,
+    bashPath: opts.bashPath,
+    results,
+  };
+}

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -746,6 +746,11 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run("echo \"[$(printf 'a\\n')]\"")).stdout).toBe('[a]\n');
     // Unquoted $(...) approximates IFS split (PS space-join), matching pre-#88.
     expect((await run("echo $(printf 'a\\nb')")).stdout.trim()).toBe('a b');
+    // C-4: list inside $(...) — unquoted IFS-joins; quoted keeps the newline.
+    expect((await run('echo $(echo a; echo b)')).stdout.trim()).toBe('a b');
+    expect((await run('echo "$(echo a; echo b)"')).stdout).toBe('a\nb\n');
+    expect((await run('echo $(false; echo x)')).stdout.trim()).toBe('x');
+    expect((await run('echo $(true && echo y)')).stdout.trim()).toBe('y');
   });
 
   it('VAR=value prefixes do not leak past the command', async () => {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -216,6 +216,27 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     const r = await run('sort dups.txt | uniq -c');
     expect(r.stdout).toMatch(/2 aaa/);
     expect(r.stdout).toMatch(/1 bbb/);
+    expect((await run("printf '10\\n2\\n1\\n' | sort -n")).stdout.trim().split(/\r?\n/)).toEqual([
+      '1',
+      '2',
+      '10',
+    ]);
+  });
+
+  it('cut -d -f and tr -d still work', async () => {
+    expect((await run("cut -d ' ' -f1 nums.txt")).stdout.trim().split(/\r?\n/)).toEqual([
+      '1',
+      '3',
+      '5',
+    ]);
+    expect((await run('printf abc | tr -d b')).stdout.trim()).toBe('ac');
+  });
+
+  it('sort -z is unsupported', async () => {
+    const r = await run('sort -z dups.txt');
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("option '-z' is not supported by fauxnix");
+    expect(r.stdout).toBe('');
   });
 
   it('head/tail/wc', async () => {

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -369,6 +369,21 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(r.stdout.trim()).toBe('apple');
   });
 
+  it('rejects stdout redirect on a non-last pipeline stage', () => {
+    expect(() => translateCommandList(parseCommand('echo hi >f | cat'))).toThrow(
+      'fauxnix: stdout redirect on a non-last pipeline stage is not supported yet; write the file in a previous list segment (cmd >f; cat f) or wait for per-stage fds (#157)',
+    );
+  });
+
+  it('last-stage stdout redirect still writes', async () => {
+    const r = await run('echo hi | cat > lastpipe.txt');
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(join(dir, 'lastpipe.txt'), 'utf8').trim()).toBe('hi');
+    const single = await run('echo hi > singleout.txt');
+    expect(single.exitCode).toBe(0);
+    expect(readFileSync(join(dir, 'singleout.txt'), 'utf8').trim()).toBe('hi');
+  });
+
   it(
     '[[ ]] file and string tests, including =~',
     async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,5 +1,10 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { runCli, USAGE } from '../src/cli.js';
+import { collectDoctorReport } from '../src/doctor.js';
 import { FauxnixParseError, isUnquotedLiteral, wordToString } from '../src/ast.js';
 import { parseCommand as parse, tokenize } from '../src/parser.js';
 import {
@@ -1270,5 +1275,217 @@ describe('cli check spawn error', () => {
     expect(check).toContain("probe.on('error'");
     expect(check).toMatch(/FAILED to run powershell\.exe:.*e\.message/);
     expect(check).toContain('process.exit(1)');
+  });
+});
+
+describe('cli doctor', () => {
+  it('USAGE lists doctor', async () => {
+    expect(USAGE).toMatch(/fauxnix doctor/);
+    const src = readFileSync('src/cli.ts', 'utf8');
+    expect(src).toContain("verb === 'doctor'");
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(' '));
+    };
+    try {
+      await runCli([]);
+    } finally {
+      console.log = orig;
+    }
+    expect(lines.join('\n')).toContain('fauxnix doctor');
+  });
+
+  it('collectDoctorReport does not throw when no harness configs exist', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-doctor-'));
+    try {
+      const report = await collectDoctorReport({
+        home: dir,
+        cwd: dir,
+        env: {},
+        nodeVersion: 'v20.11.0',
+      });
+      const text = report.lines.join('\n');
+      expect(text).toContain('UTF-8 default');
+      expect(text).toContain('FAUXNIX_NATIVE_ENCODING=unset → utf8 (default)');
+      expect(text).toMatch(/claude\s+: not detected — see README/);
+      expect(text).toMatch(/codex\s+: not detected — see README/);
+      expect(text).toMatch(/opencode\s+: not detected — see README/);
+      expect(text).toContain('start with: fauxnix mcp');
+      expect(text).toContain('module loads');
+      expect(text).toContain('v20.11.0');
+      expect(report.ok).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports encoding override and Node/MCP failures', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-doctor-'));
+    try {
+      const ansi = await collectDoctorReport({
+        home: dir,
+        cwd: dir,
+        env: { FAUXNIX_NATIVE_ENCODING: 'ansi' },
+        nodeVersion: 'v22.0.0',
+      });
+      expect(ansi.lines.join('\n')).toContain('ansi → GBK-native admin tools');
+      expect(ansi.ok).toBe(true);
+
+      const oldNode = await collectDoctorReport({
+        home: dir,
+        cwd: dir,
+        env: {},
+        nodeVersion: 'v16.20.0',
+        loadMcp: async () => ({ startMcpServer: async () => {} }),
+      });
+      expect(oldNode.ok).toBe(false);
+      expect(oldNode.lines.join('\n')).toContain('FAILED (requires >=18)');
+
+      const badMcp = await collectDoctorReport({
+        home: dir,
+        cwd: dir,
+        env: {},
+        nodeVersion: 'v20.0.0',
+        loadMcp: async () => {
+          throw new Error('boom');
+        },
+      });
+      expect(badMcp.ok).toBe(false);
+      expect(badMcp.lines.join('\n')).toContain('FAILED to load: boom');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('detects harness configs conservatively', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-doctor-'));
+    try {
+      const empty = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(empty.lines.join('\n')).toMatch(/claude\s+: not detected — see README/);
+
+      writeFileSync(
+        join(dir, '.claude.json'),
+        JSON.stringify({
+          notes: 'I cloned fauxnix',
+          projects: { 'C:\\repos\\fauxnix': { allowedTools: ['Bash'] } },
+        }),
+      );
+      const mention = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(mention.lines.join('\n')).toContain('fauxnix MCP not listed');
+      expect(mention.lines.join('\n')).not.toContain('fauxnix MCP configured');
+
+      writeFileSync(
+        join(dir, '.claude.json'),
+        JSON.stringify({
+          projects: {
+            'C:\\work\\app': { mcpServers: { fauxnix: { command: 'fauxnix', args: ['mcp'] } } },
+          },
+        }),
+      );
+      const claudeLocal = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(claudeLocal.lines.join('\n')).toMatch(/claude\s+: fauxnix MCP configured/);
+
+      writeFileSync(
+        join(dir, '.claude.json'),
+        JSON.stringify({ mcpServers: { fauxnix: { command: 'fauxnix', args: ['mcp'] } } }),
+      );
+      const claude = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(claude.lines.join('\n')).toMatch(/claude\s+: fauxnix MCP configured/);
+
+      const homeDir = join(dir, 'home');
+      const cwdDir = join(dir, 'cwd');
+      mkdirSync(homeDir);
+      mkdirSync(cwdDir);
+      writeFileSync(
+        join(cwdDir, '.claude.json'),
+        JSON.stringify({ mcpServers: { fauxnix: { command: 'fauxnix', args: ['mcp'] } } }),
+      );
+      const cwdClaude = await collectDoctorReport({
+        home: homeDir,
+        cwd: cwdDir,
+        env: {},
+        nodeVersion: 'v20.0.0',
+      });
+      expect(cwdClaude.lines.join('\n')).toMatch(/claude\s+: not detected — see README/);
+
+      rmSync(join(dir, '.claude.json'));
+      writeFileSync(
+        join(dir, '.mcp.json'),
+        JSON.stringify({ mcpServers: { fauxnix: { command: 'fauxnix', args: ['mcp'] } } }),
+      );
+      const project = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(project.lines.join('\n')).toMatch(/claude\s+: fauxnix MCP configured/);
+      expect(project.lines.join('\n')).toContain('.mcp.json');
+
+      writeFileSync(join(dir, '.mcp.json'), JSON.stringify({ name: 'unrelated', fauxnix: true }));
+      const unrelatedMcp = await collectDoctorReport({
+        home: dir,
+        cwd: dir,
+        env: {},
+        nodeVersion: 'v20.0.0',
+      });
+      expect(unrelatedMcp.lines.join('\n')).toMatch(/claude\s+: not detected — see README/);
+
+      mkdirSync(join(dir, '.codex'));
+      writeFileSync(join(dir, '.codex', 'config.toml'), '[model]\nmodel = "gpt-5"\n');
+      const codexBare = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(codexBare.lines.join('\n')).toContain('codex mcp add fauxnix');
+
+      writeFileSync(
+        join(dir, '.codex', 'config.toml'),
+        '[mcp_servers.fauxnix]\ncommand = "fauxnix"\nargs = ["mcp"]\n',
+      );
+      const codex = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(codex.lines.join('\n')).toMatch(/codex\s+: fauxnix MCP configured/);
+
+      mkdirSync(join(dir, '.config', 'opencode'), { recursive: true });
+      writeFileSync(
+        join(dir, '.config', 'opencode', 'opencode.json'),
+        JSON.stringify({ mcp: { fauxnix: { type: 'local', command: ['fauxnix', 'mcp'] } } }),
+      );
+      const opencode = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(opencode.lines.join('\n')).toMatch(/opencode\s+: fauxnix MCP configured/);
+
+      writeFileSync(
+        join(dir, '.config', 'opencode', 'opencode.json'),
+        JSON.stringify({
+          mcp: { servers: { fauxnix: { type: 'local', command: ['fauxnix', 'mcp'] } } },
+        }),
+      );
+      const opencodeV2 = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(opencodeV2.lines.join('\n')).toMatch(/opencode\s+: fauxnix MCP configured/);
+
+      rmSync(join(dir, '.config'), { recursive: true, force: true });
+      writeFileSync(
+        join(dir, 'opencode.json'),
+        JSON.stringify({ mcp: { fauxnix: { type: 'local', command: ['fauxnix', 'mcp'] } } }),
+      );
+      const cwdOnly = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
+      expect(cwdOnly.lines.join('\n')).toMatch(/opencode\s+: not detected — see README/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe.skipIf(process.platform !== 'win32')('cli doctor spawn', () => {
+  it('node src/index.ts doctor does not throw', () => {
+    const tsx = join(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs');
+    expect(existsSync(tsx)).toBe(true);
+    const r = spawnSync(process.execPath, [tsx, 'src/index.ts', 'doctor'], {
+      encoding: 'utf8',
+      timeout: 30000,
+      env: process.env,
+    });
+    expect(r.error).toBeUndefined();
+    expect(r.stdout).toContain('powershell');
+    expect(r.stdout).toContain('encoding');
+    expect(r.stdout).toContain('FAUXNIX_NATIVE_ENCODING');
+    expect(r.stdout).toContain('start with: fauxnix mcp');
+    expect(r.stdout).toMatch(/claude\s+:/);
+    expect(r.stdout).toMatch(/codex\s+:/);
+    expect(r.stdout).toMatch(/opencode\s+:/);
+    expect(r.status).toBe(0);
   });
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -667,6 +667,33 @@ describe('translator', () => {
     expect(plan.body).not.toContain('fx-readlines $env:FAUXNIX_STDIN_FILE');
   });
 
+  it('rejects stdout redirect on a non-last pipeline stage', () => {
+    const msg =
+      'fauxnix: stdout redirect on a non-last pipeline stage is not supported yet; write the file in a previous list segment (cmd >f; cat f) or wait for per-stage fds (#157)';
+    const bad = [
+      'echo hi >f | cat',
+      'echo hi >>f | cat',
+      'echo hi &>f | cat',
+      'echo hi &>>f | cat',
+      'echo hi >/dev/null | cat',
+      'echo hi | cat >mid | wc -l',
+    ];
+    for (const cmd of bad) {
+      expect(() => translateCommandList(parse(cmd)), cmd).toThrow(FauxnixParseError);
+      expect(() => translateCommandList(parse(cmd)), cmd).toThrow(msg);
+    }
+  });
+
+  it('allows last-stage stdout redirect and does not reject 2> on a non-last stage', () => {
+    const single = translateCommandList(parse('echo hi >f'))[0];
+    expect(single.outputRedirects).toEqual([{ op: '>', target: 'f' }]);
+    const disc = translateCommandList(parse('echo hi >/dev/null'))[0];
+    expect(disc.outputRedirects).toEqual([{ op: '>', target: '/dev/null' }]);
+    const last = translateCommandList(parse('echo hi | cat >f'))[0];
+    expect(last.outputRedirects).toEqual([{ op: '>', target: 'f' }]);
+    expect(() => translateCommandList(parse('echo hi 2>e | cat'))).not.toThrow();
+  });
+
   it('uses functions for multi-stage pipelines (PS 5.1 rule)', () => {
     const plan = translateCommandList(parse('a | b | c'))[0];
     expect(plan.script).toMatch(/function __fx_s\d+/);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1137,6 +1137,75 @@ describe('CommandSpec text-io leftovers (#143)', () => {
   });
 });
 
+describe('CommandSpec text-filters leftovers (#143)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+
+  it('sort/uniq/cut/tr are spec\'d; sed/awk/egrep stay unspec\'d', () => {
+    expect(lookupSpec('sort')).toBeTruthy();
+    expect(lookupSpec('uniq')).toBeTruthy();
+    expect(lookupSpec('cut')).toBeTruthy();
+    expect(lookupSpec('tr')).toBeTruthy();
+    expect(lookupSpec('sed')).toBeUndefined();
+    expect(lookupSpec('awk')).toBeUndefined();
+    expect(lookupSpec('egrep')).toBeUndefined();
+    expect(lookupSpec('find')).toBeUndefined();
+  });
+
+  it('sort -z is unsupported; unknown flags fail usage', () => {
+    const z = bodyOf('sort -z');
+    expect(z).toContain("option ''-z'' is not supported by fauxnix");
+    expect(z).toContain('NUL-terminated records');
+    expect(z).toContain('$script:fx_exit = 2');
+    expect(z).toContain("Try ''sort --help'' for more information.");
+    expect(z).not.toContain('[array]::Sort');
+    const unknown = bodyOf('sort -Q');
+    expect(unknown).toContain("invalid option -- ''Q''");
+    expect(unknown).not.toContain('[array]::Sort');
+  });
+
+  it('implemented sort -n/-r/-k and longs still compile', () => {
+    expect(bodyOf('sort -n f')).toContain('fx-numkey');
+    expect(bodyOf('sort -n f')).not.toContain('invalid option');
+    expect(bodyOf('sort --numeric-sort f')).toContain('fx-numkey');
+    expect(bodyOf('sort -r f')).toContain('[array]::Reverse');
+    expect(bodyOf('sort --reverse f')).toContain('[array]::Reverse');
+    expect(bodyOf('sort -k 2 f')).toContain('fx-keyof');
+    expect(bodyOf('sort -nr f')).toContain('fx-numkey');
+  });
+
+  it('uniq -c/-d/-u/-i still compile; unknown flags fail', () => {
+    expect(bodyOf('uniq -c f')).toContain("'{0,7} {1}'");
+    expect(bodyOf('uniq -c f')).not.toContain('invalid option');
+    expect(bodyOf('uniq -d f')).toContain('if ($c -gt 1)');
+    expect(bodyOf('uniq -u f')).toContain('if ($c -eq 1)');
+    expect(bodyOf('uniq -i f')).toContain('.ToLower()');
+    expect(bodyOf('uniq -z f')).toContain("invalid option -- ''z''");
+    expect(bodyOf('uniq -z f')).not.toContain('fx-uemit');
+  });
+
+  it('cut -d -f / -c still compile; unknown flags fail', () => {
+    const fields = bodyOf("cut -d, -f1 f");
+    expect(fields).toContain('.Split([char]44)');
+    expect(fields).not.toContain('invalid option');
+    expect(bodyOf('cut -c1-2 f')).toContain('.ToCharArray()');
+    expect(bodyOf('cut --complement -f1 f')).toContain('-not (');
+    expect(bodyOf('cut -z -f1 f')).toContain("invalid option -- ''z''");
+    expect(bodyOf('cut -z -f1 f')).not.toContain('.Split');
+  });
+
+  it('tr -d/-s still compile; -c is unsupported', () => {
+    const del = bodyOf('tr -d a');
+    expect(del).toContain('$fx_dl.ContainsKey');
+    expect(del).not.toContain('invalid option');
+    expect(bodyOf('tr -s a')).toContain('$fx_sq.ContainsKey');
+    const complement = bodyOf('tr -c a b');
+    expect(complement).toContain("option ''-c'' is not supported by fauxnix");
+    expect(complement).toContain('complement');
+    expect(complement).not.toContain('$fx_map');
+    expect(bodyOf('tr --complement a b')).toContain('not supported by fauxnix');
+  });
+});
+
 describe('find predicates (#130)', () => {
   const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
   const throws = (cmd: string, msg: string) => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -90,6 +90,26 @@ describe('parser', () => {
     expect(exprOfWord(a.assignments[0].value, { preserveCmdSub: true })).not.toContain("-join ' '");
   });
 
+  it('translates multi-segment command substitution (C-4)', () => {
+    expect(() => translateCommandList(parse('echo $(echo a; echo b)'))).not.toThrow();
+    const body = translateCommandList(parse('echo $(echo a; echo b)'))[0].body;
+    expect(body).toContain('fx-csub');
+    expect(body).toContain("'a'");
+    expect(body).toContain("'b'");
+    expect(body).toContain('-split [string][char]10');
+    const quoted = exprOfWord(
+      parse('echo "$(echo a; echo b)"').segments[0].pipeline.commands[0].args[0],
+    );
+    expect(quoted).toContain('fx-csub');
+    expect(quoted).toContain("'a'");
+    expect(quoted).toContain("'b'");
+    expect(quoted).not.toContain('-split [string][char]10');
+    const andBody = translateCommandList(parse('echo $(true && echo y)'))[0].body;
+    expect(andBody).toContain('fx-csub');
+    expect(andBody).toContain('if ($script:fx_exit -eq 0)');
+    expect(andBody).toContain("'y'");
+  });
+
   it('set -e is a loud usage error, not a silent no-op', () => {
     const script = translateCommandList(parse('set -e'))[0].script;
     expect(script).toMatch(/set -e\/-u\/-x is not supported/);


### PR DESCRIPTION
Integration of the first roadmap-v2 wave (#172-#179, by r3wretrhy — the roadmap was claimed within hours of #171).

**Maintainer verification on the integrated tree:**
- C-4: `echo $(echo a; echo b)` → `a b` (newline contract preserved)
- #175: non-last stdout redirect rejects loudly with the #157 workaround in the message
- #177: `sort -Z` → GNU usage error, exit 2
- **U-2 doctor verified against real machine state**: detected my actual Claude/Codex configs as configured and OpenCode as present-but-unconfigured, with fix hints — this is the five-minute-value demo
- **C-7 scaffold live**: `FAUXNIX_DIFF_ORACLE=1 npx vitest run` runs the Git-Bash differential corpus (25 seeds, >=95% identity gate asserted) — full suite with oracle: **271/271**
- T-1 SECURITY.md reviewed: trust model ("same trust decision as giving the agent a Bash tool"), host protocol surface, kill semantics, network guard — accurate to the implementation
- C-3 mini-RFC: maintainer position posted on #118 (accept `set --` as the only writer)

One integration fix: missing FauxnixParseError import in translator (#175 follow-up) — caught by typecheck, added.

Closes #172, closes #173, closes #174, closes #175, closes #176, closes #177, closes #178, closes #179.
