### PR TITLE
fix: attach one-line alternatives to loud-rejects (U-3)

### DIFF
--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -253,7 +253,7 @@ const env: Handler = (args, ctx) => {
       return (
         '[Console]::Error.WriteLine(' +
         psStr(
-          'fauxnix: env -i/--ignore-environment is not supported (would silently keep inherited secrets)',
+          'fauxnix: env -i/--ignore-environment is not supported (would silently keep inherited secrets). Use env -u NAME or unset first instead.',
         ) +
         '); $script:fx_exit = 2'
       );
@@ -2624,7 +2624,7 @@ const source: Handler = (args) => {
 
 const evalCmd: Handler = () => {
   return (
-    "[Console]::Error.WriteLine('fauxnix: eval is not supported; pass the command itself'); $script:fx_exit = 1"
+    "[Console]::Error.WriteLine('fauxnix: eval is not supported; pass the command itself instead'); $script:fx_exit = 1"
   );
 };
 
@@ -2658,7 +2658,7 @@ const alias: Handler = (args) => {
     return t !== '' && !t.startsWith('-');
   });
   if (!has) return '';
-  return "[Console]::Error.WriteLine('fauxnix: alias is not supported'); $script:fx_exit = 1";
+  return "[Console]::Error.WriteLine('fauxnix: alias is not supported. Invoke the real command instead.'); $script:fx_exit = 1";
 };
 
 const set: Handler = (args) => {
@@ -2683,7 +2683,7 @@ const set: Handler = (args) => {
     return (
       '[Console]::Error.WriteLine(' +
       psStr(
-        'fauxnix: set -e/-u/-x is not supported (would silently lie); use explicit || exit',
+        'fauxnix: set -e/-u/-x is not supported (would silently lie); use explicit || exit instead',
       ) +
       '); $script:fx_exit = 2'
     );

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -31,8 +31,22 @@ interface Token {
 }
 
 const OPERATORS = [
-  '&&', '||', '>>', '<<', '2>&1', '1>&2', '2>', '&>>', '&>', '>', '<', '|', ';',
+  '&&', '||', '>>', '<<', '2>&1', '1>&2', '2>', '&>>', '&>', '>', '<', '|', ';', '&',
 ] as const;
+
+const BACKGROUND_MSG =
+  'fauxnix: background & is not supported yet. Run the command in the foreground instead.';
+const WHILE_UNTIL_MSG =
+  'fauxnix: while/until loops are not supported yet. Use `for x in ...; do ...; done` over a known list instead.';
+const CASE_MSG = 'fauxnix: case is not supported yet. Use if/elif/else instead.';
+const FUNCTION_MSG =
+  'fauxnix: functions are not supported yet. Inline the body or repeat the command instead.';
+const IF_IN_PIPELINE_MSG =
+  'fauxnix: if in a pipeline is not supported. Run the if as its own list segment instead of piping into it.';
+const FOR_IN_PIPELINE_MSG =
+  'fauxnix: for in a pipeline is not supported. Run the for as its own list segment instead of piping into it.';
+const CSTYLE_FOR_MSG =
+  'fauxnix: C-style for ((...)) is not supported yet. Use `for x in ...; do ...; done` instead.';
 
 export function tokenize(input: string): Token[] {
   const tokens: Token[] = [];
@@ -628,6 +642,7 @@ export function parseCommand(input: string): CommandList {
   const consumeListOp = (stops?: Set<string>): ';' | '&&' | '||' | null => {
     const t = peek();
     if (t.type !== 'OP') return null;
+    if (t.op === '&') throw new FauxnixParseError(BACKGROUND_MSG);
     if (!(t.op === '&&' || t.op === '||' || isListSep(t.op))) return null;
     if (t.op === ';') {
       next();
@@ -688,16 +703,26 @@ export function parseCommand(input: string): CommandList {
       const kw = peekKw();
       if (kw === 'if') {
         if (commands.length > 0) {
-          throw new FauxnixParseError('fauxnix: if in a pipeline is not supported');
+          throw new FauxnixParseError(IF_IN_PIPELINE_MSG);
         }
         commands.push(parseIf());
       } else if (kw === 'for') {
         if (commands.length > 0) {
-          throw new FauxnixParseError('fauxnix: for in a pipeline is not supported');
+          throw new FauxnixParseError(FOR_IN_PIPELINE_MSG);
         }
         commands.push(parseFor());
+      } else if (kw === 'while' || kw === 'until') {
+        throw new FauxnixParseError(WHILE_UNTIL_MSG);
+      } else if (kw === 'case') {
+        throw new FauxnixParseError(CASE_MSG);
+      } else if (kw === 'function') {
+        throw new FauxnixParseError(FUNCTION_MSG);
       } else {
-        commands.push(parseSimple());
+        const cmd = parseSimple();
+        if (cmd.kind === 'SimpleCommand' && cmd.name && isFunctionDef(cmd)) {
+          throw new FauxnixParseError(FUNCTION_MSG);
+        }
+        commands.push(cmd);
       }
       const t = peek();
       if (t.type === 'OP' && t.op === '|') {
@@ -724,7 +749,10 @@ export function parseCommand(input: string): CommandList {
       s === 'in' ||
       s === 'do' ||
       s === 'done' ||
-      s === 'while'
+      s === 'while' ||
+      s === 'until' ||
+      s === 'case' ||
+      s === 'function'
     ) {
       return s;
     }
@@ -797,6 +825,9 @@ export function parseCommand(input: string): CommandList {
       throw new FauxnixParseError('fauxnix: `for` expected a name');
     }
     const name = wordToString(nt.parts);
+    if (name.startsWith('((')) {
+      throw new FauxnixParseError(CSTYLE_FOR_MSG);
+    }
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name) || !isUnquotedLiteral(nt.parts, name)) {
       throw new FauxnixParseError('fauxnix: `for` name must be an identifier');
     }
@@ -841,6 +872,7 @@ export function parseCommand(input: string): CommandList {
         (t.op === '&&' ||
           t.op === '||' ||
           t.op === '|' ||
+          t.op === '&' ||
           t.op === '>' ||
           t.op === '<' ||
           t.op === '>>' ||
@@ -855,7 +887,8 @@ export function parseCommand(input: string): CommandList {
         // Glue `|` onto the surrounding words so `=~ ^a|z$`,
         // `=~ (a | b)c`, and `== @(x | y)` stay one operand. A
         // spaced `|` outside an open regex / extglob group is a
-        // syntax error (bash).
+        // syntax error (bash). Tight `&` inside an open `=~ (…)`
+        // group stays in the regex, not a background job.
         const last = args.length ? args[args.length - 1] : null;
         const lastIsEqTilde = last !== null && isUnquotedLiteral(last, '=~');
         const prevIsEqTilde =
@@ -869,7 +902,17 @@ export function parseCommand(input: string): CommandList {
           pendingPatternOp(args) === '==' &&
           unmatchedExtglob(last);
         const inRe = lastIsEqTilde || prevIsEqTilde || openRe;
-        if (t.op === '|' || ((inRe || openExt) && t.tightLeft && t.op === '||')) {
+        if (t.op === '&') {
+          if (!(openRe && last && t.tightLeft)) {
+            throw new FauxnixParseError("fauxnix: [[: syntax error near unexpected token `&'");
+          }
+          args[args.length - 1] = [...last, { kind: 'Text', text: '&' }];
+          const n = peek();
+          if (n.type === 'WORD' && n.tightLeft && n.parts) {
+            next();
+            args[args.length - 1] = [...args[args.length - 1], ...n.parts];
+          }
+        } else if (t.op === '|' || ((inRe || openExt) && t.tightLeft && t.op === '||')) {
           if (
             t.op === '|' &&
             !lastIsEqTilde &&
@@ -1015,6 +1058,9 @@ export function parseCommand(input: string): CommandList {
       if (assignments.length > 0) {
         return { kind: 'SimpleCommand', assignments, name: null, args: [], redirects };
       }
+      if (peek().type === 'OP' && peek().op === '&') {
+        throw new FauxnixParseError(BACKGROUND_MSG);
+      }
       throw new FauxnixParseError('fauxnix: expected a command');
     }
     if (isUnquotedLiteral(name, '[[')) {
@@ -1109,6 +1155,14 @@ export function parseCommand(input: string): CommandList {
   }
 
   return parseList();
+}
+
+function isFunctionDef(cmd: SimpleCommand): boolean {
+  if (!cmd.name) return false;
+  const n = wordToString(cmd.name);
+  if (!isUnquotedLiteral(cmd.name, n)) return false;
+  if (/^[A-Za-z_][A-Za-z0-9_]*\(\)$/.test(n)) return true;
+  return cmd.args.length > 0 && isUnquotedLiteral(cmd.args[0], '()');
 }
 
 function isRedirectOp(op: string | undefined): boolean {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -118,6 +118,7 @@ describe('parser', () => {
   it('set -e is a loud usage error, not a silent no-op', () => {
     const script = translateCommandList(parse('set -e'))[0].script;
     expect(script).toMatch(/set -e\/-u\/-x is not supported/);
+    expect(script).toMatch(/use explicit \|\| exit/i);
     expect(script).toContain('$script:fx_exit = 2');
   });
 
@@ -208,6 +209,24 @@ describe('parser', () => {
   it('rejects heredocs with a helpful message', () => {
     expect(() => parse('cat <<EOF')).toThrow(FauxnixParseError);
     expect(() => parse('cat <<EOF')).toThrow(/heredoc/);
+    expect(() => parse('cat <<EOF')).toThrow(/instead/);
+  });
+
+  it('rejects while/until/case/functions/background with an alternative (U-3)', () => {
+    expect(() => parse('while true; do echo x; done')).toThrow(FauxnixParseError);
+    expect(() => parse('while true; do echo x; done')).toThrow(/while\/until/);
+    expect(() => parse('while true; do echo x; done')).toThrow(/for x in/);
+    expect(() => parse('until false; do echo x; done')).toThrow(/while\/until/);
+    expect(() => parse('case x in a) echo a;; esac')).toThrow(/case/);
+    expect(() => parse('case x in a) echo a;; esac')).toThrow(/if\/elif\/else/);
+    expect(() => parse('function foo { echo x; }')).toThrow(/functions/);
+    expect(() => parse('foo() { echo x; }')).toThrow(/functions/);
+    expect(() => parse('foo () { echo x; }')).toThrow(/functions/);
+    expect(() => parse('echo hi &')).toThrow(/background/);
+    expect(() => parse('echo hi &')).toThrow(/foreground/);
+    expect(() => parse('& echo hi')).toThrow(/background/);
+    expect(() => parse('for ((i=0;i<3;i++)); do echo x; done')).toThrow(/C-style for/);
+    expect(() => parse('for ((i=0;i<3;i++)); do echo x; done')).toThrow(/for x in/);
   });
 
   it('rejects trailing && / || instead of dropping them', () => {
@@ -227,8 +246,18 @@ describe('parser', () => {
   it('env -i is a loud usage error, not a silent ignore', () => {
     const script = translateCommandList(parse('env -i echo hi'))[0].script;
     expect(script).toMatch(/env -i\/--ignore-environment is not supported/);
+    expect(script).toMatch(/env -u NAME|unset first instead/);
     expect(script).toContain('$script:fx_exit = 2');
     expect(script).not.toContain("fx-write");
+  });
+
+  it('alias and eval reject with an alternative', () => {
+    const alias = translateCommandList(parse('alias ll=ls'))[0].script;
+    expect(alias).toMatch(/alias is not supported/);
+    expect(alias).toMatch(/instead/i);
+    const ev = translateCommandList(parse('eval echo hi'))[0].script;
+    expect(ev).toMatch(/eval is not supported/);
+    expect(ev).toMatch(/instead/i);
   });
 
   it('parses word-level $((...)) as Arith, not $( (expr) )', () => {
@@ -1582,6 +1611,34 @@ describe('cli doctor', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('U-3 loud-reject alternatives', () => {
+  const files = ['src/translator.ts', 'src/parser.ts', 'src/commands/sysinfo.ts'];
+  const alt = /\binstead\b|\buse\b|\btry\b|\bpipe\b|#157|\bwait\b/i;
+  const gnuAllow =
+    /invalid option --|unrecognized option|option requires an argument|Try '.+ --help'/;
+
+  it('not-supported-yet emit strings carry an alternative phrase', () => {
+    const missing: string[] = [];
+    for (const rel of files) {
+      const src = readFileSync(rel, 'utf8');
+      for (const line of src.split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+          continue;
+        }
+        const chunks = line.match(/'((?:\\'|[^'])*)'|"((?:\\"|[^"])*)"/g) ?? [];
+        for (const raw of chunks) {
+          const s = raw.slice(1, -1);
+          if (!/not supported yet/i.test(s)) continue;
+          if (gnuAllow.test(s)) continue;
+          if (!alt.test(s)) missing.push(rel + ': ' + s);
+        }
+      }
+    }
+    expect(missing).toEqual([]);
   });
 });
 


### PR DESCRIPTION
RFC 1.0 item **U-3** (#118): every loud-reject carries a one-line actionable alternative.

User-facing language/runtime gaps:

- heredocs (already: "Pass the text via echo pipe or a temp file instead.")
- `while`/`until` — use `for x in ...; do ...; done` over a known list
- `case` — use if/elif/else
- functions (`function foo` / `foo()`) — inline the body or repeat the command
- background `&` — run in the foreground
- C-style `for ((...))` — use `for x in ...`
- `if`/`for` in a pipeline — run as its own list segment
- `env -i` — use `env -u NAME` or unset first
- `set -e/-u/-x` — use explicit `|| exit`
- `alias` — invoke the real command
- `eval` — pass the command itself
- non-last stdout redirect — already had the #157 workaround

GNU usage errors (`invalid option -- 'z'`) are unchanged.

Unit test scans `translator.ts` / `parser.ts` / `sysinfo.ts` quoted emit strings for `"not supported yet"` without an alternative phrase (`instead` / `use` / `try` / `pipe` / `#157` / `wait`). GNU-style messages are allowlisted; comment lines are skipped so the scan stays tight.

`npx vitest run --dir test`: 273 passed, 1 skipped (differential oracle).

Not merging.
