### PR TITLE
feat: fauxnix install for harness MCP config (U-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ fauxnix translate "find . -name '*.log' -mtime +7 -delete"
 fauxnix check
 fauxnix doctor                   # check + encoding, harness config, MCP
 
+# write user-level MCP config (idempotent; also --codex/--opencode/--kimi/--qwen)
+fauxnix install --claude
+
 # run the MCP stdio server (what agent harnesses connect to)
 fauxnix mcp
 ```
@@ -110,7 +113,9 @@ with argv-style quoting — no string re-parsing, no quoting bugs.
 ## Use with your agent harness
 
 fauxnix ships an MCP stdio server exposing a `bash` tool (plus `fauxnix_translate` and
-`fauxnix_session`). Point any MCP-capable harness at it:
+`fauxnix_session`). Point any MCP-capable harness at it with
+`fauxnix install --claude` (or `--codex` / `--opencode` / `--kimi` / `--qwen`).
+Idempotent; prints what changed. Manual configs below.
 
 **Claude Code**
 ```bash
@@ -138,6 +143,15 @@ interactively and approve once).
 
 **Kimi Code** — unlike the others, MCP servers live in a JSON file, not the
 TOML config: `~/.kimi-code/mcp.json`
+```json
+{
+  "mcpServers": {
+    "fauxnix": { "command": "fauxnix", "args": ["mcp"] }
+  }
+}
+```
+
+**Qwen Code** (`~/.qwen/settings.json`)
 ```json
 {
   "mcpServers": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { listCommandsJson, registeredNames, specsMarkdown } from './registry.js'
 import { encodeCommand } from './encoding.js';
 import { startMcpServer } from './mcp.js';
 import { collectDoctorReport } from './doctor.js';
+import { runInstall } from './install.js';
 import { packageVersion } from './version.js';
 import './commands/install-all.js';
 
@@ -21,6 +22,7 @@ Usage:
   fauxnix list --markdown            CommandSpec tables (same text as docs/command-specs.md)
   fauxnix check                      verify the local PowerShell environment
   fauxnix doctor                     check + encoding, harness config, MCP readiness
+  fauxnix install --claude|--codex|--opencode|--kimi|--qwen
   fauxnix --version
 
 Notes:
@@ -62,6 +64,13 @@ export async function runCli(argv: string[]): Promise<void> {
 
   if (verb === 'doctor') {
     await runDoctor();
+    return;
+  }
+
+  if (verb === 'install') {
+    const result = runInstall(rest);
+    for (const line of result.lines) console.log(line);
+    if (!result.ok) process.exitCode = 1;
     return;
   }
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -85,10 +85,20 @@ function detectClaude(home: string, cwd: string, env: NodeJS.ProcessEnv): string
   return `found ${projectPath}, fauxnix MCP not listed — see README`;
 }
 
-function claudeUserConfigPath(home: string, env: NodeJS.ProcessEnv): string {
+export function claudeUserConfigPath(home: string, env: NodeJS.ProcessEnv): string {
   const dir = env.CLAUDE_CONFIG_DIR?.trim();
   if (dir) return join(dir, '.claude.json');
   return join(home, '.claude.json');
+}
+
+export function codexConfigPath(home: string, env: NodeJS.ProcessEnv): string {
+  const codexHome = env.CODEX_HOME?.trim() || join(home, '.codex');
+  return join(codexHome, 'config.toml');
+}
+
+export function openCodeConfigPath(home: string, env: NodeJS.ProcessEnv): string {
+  const xdg = env.XDG_CONFIG_HOME?.trim() || join(home, '.config');
+  return join(xdg, 'opencode', 'opencode.json');
 }
 
 function inspectClaudeJson(path: string): {
@@ -124,8 +134,7 @@ function inspectClaudeJson(path: string): {
 }
 
 function detectCodex(home: string, env: NodeJS.ProcessEnv): string {
-  const codexHome = env.CODEX_HOME?.trim() || join(home, '.codex');
-  const path = join(codexHome, 'config.toml');
+  const path = codexConfigPath(home, env);
   if (!existsSync(path)) return 'not detected — see README';
   const text = readText(path);
   if (text === undefined) return `found ${path} (unreadable) — see README`;
@@ -133,7 +142,7 @@ function detectCodex(home: string, env: NodeJS.ProcessEnv): string {
   return `found ${path}, fauxnix MCP not listed — run: codex mcp add fauxnix -- fauxnix mcp`;
 }
 
-function hasCodexFauxnix(text: string): boolean {
+export function hasCodexFauxnix(text: string): boolean {
   if (/^\s*\[mcp_servers\.(?:fauxnix|"fauxnix"|'fauxnix')\]/im.test(text)) return true;
   const tables = text.split(/^\s*\[/m);
   for (const table of tables) {
@@ -153,8 +162,7 @@ function hasCodexFauxnix(text: string): boolean {
 }
 
 function detectOpenCode(home: string, env: NodeJS.ProcessEnv): string {
-  const xdg = env.XDG_CONFIG_HOME?.trim() || join(home, '.config');
-  const path = join(xdg, 'opencode', 'opencode.json');
+  const path = openCodeConfigPath(home, env);
   if (!existsSync(path)) return 'not detected — see README';
   const text = readText(path);
   if (text === undefined) return `found ${path} (unreadable) — see README`;
@@ -168,7 +176,7 @@ function detectOpenCode(home: string, env: NodeJS.ProcessEnv): string {
   return `found ${path}, fauxnix MCP not listed — add mcp.fauxnix (see README)`;
 }
 
-function hasOpenCodeFauxnix(data: unknown): boolean {
+export function hasOpenCodeFauxnix(data: unknown): boolean {
   if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
   const mcp = (data as Record<string, unknown>).mcp;
   if (!isServerMap(mcp)) return false;
@@ -177,11 +185,11 @@ function hasOpenCodeFauxnix(data: unknown): boolean {
   return isServerMap(nested) && serverMapHasFauxnix(nested);
 }
 
-function isServerMap(value: unknown): boolean {
+export function isServerMap(value: unknown): boolean {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
-function serverMapHasFauxnix(value: unknown): boolean {
+export function serverMapHasFauxnix(value: unknown): boolean {
   if (!isServerMap(value)) return false;
   for (const [name, cfg] of Object.entries(value as Record<string, unknown>)) {
     if (name === 'servers') continue;

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,0 +1,247 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+  claudeUserConfigPath,
+  codexConfigPath,
+  hasCodexFauxnix,
+  hasOpenCodeFauxnix,
+  isServerMap,
+  openCodeConfigPath,
+  serverMapHasFauxnix,
+} from './doctor.js';
+
+export type InstallOptions = {
+  home?: string;
+  /** Accepted for parity with collectDoctorReport; install writes user-level configs only. */
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type InstallReport = {
+  lines: string[];
+  ok: boolean;
+};
+
+export const INSTALL_FLAGS = ['claude', 'codex', 'opencode', 'kimi', 'qwen'] as const;
+export type HarnessName = (typeof INSTALL_FLAGS)[number];
+
+const STDIO = { command: 'fauxnix', args: ['mcp'] };
+const OPENCODE_STDIO = { type: 'local', command: ['fauxnix', 'mcp'] };
+
+type Ctx = { home: string; env: NodeJS.ProcessEnv };
+type One = { ok: boolean; line: string };
+
+type JsonRead =
+  | { state: 'missing' }
+  | { state: 'empty' }
+  | { state: 'invalid'; reason: string }
+  | { state: 'ok'; data: Record<string, unknown> };
+
+export function kimiConfigPath(home: string, env: NodeJS.ProcessEnv): string {
+  const root = env.KIMI_CODE_HOME?.trim() || join(home, '.kimi-code');
+  return join(root, 'mcp.json');
+}
+
+export function qwenConfigPath(home: string, env: NodeJS.ProcessEnv): string {
+  return join(home, '.qwen', 'settings.json');
+}
+
+export function runInstall(argv: string[], opts: InstallOptions = {}): InstallReport {
+  const parsed = parseHarnessFlags(argv);
+  if (parsed.help) return { lines: installUsageLines(), ok: true };
+  if (parsed.error) return { lines: [parsed.error, ...installUsageLines()], ok: false };
+
+  const ctx: Ctx = {
+    home: opts.home ?? homedir(),
+    env: opts.env ?? process.env,
+  };
+
+  const lines: string[] = [];
+  let ok = true;
+  for (const name of parsed.harnesses) {
+    const one = installHarness(name, ctx);
+    lines.push(one.line);
+    if (!one.ok) ok = false;
+  }
+  return { lines, ok };
+}
+
+function parseHarnessFlags(argv: string[]): {
+  help?: boolean;
+  error?: string;
+  harnesses: HarnessName[];
+} {
+  if (argv.some((a) => a === '--help' || a === '-h')) return { help: true, harnesses: [] };
+  if (argv.length === 0) {
+    return { error: 'select a harness: --claude --codex --opencode --kimi --qwen', harnesses: [] };
+  }
+  const harnesses: HarnessName[] = [];
+  const seen = new Set<HarnessName>();
+  for (const a of argv) {
+    if (!a.startsWith('--') || a === '--') {
+      return { error: `unknown argument: ${a}`, harnesses: [] };
+    }
+    const name = a.slice(2);
+    if (!isHarness(name)) return { error: `unknown harness: ${a}`, harnesses: [] };
+    if (!seen.has(name)) {
+      seen.add(name);
+      harnesses.push(name);
+    }
+  }
+  return { harnesses };
+}
+
+function isHarness(s: string): s is HarnessName {
+  return (INSTALL_FLAGS as readonly string[]).includes(s);
+}
+
+function installUsageLines(): string[] {
+  return ['Usage:', '  fauxnix install --claude|--codex|--opencode|--kimi|--qwen'];
+}
+
+function installHarness(name: HarnessName, ctx: Ctx): One {
+  switch (name) {
+    case 'claude':
+      return patchMcpServers(claudeUserConfigPath(ctx.home, ctx.env), 'claude');
+    case 'codex':
+      return patchCodex(codexConfigPath(ctx.home, ctx.env));
+    case 'opencode':
+      return patchOpenCode(openCodeConfigPath(ctx.home, ctx.env));
+    case 'kimi':
+      return patchMcpServers(kimiConfigPath(ctx.home, ctx.env), 'kimi');
+    case 'qwen':
+      return patchMcpServers(qwenConfigPath(ctx.home, ctx.env), 'qwen');
+  }
+}
+
+function patchMcpServers(path: string, harness: HarnessName): One {
+  const read = readJsonObject(path);
+  if (read.state === 'invalid') {
+    return { ok: false, line: `${harness}: ${path} is ${read.reason} — not modified` };
+  }
+  const existed = read.state !== 'missing';
+  const data = read.state === 'ok' ? read.data : {};
+  if (serverMapHasFauxnix(data.mcpServers)) {
+    return { ok: true, line: `${harness}: already configured (${path})` };
+  }
+  if (data.mcpServers != null && !isServerMap(data.mcpServers)) {
+    return { ok: false, line: `${harness}: ${path} mcpServers is not an object — not modified` };
+  }
+  if (!isServerMap(data.mcpServers)) data.mcpServers = {};
+  (data.mcpServers as Record<string, unknown>).fauxnix = {
+    command: STDIO.command,
+    args: [...STDIO.args],
+  };
+  return writeJson(path, data, harness, existed, 'added mcpServers.fauxnix');
+}
+
+function patchOpenCode(path: string): One {
+  const read = readJsonObject(path);
+  if (read.state === 'invalid') {
+    return { ok: false, line: `opencode: ${path} is ${read.reason} — not modified` };
+  }
+  const existed = read.state !== 'missing';
+  const data = read.state === 'ok' ? read.data : {};
+  if (hasOpenCodeFauxnix(data)) {
+    return { ok: true, line: `opencode: already configured (${path})` };
+  }
+  if (data.mcp != null && !isServerMap(data.mcp)) {
+    return { ok: false, line: `opencode: ${path} mcp is not an object — not modified` };
+  }
+  if (!isServerMap(data.mcp)) data.mcp = {};
+  const mcp = data.mcp as Record<string, unknown>;
+  const payload = { type: OPENCODE_STDIO.type, command: [...OPENCODE_STDIO.command] };
+  if (isServerMap(mcp.servers)) {
+    (mcp.servers as Record<string, unknown>).fauxnix = payload;
+    return writeJson(path, data, 'opencode', existed, 'added mcp.servers.fauxnix');
+  }
+  mcp.fauxnix = payload;
+  return writeJson(path, data, 'opencode', existed, 'added mcp.fauxnix');
+}
+
+function patchCodex(path: string): One {
+  const existed = existsSync(path);
+  if (!existed) {
+    const written = writeText(path, tomlTable('\n'));
+    if (!written.ok) return { ok: false, line: `codex: failed to write ${path}: ${written.error}` };
+    return { ok: true, line: `codex: created ${path}` };
+  }
+  const text = readText(path);
+  if (text === undefined) {
+    return { ok: false, line: `codex: ${path} is unreadable — not modified` };
+  }
+  if (hasCodexFauxnix(stripBom(text))) {
+    return { ok: true, line: `codex: already configured (${path})` };
+  }
+  const nl = text.includes('\r\n') ? '\r\n' : '\n';
+  if (stripBom(text).trim() === '') {
+    const written = writeText(path, tomlTable(nl));
+    if (!written.ok) return { ok: false, line: `codex: failed to write ${path}: ${written.error}` };
+    return { ok: true, line: `codex: patched ${path} (appended [mcp_servers.fauxnix])` };
+  }
+  let body = text;
+  if (!body.endsWith('\n')) body += nl;
+  if (!body.endsWith(nl + nl)) body += nl;
+  const written = writeText(path, body + tomlTable(nl));
+  if (!written.ok) return { ok: false, line: `codex: failed to write ${path}: ${written.error}` };
+  return { ok: true, line: `codex: patched ${path} (appended [mcp_servers.fauxnix])` };
+}
+
+function tomlTable(nl: string): string {
+  return `[mcp_servers.fauxnix]${nl}command = "fauxnix"${nl}args = ["mcp"]${nl}`;
+}
+
+function writeJson(
+  path: string,
+  data: Record<string, unknown>,
+  harness: HarnessName,
+  existed: boolean,
+  change: string,
+): One {
+  const written = writeText(path, JSON.stringify(data, null, 2) + '\n');
+  if (!written.ok) {
+    return { ok: false, line: `${harness}: failed to write ${path}: ${written.error}` };
+  }
+  if (existed) return { ok: true, line: `${harness}: patched ${path} (${change})` };
+  return { ok: true, line: `${harness}: created ${path}` };
+}
+
+function writeText(path: string, contents: string): { ok: true } | { ok: false; error: string } {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, contents, 'utf8');
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+function readJsonObject(path: string): JsonRead {
+  if (!existsSync(path)) return { state: 'missing' };
+  const text = readText(path);
+  if (text === undefined) return { state: 'invalid', reason: 'unreadable' };
+  const stripped = stripBom(text).trim();
+  if (stripped === '') return { state: 'empty' };
+  try {
+    const data = JSON.parse(stripped);
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      return { state: 'invalid', reason: 'not a JSON object' };
+    }
+    return { state: 'ok', data: data as Record<string, unknown> };
+  } catch {
+    return { state: 'invalid', reason: 'not valid JSON' };
+  }
+}
+
+function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+function readText(path: string): string | undefined {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return undefined;
+  }
+}

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1949,5 +1949,5 @@ describe.skipIf(process.platform !== 'win32')('cli doctor spawn', () => {
     expect(r.stdout).toMatch(/codex\s+:/);
     expect(r.stdout).toMatch(/opencode\s+:/);
     expect(r.status).toBe(0);
-  });
+  }, 30000);
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,10 +1,11 @@
 import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { runCli, USAGE } from '../src/cli.js';
 import { collectDoctorReport } from '../src/doctor.js';
+import { kimiConfigPath, qwenConfigPath, runInstall } from '../src/install.js';
 import { FauxnixParseError, isUnquotedLiteral, wordToString } from '../src/ast.js';
 import { parseCommand as parse, tokenize } from '../src/parser.js';
 import {
@@ -1579,6 +1580,351 @@ describe('cli doctor', () => {
       );
       const cwdOnly = await collectDoctorReport({ home: dir, cwd: dir, env: {}, nodeVersion: 'v20.0.0' });
       expect(cwdOnly.lines.join('\n')).toMatch(/opencode\s+: not detected — see README/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('cli install', () => {
+  it('USAGE lists install', async () => {
+    expect(USAGE).toMatch(/fauxnix install --claude/);
+    expect(USAGE).toContain('--codex');
+    expect(USAGE).toContain('--opencode');
+    expect(USAGE).toContain('--kimi');
+    expect(USAGE).toContain('--qwen');
+    const src = readFileSync('src/cli.ts', 'utf8');
+    expect(src).toContain("verb === 'install'");
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(' '));
+    };
+    try {
+      await runCli([]);
+    } finally {
+      console.log = orig;
+    }
+    expect(lines.join('\n')).toContain('fauxnix install');
+  });
+
+  it('runCli install without flags prints usage and does not write', async () => {
+    const lines: string[] = [];
+    const orig = console.log;
+    const prev = process.exitCode;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.map((a) => String(a)).join(' '));
+    };
+    process.exitCode = undefined;
+    try {
+      await runCli(['install']);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      console.log = orig;
+      process.exitCode = prev;
+    }
+    expect(lines.join('\n')).toContain('--claude');
+    expect(lines.join('\n')).toContain('select a harness');
+  });
+});
+
+describe('install harness config', () => {
+  function opts(dir: string, env: NodeJS.ProcessEnv = {}) {
+    return { home: dir, cwd: dir, env };
+  }
+
+  async function doctorText(dir: string, env: NodeJS.ProcessEnv = {}): Promise<string> {
+    const report = await collectDoctorReport({
+      home: dir,
+      cwd: dir,
+      env,
+      nodeVersion: 'v20.0.0',
+    });
+    return report.lines.join('\n');
+  }
+
+  it('rejects unknown flags and --help without writing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    expect(dir).not.toBe(homedir());
+    try {
+      const bad = runInstall(['--nope'], opts(dir));
+      expect(bad.ok).toBe(false);
+      expect(bad.lines.join('\n')).toContain('unknown harness: --nope');
+      expect(existsSync(join(dir, '.claude.json'))).toBe(false);
+
+      const help = runInstall(['--help'], opts(dir));
+      expect(help.ok).toBe(true);
+      expect(help.lines.join('\n')).toContain('fauxnix install --claude');
+      expect(existsSync(join(dir, '.claude.json'))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes Claude user config, preserves unrelated keys, and is idempotent', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    expect(dir).not.toBe(homedir());
+    try {
+      const claudePath = join(dir, '.claude.json');
+      writeFileSync(
+        claudePath,
+        JSON.stringify(
+          {
+            theme: 'dark',
+            projects: { 'C:\\work\\app': { allowedTools: ['Bash'] } },
+            mcpServers: { github: { command: 'npx' } },
+          },
+          null,
+          2,
+        ),
+      );
+      const r = runInstall(['--claude'], opts(dir));
+      expect(r.ok).toBe(true);
+      expect(r.lines[0]).toContain('patched');
+      expect(r.lines[0]).toContain(claudePath);
+      const data = JSON.parse(readFileSync(claudePath, 'utf8')) as {
+        theme: string;
+        projects: unknown;
+        mcpServers: Record<string, unknown>;
+      };
+      expect(data.theme).toBe('dark');
+      expect(data.projects).toEqual({ 'C:\\work\\app': { allowedTools: ['Bash'] } });
+      expect(data.mcpServers.github).toEqual({ command: 'npx' });
+      expect(data.mcpServers.fauxnix).toEqual({ command: 'fauxnix', args: ['mcp'] });
+      expect(await doctorText(dir)).toMatch(/claude\s+: fauxnix MCP configured/);
+
+      const before = readFileSync(claudePath, 'utf8');
+      const again = runInstall(['--claude'], opts(dir));
+      expect(again.ok).toBe(true);
+      expect(again.lines[0]).toContain('already configured');
+      expect(readFileSync(claudePath, 'utf8')).toBe(before);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates Claude config and respects CLAUDE_CONFIG_DIR', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    try {
+      const created = runInstall(['--claude'], opts(dir));
+      expect(created.ok).toBe(true);
+      expect(created.lines[0]).toContain('created');
+      expect(JSON.parse(readFileSync(join(dir, '.claude.json'), 'utf8'))).toEqual({
+        mcpServers: { fauxnix: { command: 'fauxnix', args: ['mcp'] } },
+      });
+
+      const cfgDir = join(dir, 'custom-claude');
+      const env = { CLAUDE_CONFIG_DIR: cfgDir };
+      const custom = runInstall(['--claude'], opts(dir, env));
+      expect(custom.ok).toBe(true);
+      expect(existsSync(join(cfgDir, '.claude.json'))).toBe(true);
+      expect(custom.lines[0]).toContain(join(cfgDir, '.claude.json'));
+      expect(await doctorText(dir, env)).toMatch(/claude\s+: fauxnix MCP configured/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not overwrite invalid Claude JSON or a non-object mcpServers', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    try {
+      const claudePath = join(dir, '.claude.json');
+      writeFileSync(claudePath, '{ not json');
+      const bad = runInstall(['--claude'], opts(dir));
+      expect(bad.ok).toBe(false);
+      expect(bad.lines[0]).toContain('not valid JSON');
+      expect(readFileSync(claudePath, 'utf8')).toBe('{ not json');
+
+      writeFileSync(claudePath, JSON.stringify({ mcpServers: ['nope'] }));
+      const wrong = runInstall(['--claude'], opts(dir));
+      expect(wrong.ok).toBe(false);
+      expect(wrong.lines[0]).toContain('mcpServers is not an object');
+      expect(JSON.parse(readFileSync(claudePath, 'utf8'))).toEqual({ mcpServers: ['nope'] });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write project .mcp.json for Claude', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    try {
+      writeFileSync(join(dir, '.mcp.json'), JSON.stringify({ keep: true }));
+      const r = runInstall(['--claude'], opts(dir));
+      expect(r.ok).toBe(true);
+      expect(existsSync(join(dir, '.claude.json'))).toBe(true);
+      expect(JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf8'))).toEqual({ keep: true });
+      expect(await doctorText(dir)).toMatch(/claude\s+: fauxnix MCP configured/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('appends Codex TOML without rewriting comments and is idempotent', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    try {
+      mkdirSync(join(dir, '.codex'));
+      const path = join(dir, '.codex', 'config.toml');
+      writeFileSync(path, '# keep me\r\n[model]\r\nmodel = "gpt-5"\r\n');
+      const r = runInstall(['--codex'], opts(dir));
+      expect(r.ok).toBe(true);
+      expect(r.lines[0]).toContain('patched');
+      const out = readFileSync(path, 'utf8');
+      expect(out.startsWith('# keep me')).toBe(true);
+      expect(out).toContain('[model]');
+      expect(out).toContain('model = "gpt-5"');
+      expect(out).toContain('[mcp_servers.fauxnix]');
+      expect(out).toContain('command = "fauxnix"');
+      expect(out).toContain('args = ["mcp"]');
+      expect(await doctorText(dir)).toMatch(/codex\s+: fauxnix MCP configured/);
+
+      const before = readFileSync(path, 'utf8');
+      const again = runInstall(['--codex'], opts(dir));
+      expect(again.lines[0]).toContain('already configured');
+      expect(readFileSync(path, 'utf8')).toBe(before);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates Codex config and respects CODEX_HOME', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    try {
+      const created = runInstall(['--codex'], opts(dir));
+      expect(created.ok).toBe(true);
+      expect(created.lines[0]).toContain('created');
+      expect(readFileSync(join(dir, '.codex', 'config.toml'), 'utf8')).toContain(
+        '[mcp_servers.fauxnix]',
+      );
+
+      const home = join(dir, 'my-codex');
+      const env = { CODEX_HOME: home };
+      const custom = runInstall(['--codex'], opts(dir, env));
+      expect(custom.ok).toBe(true);
+      expect(existsSync(join(home, 'config.toml'))).toBe(true);
+      expect(await doctorText(dir, env)).toMatch(/codex\s+: fauxnix MCP configured/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes OpenCode mcp.fauxnix, nested servers, and respects XDG_CONFIG_HOME', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    try {
+      const path = join(dir, '.config', 'opencode', 'opencode.json');
+      mkdirSync(join(dir, '.config', 'opencode'), { recursive: true });
+      writeFileSync(
+        path,
+        JSON.stringify({
+          $schema: 'https://opencode.ai/config.json',
+          model: 'x',
+          mcp: { github: { type: 'remote', url: 'https://example' } },
+        }),
+      );
+      const r = runInstall(['--opencode'], opts(dir));
+      expect(r.ok).toBe(true);
+      expect(r.lines[0]).toContain('patched');
+      const data = JSON.parse(readFileSync(path, 'utf8')) as {
+        $schema: string;
+        model: string;
+        mcp: Record<string, unknown>;
+      };
+      expect(data.$schema).toBe('https://opencode.ai/config.json');
+      expect(data.model).toBe('x');
+      expect(data.mcp.github).toEqual({ type: 'remote', url: 'https://example' });
+      expect(data.mcp.fauxnix).toEqual({ type: 'local', command: ['fauxnix', 'mcp'] });
+      expect(await doctorText(dir)).toMatch(/opencode\s+: fauxnix MCP configured/);
+
+      const nestedDir = join(dir, 'xdg');
+      const nestedPath = join(nestedDir, 'opencode', 'opencode.json');
+      mkdirSync(join(nestedDir, 'opencode'), { recursive: true });
+      writeFileSync(
+        nestedPath,
+        JSON.stringify({
+          mcp: { servers: { github: { type: 'local', command: ['npx'] } } },
+        }),
+      );
+      const env = { XDG_CONFIG_HOME: nestedDir };
+      const nested = runInstall(['--opencode'], opts(dir, env));
+      expect(nested.ok).toBe(true);
+      const nestedData = JSON.parse(readFileSync(nestedPath, 'utf8')) as {
+        mcp: { servers: Record<string, unknown> };
+      };
+      expect(nestedData.mcp.servers.github).toEqual({ type: 'local', command: ['npx'] });
+      expect(nestedData.mcp.servers.fauxnix).toEqual({
+        type: 'local',
+        command: ['fauxnix', 'mcp'],
+      });
+      expect(await doctorText(dir, env)).toMatch(/opencode\s+: fauxnix MCP configured/);
+
+      writeFileSync(join(dir, 'opencode.json'), JSON.stringify({ keep: true }));
+      const cwdFile = readFileSync(join(dir, 'opencode.json'), 'utf8');
+      runInstall(['--opencode'], opts(dir));
+      expect(readFileSync(join(dir, 'opencode.json'), 'utf8')).toBe(cwdFile);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes Kimi ~/.kimi-code/mcp.json and Qwen ~/.qwen/settings.json', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    try {
+      const kimiPath = kimiConfigPath(dir, {});
+      mkdirSync(join(dir, '.kimi-code'));
+      writeFileSync(
+        kimiPath,
+        JSON.stringify({ mcpServers: { other: { command: 'npx' } } }, null, 2),
+      );
+      const kimi = runInstall(['--kimi'], opts(dir));
+      expect(kimi.ok).toBe(true);
+      expect(kimi.lines[0]).toContain('patched');
+      const kimiData = JSON.parse(readFileSync(kimiPath, 'utf8')) as {
+        mcpServers: Record<string, unknown>;
+      };
+      expect(kimiData.mcpServers.other).toEqual({ command: 'npx' });
+      expect(kimiData.mcpServers.fauxnix).toEqual({ command: 'fauxnix', args: ['mcp'] });
+
+      const qwenPath = qwenConfigPath(dir, {});
+      mkdirSync(join(dir, '.qwen'));
+      writeFileSync(
+        qwenPath,
+        JSON.stringify({ theme: 'dark', mcpServers: { other: { command: 'npx' } } }, null, 2),
+      );
+      const qwen = runInstall(['--qwen'], opts(dir));
+      expect(qwen.ok).toBe(true);
+      const qwenData = JSON.parse(readFileSync(qwenPath, 'utf8')) as {
+        theme: string;
+        mcpServers: Record<string, unknown>;
+      };
+      expect(qwenData.theme).toBe('dark');
+      expect(qwenData.mcpServers.other).toEqual({ command: 'npx' });
+      expect(qwenData.mcpServers.fauxnix).toEqual({ command: 'fauxnix', args: ['mcp'] });
+
+      const kimiHome = join(dir, 'kimi-home');
+      const kimiEnv = { KIMI_CODE_HOME: kimiHome };
+      const custom = runInstall(['--kimi'], opts(dir, kimiEnv));
+      expect(custom.ok).toBe(true);
+      expect(existsSync(join(kimiHome, 'mcp.json'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('installs multiple harnesses in one invocation', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    try {
+      const r = runInstall(['--claude', '--codex', '--opencode', '--kimi', '--qwen'], opts(dir));
+      expect(r.ok).toBe(true);
+      expect(r.lines).toHaveLength(5);
+      expect(r.lines.every((l) => l.includes('created'))).toBe(true);
+      expect(existsSync(join(dir, '.claude.json'))).toBe(true);
+      expect(existsSync(join(dir, '.codex', 'config.toml'))).toBe(true);
+      expect(existsSync(join(dir, '.config', 'opencode', 'opencode.json'))).toBe(true);
+      expect(existsSync(join(dir, '.kimi-code', 'mcp.json'))).toBe(true);
+      expect(existsSync(join(dir, '.qwen', 'settings.json'))).toBe(true);
+      const text = await doctorText(dir);
+      expect(text).toMatch(/claude\s+: fauxnix MCP configured/);
+      expect(text).toMatch(/codex\s+: fauxnix MCP configured/);
+      expect(text).toMatch(/opencode\s+: fauxnix MCP configured/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
﻿RFC 1.0 **U-1** / #118.

`fauxnix install --claude|--codex|--opencode|--kimi|--qwen` writes or patches user-level MCP config. Idempotent: if fauxnix is already listed, prints `already configured` and exits 0. Unrelated keys/tables are left alone. Prints what changed (`created` / `patched` / `already configured`).

## Harnesses

| Flag | Path | Payload |
|---|---|---|
| `--claude` | `~/.claude.json` (`CLAUDE_CONFIG_DIR`) | `mcpServers.fauxnix = { command: "fauxnix", args: ["mcp"] }` |
| `--codex` | `~/.codex/config.toml` (`CODEX_HOME`) | append `[mcp_servers.fauxnix]` (does not rewrite comments) |
| `--opencode` | `~/.config/opencode/opencode.json` (`XDG_CONFIG_HOME`) | `mcp.fauxnix` (or `mcp.servers.fauxnix` when that map already exists) |
| `--kimi` | `~/.kimi-code/mcp.json` (`KIMI_CODE_HOME`) | `mcpServers.fauxnix` — path from Kimi Code docs |
| `--qwen` | `~/.qwen/settings.json` | `mcpServers.fauxnix` — path from Qwen Code docs |

Invalid JSON / non-object `mcpServers` is refused (`not modified`). Multiple flags in one invocation are allowed.

Doctor detection for kimi/qwen (U-2 follow-up) is not in this PR; doctor still reports claude/codex/opencode. Doctor fix-hints still mention `claude mcp add` / `codex mcp add`.

## Tests

Injectable `home`/`cwd`/`env` like `collectDoctorReport`. Never writes the developer's real `~/.claude.json`. Round-trips through doctor after claude/codex/opencode install. `npx vitest run --dir test`: 282 passed, 1 skipped.
