### PR TITLE
test: give cli doctor spawn 30s (vitest default 5s flakes CI)

### DIFF
--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1603,5 +1603,5 @@ describe.skipIf(process.platform !== 'win32')('cli doctor spawn', () => {
     expect(r.stdout).toMatch(/codex\s+:/);
     expect(r.stdout).toMatch(/opencode\s+:/);
     expect(r.status).toBe(0);
-  });
+  }, 30000);
 });


### PR DESCRIPTION
U-2 doctor spawnSync already waits 30s for powershell.exe, but vitest's default 5s hook kills the test on GH Windows. #182/#183 went red on this flake from main. Not merging.