### PR TITLE
feat: while/until loops (RFC 1.0 C-1 slice)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,12 +213,12 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`,
+- `tail -f`, `eval`, `alias`, heredocs, `case`,
   `env -i`/`--ignore-environment`,
   background `&`, and stdout redirects (`>` `>>` `&>` `&>>`) on a non-last
   pipeline stage (`echo hi >f | cat`) are rejected with actionable error
   messages instead of misbehaving.
-  (`if/then/elif/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
+  (`if/then/elif/else/fi`, `for x in ...`, `while`/`until`, backtick substitution, `command -v`, pipeline `read`,
   dotenv-style `source`, and word-level `$((...))` arithmetic expansion are supported.)
 - `command -v <builtin>` prints `/usr/bin/<name>` where bash prints the bare builtin name;
   exit codes and empty-result semantics match.

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -10,9 +10,10 @@
  *   - command substitution: $(...) and `...` (recursively translated)
  *   - arithmetic expansion: $((...)) (existing fx-arith engine)
  *   - env assignment prefix: VAR=value cmd
+ *   - control:              if/then/elif/else/fi, for-in, while/until
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
- *   heredocs, subshells (...), background &, while/until/case,
+ *   heredocs, subshells (...), background &, case,
  *   globs inside quotes, process substitution <(...).
  */
 
@@ -28,7 +29,7 @@ export interface ListSegment {
   op: ';' | '&&' | '||';
 }
 
