### PR TITLE
docs: harness quickstarts for claude/codex/opencode/kimi/qwen (U-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ with argv-style quoting — no string re-parsing, no quoting bugs.
 fauxnix ships an MCP stdio server exposing a `bash` tool (plus `fauxnix_translate` and
 `fauxnix_session`). Point any MCP-capable harness at it:
 
+- **Quickstarts** — copy-paste config + a 10-command smoke: [`docs/examples/`](docs/examples/)
+
 **Claude Code**
 ```bash
 claude mcp add fauxnix -- fauxnix mcp

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,15 @@
+# Harness quickstarts
+
+Copy-paste MCP config and a 10-command smoke for each harness. Preferred installer is `fauxnix install --<harness>` (RFC U-1); each page also has the same keys for a manual paste. Smoke is v0.10.0-safe (no `while`/`until`/`case`, no arrays). Encoding is UTF-8 by default.
+
+| Harness | Config file | Install |
+|---|---|---|
+| [Claude Code](claude.md) | `%USERPROFILE%\.claude.json` | `fauxnix install --claude` |
+| [Codex](codex.md) | `%USERPROFILE%\.codex\config.toml` | `fauxnix install --codex` |
+| [OpenCode](opencode.md) | `%USERPROFILE%\.config\opencode\opencode.json` | `fauxnix install --opencode` |
+| [Kimi Code](kimi.md) | `%USERPROFILE%\.kimi-code\mcp.json` | `fauxnix install --kimi` |
+| [Qwen Code](qwen.md) | `%USERPROFILE%\.qwen\settings.json` | `fauxnix install --qwen` |
+
+Env overrides (when set): `CLAUDE_CONFIG_DIR` → that dir `\.claude.json`; `CODEX_HOME` → `%CODEX_HOME%\config.toml`; `XDG_CONFIG_HOME` → `%XDG_CONFIG_HOME%\opencode\opencode.json`; `KIMI_CODE_HOME` → `%KIMI_CODE_HOME%\mcp.json`. Qwen has no override.
+
+Each page: prerequisites, one-liner + manual block, `fauxnix check` / `fauxnix doctor`, then the smoke. After install, restart the harness so it reloads MCP (`fauxnix mcp`). RFC 1.0 **U-4** / #118.

--- a/docs/examples/claude.md
+++ b/docs/examples/claude.md
@@ -1,0 +1,62 @@
+# Claude Code
+
+fauxnix is a bash→PowerShell translation layer for AI agents on Windows — no WSL, no VM. This harness talks to it over MCP stdio (`fauxnix mcp`); the tool name is `bash`.
+
+## Prerequisites
+
+- Windows
+- Node.js ≥ 18
+- `npm i -g fauxnix-cli` (the installed command is still `fauxnix`)
+- PowerShell 5.1 (built-in)
+
+## Install
+
+Preferred (idempotent; writes the same keys as the block below):
+
+```bash
+fauxnix install --claude
+```
+
+If `install` is not in your build, paste the block by hand.
+
+**Path:** `%USERPROFILE%\.claude.json`
+
+If `CLAUDE_CONFIG_DIR` is set, the file is `%CLAUDE_CONFIG_DIR%\.claude.json` instead. Merge `mcpServers.fauxnix`; do not wipe other servers.
+
+```json
+{
+  "mcpServers": {
+    "fauxnix": { "command": "fauxnix", "args": ["mcp"] }
+  }
+}
+```
+
+Harness CLI equivalent: `claude mcp add fauxnix -- fauxnix mcp`.
+
+## Verify
+
+```bash
+fauxnix check
+fauxnix doctor
+```
+
+Encoding is UTF-8 by default (`FAUXNIX_NATIVE_ENCODING` unset). `doctor` reports `claude : fauxnix MCP configured (...)` when the block is present. Restart Claude Code so it reloads MCP.
+
+## Smoke
+
+Run each line through the MCP `bash` tool (not PowerShell). v0.10.0-safe: no `while`/`until`/`case`, no arrays. Comments are expected stdout; every command exits 0. The `for` loop prints two lines (`a` then `b`).
+
+```
+echo hi                          # hi
+printf '%s=%d\n' x 42            # x=42
+echo $(echo nested)              # nested
+echo $((1+1))                    # 2
+unset X; echo ${X:-def}          # def
+if true; then echo YES; fi       # YES
+for x in a b; do echo $x; done   # a\nb
+false || echo FELLBACK           # FELLBACK
+echo hi | grep hi                # hi
+true; echo $?                    # 0
+```
+
+CLI equivalent (same stdout): `fauxnix 'echo hi'`.

--- a/docs/examples/codex.md
+++ b/docs/examples/codex.md
@@ -1,0 +1,62 @@
+# Codex
+
+fauxnix is a bash→PowerShell translation layer for AI agents on Windows — no WSL, no VM. This harness talks to it over MCP stdio (`fauxnix mcp`); the tool name is `bash`.
+
+## Prerequisites
+
+- Windows
+- Node.js ≥ 18
+- `npm i -g fauxnix-cli` (the installed command is still `fauxnix`)
+- PowerShell 5.1 (built-in)
+
+## Install
+
+Preferred (idempotent; writes the same keys as the block below):
+
+```bash
+fauxnix install --codex
+```
+
+If `install` is not in your build, paste the block by hand.
+
+**Path:** `%USERPROFILE%\.codex\config.toml`
+
+If `CODEX_HOME` is set, the file is `%CODEX_HOME%\config.toml` instead. Append the table; do not wipe other sections.
+
+```toml
+[mcp_servers.fauxnix]
+command = "fauxnix"
+args = ["mcp"]
+```
+
+Harness CLI equivalent: `codex mcp add fauxnix -- fauxnix mcp`.
+
+In non-interactive `codex exec`, MCP tool calls are auto-denied by the approval layer. Pass `--dangerously-bypass-approvals-and-sandbox`, or run interactively and approve once.
+
+## Verify
+
+```bash
+fauxnix check
+fauxnix doctor
+```
+
+Encoding is UTF-8 by default (`FAUXNIX_NATIVE_ENCODING` unset). `doctor` reports `codex : fauxnix MCP configured (...)` when the table is present. Restart Codex so it reloads MCP.
+
+## Smoke
+
+Run each line through the MCP `bash` tool (not PowerShell). v0.10.0-safe: no `while`/`until`/`case`, no arrays. Comments are expected stdout; every command exits 0. The `for` loop prints two lines (`a` then `b`).
+
+```
+echo hi                          # hi
+printf '%s=%d\n' x 42            # x=42
+echo $(echo nested)              # nested
+echo $((1+1))                    # 2
+unset X; echo ${X:-def}          # def
+if true; then echo YES; fi       # YES
+for x in a b; do echo $x; done   # a\nb
+false || echo FELLBACK           # FELLBACK
+echo hi | grep hi                # hi
+true; echo $?                    # 0
+```
+
+CLI equivalent (same stdout): `fauxnix 'echo hi'`.

--- a/docs/examples/kimi.md
+++ b/docs/examples/kimi.md
@@ -1,0 +1,60 @@
+# Kimi Code
+
+fauxnix is a bash→PowerShell translation layer for AI agents on Windows — no WSL, no VM. This harness talks to it over MCP stdio (`fauxnix mcp`); the tool name is `bash`.
+
+## Prerequisites
+
+- Windows
+- Node.js ≥ 18
+- `npm i -g fauxnix-cli` (the installed command is still `fauxnix`)
+- PowerShell 5.1 (built-in)
+
+## Install
+
+Preferred (idempotent; writes the same keys as the block below):
+
+```bash
+fauxnix install --kimi
+```
+
+If `install` is not in your build, paste the block by hand.
+
+**Path:** `%USERPROFILE%\.kimi-code\mcp.json`
+
+MCP servers live in this JSON file, not the Kimi TOML config. If `KIMI_CODE_HOME` is set, the file is `%KIMI_CODE_HOME%\mcp.json` instead. Merge `mcpServers.fauxnix`; do not wipe other servers.
+
+```json
+{
+  "mcpServers": {
+    "fauxnix": { "command": "fauxnix", "args": ["mcp"] }
+  }
+}
+```
+
+## Verify
+
+```bash
+fauxnix check
+fauxnix doctor
+```
+
+Encoding is UTF-8 by default (`FAUXNIX_NATIVE_ENCODING` unset). v0.10.0 `doctor` does not list a kimi row; it still confirms PowerShell, encoding, and `mcp : module loads`. Restart Kimi Code so it reloads MCP.
+
+## Smoke
+
+Run each line through the MCP `bash` tool (not PowerShell). v0.10.0-safe: no `while`/`until`/`case`, no arrays. Comments are expected stdout; every command exits 0. The `for` loop prints two lines (`a` then `b`).
+
+```
+echo hi                          # hi
+printf '%s=%d\n' x 42            # x=42
+echo $(echo nested)              # nested
+echo $((1+1))                    # 2
+unset X; echo ${X:-def}          # def
+if true; then echo YES; fi       # YES
+for x in a b; do echo $x; done   # a\nb
+false || echo FELLBACK           # FELLBACK
+echo hi | grep hi                # hi
+true; echo $?                    # 0
+```
+
+CLI equivalent (same stdout): `fauxnix 'echo hi'`.

--- a/docs/examples/opencode.md
+++ b/docs/examples/opencode.md
@@ -1,0 +1,74 @@
+# OpenCode
+
+fauxnix is a bash→PowerShell translation layer for AI agents on Windows — no WSL, no VM. This harness talks to it over MCP stdio (`fauxnix mcp`); the tool name is `bash`.
+
+## Prerequisites
+
+- Windows
+- Node.js ≥ 18
+- `npm i -g fauxnix-cli` (the installed command is still `fauxnix`)
+- PowerShell 5.1 (built-in)
+
+## Install
+
+Preferred (idempotent; writes the same keys as the block below):
+
+```bash
+fauxnix install --opencode
+```
+
+If `install` is not in your build, paste the block by hand.
+
+**Path:** `%USERPROFILE%\.config\opencode\opencode.json`
+
+If `XDG_CONFIG_HOME` is set, the file is `%XDG_CONFIG_HOME%\opencode\opencode.json` instead. Merge; do not wipe other keys.
+
+Default shape (`mcp.fauxnix`):
+
+```json
+{
+  "mcp": {
+    "fauxnix": { "type": "local", "command": ["fauxnix", "mcp"] }
+  }
+}
+```
+
+If `mcp.servers` already exists as an object, put fauxnix there instead (`mcp.servers.fauxnix`) — do not also add a sibling `mcp.fauxnix`:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "fauxnix": { "type": "local", "command": ["fauxnix", "mcp"] }
+    }
+  }
+}
+```
+
+## Verify
+
+```bash
+fauxnix check
+fauxnix doctor
+```
+
+Encoding is UTF-8 by default (`FAUXNIX_NATIVE_ENCODING` unset). `doctor` reports `opencode : fauxnix MCP configured (...)` when either shape is present. Restart OpenCode so it reloads MCP.
+
+## Smoke
+
+Run each line through the MCP `bash` tool (not PowerShell). v0.10.0-safe: no `while`/`until`/`case`, no arrays. Comments are expected stdout; every command exits 0. The `for` loop prints two lines (`a` then `b`).
+
+```
+echo hi                          # hi
+printf '%s=%d\n' x 42            # x=42
+echo $(echo nested)              # nested
+echo $((1+1))                    # 2
+unset X; echo ${X:-def}          # def
+if true; then echo YES; fi       # YES
+for x in a b; do echo $x; done   # a\nb
+false || echo FELLBACK           # FELLBACK
+echo hi | grep hi                # hi
+true; echo $?                    # 0
+```
+
+CLI equivalent (same stdout): `fauxnix 'echo hi'`.

--- a/docs/examples/qwen.md
+++ b/docs/examples/qwen.md
@@ -1,0 +1,60 @@
+# Qwen Code
+
+fauxnix is a bash→PowerShell translation layer for AI agents on Windows — no WSL, no VM. This harness talks to it over MCP stdio (`fauxnix mcp`); the tool name is `bash`.
+
+## Prerequisites
+
+- Windows
+- Node.js ≥ 18
+- `npm i -g fauxnix-cli` (the installed command is still `fauxnix`)
+- PowerShell 5.1 (built-in)
+
+## Install
+
+Preferred (idempotent; writes the same keys as the block below):
+
+```bash
+fauxnix install --qwen
+```
+
+If `install` is not in your build, paste the block by hand.
+
+**Path:** `%USERPROFILE%\.qwen\settings.json`
+
+Merge `mcpServers.fauxnix`; do not wipe other keys.
+
+```json
+{
+  "mcpServers": {
+    "fauxnix": { "command": "fauxnix", "args": ["mcp"] }
+  }
+}
+```
+
+## Verify
+
+```bash
+fauxnix check
+fauxnix doctor
+```
+
+Encoding is UTF-8 by default (`FAUXNIX_NATIVE_ENCODING` unset). v0.10.0 `doctor` does not list a qwen row; it still confirms PowerShell, encoding, and `mcp : module loads`. Restart Qwen Code so it reloads MCP.
+
+## Smoke
+
+Run each line through the MCP `bash` tool (not PowerShell). v0.10.0-safe: no `while`/`until`/`case`, no arrays. Comments are expected stdout; every command exits 0. The `for` loop prints two lines (`a` then `b`).
+
+```
+echo hi                          # hi
+printf '%s=%d\n' x 42            # x=42
+echo $(echo nested)              # nested
+echo $((1+1))                    # 2
+unset X; echo ${X:-def}          # def
+if true; then echo YES; fi       # YES
+for x in a b; do echo $x; done   # a\nb
+false || echo FELLBACK           # FELLBACK
+echo hi | grep hi                # hi
+true; echo $?                    # 0
+```
+
+CLI equivalent (same stdout): `fauxnix 'echo hi'`.


### PR DESCRIPTION
RFC 1.0 **U-4** / #118. Five examples + index. Smoke is v0.10-safe. Not merging.

Copy-paste MCP config and a 10-command smoke for claude, codex, opencode, kimi, and qwen (`docs/examples/<harness>.md` plus `docs/examples/README.md`). Paths and keys match `src/install.ts` INSTALL_FLAGS / `src/doctor.ts` (U-1 installer one-liner + the same manual block). Smoke does not depend on unmerged `while`/`case`/arrays.

Linked from README under Use with your agent harness.