-export type ShellCommand = SimpleCommand | IfCommand | ForCommand;
+export type ShellCommand = SimpleCommand | IfCommand | ForCommand | WhileCommand;
 
 export interface Pipeline {
   kind: 'Pipeline';
@@ -47,6 +48,15 @@ export interface ForCommand {
   kind: 'For';
   name: string;
   words: Word[];
+  body: CommandList;
+  redirects: Redirect[];
+}
+
+export interface WhileCommand {
+  kind: 'While';
+  /** true for `until TEST; do BODY; done`. */
+  until: boolean;
+  test: CommandList;
   body: CommandList;
   redirects: Redirect[];
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -39,7 +39,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, while/until/case, env -i/--ignore-environment, background jobs. if/then/elif/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
+Not supported: heredocs, case, env -i/--ignore-environment, background jobs. if/then/elif/else/fi, for-in loops, while/until, and word-level \$((...)) arithmetic expansion are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is started when the MCP session begins (and after reset), so the first bash tool call is already warm.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout, 130 cancelled). The tool also returns structuredContent (schemaVersion 1) with stdout/stderr/exitCode/timedOut/cancelled/truncated/sessionId.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -9,6 +9,7 @@ import {
   SimpleCommand,
   IfCommand,
   ForCommand,
+  WhileCommand,
   ShellCommand,
   Word,
   WordPart,
@@ -696,6 +697,16 @@ export function parseCommand(input: string): CommandList {
           throw new FauxnixParseError('fauxnix: for in a pipeline is not supported');
         }
         commands.push(parseFor());
+      } else if (kw === 'while') {
+        if (commands.length > 0) {
+          throw new FauxnixParseError('fauxnix: while in a pipeline is not supported');
+        }
+        commands.push(parseWhile());
+      } else if (kw === 'until') {
+        if (commands.length > 0) {
+          throw new FauxnixParseError('fauxnix: until in a pipeline is not supported');
+        }
+        commands.push(parseUntil());
       } else {
         commands.push(parseSimple());
       }
@@ -724,7 +735,8 @@ export function parseCommand(input: string): CommandList {
       s === 'in' ||
       s === 'do' ||
       s === 'done' ||
-      s === 'while'
+      s === 'while' ||
+      s === 'until'
     ) {
       return s;
     }
@@ -817,6 +829,18 @@ export function parseCommand(input: string): CommandList {
     const body = parseListUntil(['done']);
     expectKw('done');
     return { kind: 'For', name, words, body, redirects: [] };
+  };
+
+  const parseWhile = (): WhileCommand => parseWhileLoop(false);
+  const parseUntil = (): WhileCommand => parseWhileLoop(true);
+
+  const parseWhileLoop = (until: boolean): WhileCommand => {
+    expectKw(until ? 'until' : 'while');
+    const test = parseListUntil(['do']);
+    expectKw('do');
+    const body = parseListUntil(['done']);
+    expectKw('done');
+    return { kind: 'While', until, test, body, redirects: [] };
   };
 
   const parseSimple = (): SimpleCommand => {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -7,6 +7,7 @@ import {
   SimpleCommand,
   IfCommand,
   ForCommand,
+  WhileCommand,
   Word,
   WordPart,
   isUnquotedLiteral,
@@ -878,6 +879,21 @@ function translateFor(cmd: ForCommand): string {
   return lines.join('\n');
 }
 
+function translateWhile(cmd: WhileCommand): string {
+  // Bash: last executed body owns status; a test that ends the loop does not.
+  // Never-entered loops (`while false; do …; done`, `until true; do …; done`)
+  // exit 0. Save the body status and restore it on the failing test.
+  const fail = cmd.until ? '$script:fx_exit -eq 0' : '$script:fx_exit -ne 0';
+  const lines = ['$fx_wst = 0', 'do {'];
+  for (const l of translateListInline(cmd.test).split('\n')) lines.push(l ? '  ' + l : l);
+  lines.push('  if (' + fail + ') { $script:fx_exit = $fx_wst; break }');
+  lines.push('  $script:fx_exit = 0');
+  for (const l of translateListInline(cmd.body).split('\n')) lines.push(l ? '  ' + l : l);
+  lines.push('  $fx_wst = $script:fx_exit');
+  lines.push('} while ($true)');
+  return lines.join('\n');
+}
+
 function stdinTarget(c: ShellCommand): string | null {
   let t: string | null = null;
   for (const r of c.redirects) {
@@ -910,7 +926,7 @@ function rejectNonLastStdoutRedirects(commands: ShellCommand[]): void {
 }
 
 export function translatePipelineBody(p: {
-  commands: Array<SimpleCommand | IfCommand | ForCommand>;
+  commands: Array<SimpleCommand | IfCommand | ForCommand | WhileCommand>;
 }): PipelineParts {
   // Last-stage `>` is Node apply; a non-last `>` would truncate the file and
   // still feed the pipe. Fail loud until in-stage writes (#157).
@@ -929,6 +945,7 @@ export function translatePipelineBody(p: {
       i === 0 ? 'first' : i === p.commands.length - 1 ? 'last' : 'middle';
     if (c.kind === 'If') bodies.push(translateIf(c));
     else if (c.kind === 'For') bodies.push(translateFor(c));
+    else if (c.kind === 'While') bodies.push(translateWhile(c));
     else bodies.push(translateSimple(c, position, hasStdin));
   }
 

--- a/test/differential.test.ts
+++ b/test/differential.test.ts
@@ -24,7 +24,7 @@ describe('differential corpus scaffold (C-7 / #118)', () => {
     expect(corpus.gate.targetCases).toBe(200);
     expect(corpus.gate.identity).toBe(0.95);
     expect(corpus.cases.length).toBeGreaterThanOrEqual(15);
-    expect(corpus.cases.length).toBeLessThanOrEqual(40);
+    expect(corpus.cases.length).toBeLessThanOrEqual(50);
     const ids = corpus.cases.map((c) => c.id);
     expect(new Set(ids).size).toBe(ids.length);
     expect(ids).toEqual(expect.arrayContaining([

--- a/test/differential/corpus.json
+++ b/test/differential/corpus.json
@@ -182,6 +182,21 @@
       "source": "#112"
     },
     {
+      "id": "while-count",
+      "cmd": "i=0; while [ $i -lt 3 ]; do echo $i; i=$((i+1)); done",
+      "source": "C-1 / #118"
+    },
+    {
+      "id": "until-count",
+      "cmd": "i=0; until [ $i -eq 2 ]; do echo $i; i=$((i+1)); done",
+      "source": "C-1 / #118"
+    },
+    {
+      "id": "while-false-status",
+      "cmd": "while false; do echo x; done; echo $?",
+      "source": "C-1 / #118"
+    },
+    {
       "id": "status-false",
       "cmd": "false; echo $?",
       "source": "integration: $? reflects the previous segment"

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1178,6 +1178,19 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     );
   });
 
+  it('while/until loops iterate and match bash status', async () => {
+    expect((await run('i=0; while [ $i -lt 3 ]; do echo $i; i=$((i+1)); done')).stdout.trim()).toBe(
+      '0\n1\n2',
+    );
+    expect((await run('i=0; until [ $i -eq 2 ]; do echo $i; i=$((i+1)); done')).stdout.trim()).toBe(
+      '0\n1',
+    );
+    expect((await run('while false; do echo x; done')).exitCode).toBe(0);
+    expect((await run('until true; do echo x; done')).exitCode).toBe(0);
+    expect((await run('i=0; while [ $i -lt 1 ]; do i=$((i+1)); false; done')).exitCode).toBe(1);
+    expect((await run('i=0; while [ $i -lt 1 ]; do i=$((i+1)); true; done')).exitCode).toBe(0);
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -164,6 +164,26 @@ describe('parser', () => {
     expect(c.words).toHaveLength(3);
   });
 
+  it('parses while TEST; do BODY; done', () => {
+    const list = parse('while [ $i -lt 3 ]; do echo $i; done');
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('While');
+    if (c.kind !== 'While') return;
+    expect(c.until).toBe(false);
+    expect(c.redirects).toEqual([]);
+    expect(c.test.segments).toHaveLength(1);
+    expect(c.body.segments).toHaveLength(1);
+  });
+
+  it('parses until TEST; do BODY; done', () => {
+    const list = parse('until [ $i -eq 2 ]; do echo $i; done');
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('While');
+    if (c.kind !== 'While') return;
+    expect(c.until).toBe(true);
+    expect(c.redirects).toEqual([]);
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);
@@ -754,6 +774,20 @@ describe('translator', () => {
     expect(dyn).toMatch(/\$fx_ek\d+/);
     const once = translateCommandList(parse('T=x export X=$(echo once)'))[0].script;
     expect(once).not.toMatch(/\$fx_ek\d+/);
+  });
+
+  it('translates while/until as a do/while loop', () => {
+    const w = translateCommandList(parse('while false; do echo x; done'))[0].body;
+    expect(w).toContain('do {');
+    expect(w).toContain('} while ($true)');
+    expect(w).toContain('$script:fx_exit -ne 0');
+    expect(w).toContain('$script:fx_exit = 0');
+    expect(w).not.toContain('??');
+    const u = translateCommandList(parse('until true; do echo x; done'))[0].body;
+    expect(u).toContain('do {');
+    expect(u).toContain('} while ($true)');
+    expect(u).toContain('$script:fx_exit -eq 0');
+    expect(u).not.toContain('??');
   });
 });
 

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1637,5 +1637,5 @@ describe.skipIf(process.platform !== 'win32')('cli doctor spawn', () => {
     expect(r.stdout).toMatch(/codex\s+:/);
     expect(r.stdout).toMatch(/opencode\s+:/);
     expect(r.status).toBe(0);
-  });
+  }, 30000);
 });


### PR DESCRIPTION
RFC 1.0 **C-1** slice: `while` / `until` only. Tracking #118.

`peekKw` already returned `while`, but `parsePipeline` only special-cased `if`/`for`, so `while TEST; do BODY; done` fell through to a simple command (silently wrong).

### What landed
- AST `WhileCommand` (`kind: 'While'`, `until`, `test`, `body`, `redirects: []`)
- Parser: `until` in `peekKw`; `while`/`until TEST; do BODY; done` (same pipeline-compound rule as `for`)
- Translator (PS 5.1, no `??`):
  `do { test; if (until ? exit==0 : exit!=0) { restore body status; break }; fx_exit=0; body } while ($true)`
- Bash status: `while false; do echo x; done` and `until true; do echo x; done` exit 0. Last body command owns status if the loop ran.
- MCP + README: `while`/`until` supported; `case` still not

### Not in this PR
- `case` / `;;` / `;&` fallthrough

### Tests
`npx vitest run --dir test` — 274 passed, 1 skipped (oracle unset)
