### PR TITLE
feat: CommandSpec for gzip/gunzip/zcat/zip/unzip (C-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,10 @@ development:
 `cp` / `mv` / `rm` / `touch` / `du` / `ls` / `ll` / `mkdir` / `rmdir` / `mktemp` / `ln` /
 `readlink` / `realpath` / `basename` / `dirname` / `stat` / `file` / `df` / `chmod` / `chown` /
 `diff` / `tee` / `grep` / `head` / `echo` / `printf` / `cat` / `tail` / `wc` / `sort` / `uniq` /
-`cut` / `tr` carry a `CommandSpec`: unknown options fail with a GNU-style
+`cut` / `tr` / `gzip` / `gunzip` / `zcat` / `zip` / `unzip` carry a `CommandSpec`: unknown options fail with a GNU-style
 usage error instead of being ignored (`find` stays unspec'd so predicates like `-name` still
-compile; `sed`/`awk`/`egrep` stay unspec'd). Implemented GNU holes: `cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` /
+compile; `sed`/`awk`/`egrep` stay unspec'd; `tar` stays unspec'd because it is fx-native to
+`tar.exe` and unknown GNU flags must reach bsdtar). Implemented GNU holes: `cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` /
 `head --lines` / `du --max-depth`. `fauxnix list --json` and `docs/command-specs.md` dump the
 same metadata.
 - **shell/system**: `cd pwd export unset env printenv ps kill pkill pgrep sleep which type whoami

--- a/docs/command-specs.md
+++ b/docs/command-specs.md
@@ -335,6 +335,111 @@ Effects: `read`
 | `-c`, `--complement` | flag | unsupported (complement) |
 | `-C` | flag | unsupported (complement) |
 
+## `gzip`
+
+Effects: `read`, `write`, `delete`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-d`, `--decompress` | flag | implemented |
+| `--uncompress` | flag | implemented |
+| `-k`, `--keep` | flag | implemented |
+| `-c`, `--stdout` | flag | implemented |
+| `--to-stdout` | flag | implemented |
+| `-t`, `--test` | flag | implemented |
+| `-1`, `--fast` | flag | implemented |
+| `-2` | flag | implemented |
+| `-3` | flag | implemented |
+| `-4` | flag | implemented |
+| `-5` | flag | implemented |
+| `-6` | flag | implemented |
+| `-7` | flag | implemented |
+| `-8` | flag | implemented |
+| `-9`, `--best` | flag | implemented |
+| `-f`, `--force` | flag | unsupported (force from terminal) |
+| `-q`, `--quiet` | flag | unsupported (quiet) |
+| `-v`, `--verbose` | flag | unsupported (verbose) |
+| `-n`, `--no-name` | flag | unsupported (no-name) |
+| `-r`, `--recursive` | flag | unsupported (recursive) |
+| `-S`, `--suffix` | required | unsupported (suffix) |
+
+## `gunzip`
+
+Effects: `read`, `write`, `delete`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-d`, `--decompress` | flag | implemented |
+| `--uncompress` | flag | implemented |
+| `-k`, `--keep` | flag | implemented |
+| `-c`, `--stdout` | flag | implemented |
+| `--to-stdout` | flag | implemented |
+| `-t`, `--test` | flag | implemented |
+| `-1`, `--fast` | flag | implemented |
+| `-2` | flag | implemented |
+| `-3` | flag | implemented |
+| `-4` | flag | implemented |
+| `-5` | flag | implemented |
+| `-6` | flag | implemented |
+| `-7` | flag | implemented |
+| `-8` | flag | implemented |
+| `-9`, `--best` | flag | implemented |
+| `-f`, `--force` | flag | unsupported (force from terminal) |
+| `-q`, `--quiet` | flag | unsupported (quiet) |
+| `-v`, `--verbose` | flag | unsupported (verbose) |
+| `-n`, `--no-name` | flag | unsupported (no-name) |
+| `-r`, `--recursive` | flag | unsupported (recursive) |
+| `-S`, `--suffix` | required | unsupported (suffix) |
+
+## `zcat`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-d`, `--decompress` | flag | implemented |
+| `--uncompress` | flag | implemented |
+| `-k`, `--keep` | flag | implemented |
+| `-c`, `--stdout` | flag | implemented |
+| `--to-stdout` | flag | implemented |
+| `-t`, `--test` | flag | implemented |
+| `-1`, `--fast` | flag | implemented |
+| `-2` | flag | implemented |
+| `-3` | flag | implemented |
+| `-4` | flag | implemented |
+| `-5` | flag | implemented |
+| `-6` | flag | implemented |
+| `-7` | flag | implemented |
+| `-8` | flag | implemented |
+| `-9`, `--best` | flag | implemented |
+| `-f`, `--force` | flag | unsupported (force from terminal) |
+| `-q`, `--quiet` | flag | unsupported (quiet) |
+| `-v`, `--verbose` | flag | unsupported (verbose) |
+| `-n`, `--no-name` | flag | unsupported (no-name) |
+| `-r`, `--recursive` | flag | unsupported (recursive) |
+| `-S`, `--suffix` | required | unsupported (suffix) |
+
+## `zip`
+
+Effects: `read`, `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-r` | flag | implemented |
+| `-q` | flag | implemented |
+| `-x`, `--exclude` | required | unsupported (exclude patterns) |
+
+## `unzip`
+
+Effects: `read`, `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-l` | flag | implemented |
+| `-o` | flag | implemented |
+| `-q` | flag | implemented |
+| `-d`, `--directory` | required | implemented |
+
 ## Unspec'd commands
 
-`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `cd`, `clear`, `command`, `curl`, `date`, `dig`, `dirs`, `egrep`, `env`, `eval`, `exit`, `export`, `false`, `find`, `free`, `groups`, `gunzip`, `gzip`, `history`, `host`, `hostname`, `id`, `ifconfig`, `ip`, `kill`, `less`, `man`, `md5sum`, `more`, `netstat`, `nl`, `nproc`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `printenv`, `ps`, `pushd`, `pwd`, `read`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `sleep`, `source`, `ss`, `sudo`, `tac`, `tar`, `test`, `timeout`, `true`, `type`, `uname`, `unset`, `unzip`, `uptime`, `wget`, `which`, `whoami`, `xargs`, `yes`, `zcat`, `zip`
+`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `cd`, `clear`, `command`, `curl`, `date`, `dig`, `dirs`, `egrep`, `env`, `eval`, `exit`, `export`, `false`, `find`, `free`, `groups`, `history`, `host`, `hostname`, `id`, `ifconfig`, `ip`, `kill`, `less`, `man`, `md5sum`, `more`, `netstat`, `nl`, `nproc`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `printenv`, `ps`, `pushd`, `pwd`, `read`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `sleep`, `source`, `ss`, `sudo`, `tac`, `tar`, `test`, `timeout`, `true`, `type`, `uname`, `unset`, `uptime`, `wget`, `which`, `whoami`, `xargs`, `yes`

--- a/src/commands/archive.ts
+++ b/src/commands/archive.ts
@@ -1,5 +1,5 @@
 import { Word, wordToString } from '../ast.js';
-import { Handler, PipelineCtx, parseWords, psStr } from '../registry.js';
+import { CommandSpec, Handler, OptionSpec, PipelineCtx, parseWords, psStr } from '../registry.js';
 import { argListExpr, exprOfWord, operandExpr } from '../translator.js';
 
 /* ------------------------------------------------------------------ */
@@ -239,6 +239,8 @@ const zcat: Handler = (args, ctx) => gzBlock(args, ctx, { decompress: true, stdo
 
 /* ------------------------------------------------------------------ */
 /* tar — Windows 10+ ships bsdtar as tar.exe, pass everything through  */
+/* Intentionally unspec'd: registerSpec fail-loud would reject GNU     */
+/* flags bsdtar accepts (--numeric-owner, …). Same class as find.      */
 /* ------------------------------------------------------------------ */
 
 const tar: Handler = (args) => {
@@ -415,8 +417,89 @@ const unzip: Handler = (args) => {
 };
 
 /* ------------------------------------------------------------------ */
-/* exports                                                             */
+/* CommandSpec (C-5 archive slice)                                     */
+/* tar stays unspec'd: fx-native to tar.exe; unknown GNU flags must    */
+/* reach bsdtar. gzip -f is a no-op today and the stdin-from-terminal  */
+/* message advertises it, so it is unsupported (force from terminal)   */
+/* rather than a silent ignore.                                        */
 /* ------------------------------------------------------------------ */
+
+const gzipOptions: OptionSpec[] = [
+  { short: 'd', long: '--decompress', support: 'implemented' },
+  { long: '--uncompress', support: 'implemented' },
+  { short: 'k', long: '--keep', support: 'implemented' },
+  { short: 'c', long: '--stdout', support: 'implemented' },
+  { long: '--to-stdout', support: 'implemented' },
+  { short: 't', long: '--test', support: 'implemented' },
+  { short: '1', long: '--fast', support: 'implemented' },
+  { short: '2', support: 'implemented' },
+  { short: '3', support: 'implemented' },
+  { short: '4', support: 'implemented' },
+  { short: '5', support: 'implemented' },
+  { short: '6', support: 'implemented' },
+  { short: '7', support: 'implemented' },
+  { short: '8', support: 'implemented' },
+  { short: '9', long: '--best', support: 'implemented' },
+  { short: 'f', long: '--force', support: 'unsupported', reason: 'force from terminal' },
+  { short: 'q', long: '--quiet', support: 'unsupported', reason: 'quiet' },
+  { short: 'v', long: '--verbose', support: 'unsupported', reason: 'verbose' },
+  { short: 'n', long: '--no-name', support: 'unsupported', reason: 'no-name' },
+  { short: 'r', long: '--recursive', support: 'unsupported', reason: 'recursive' },
+  { short: 'S', long: '--suffix', takesValue: true, support: 'unsupported', reason: 'suffix' },
+];
+
+export const specs: CommandSpec[] = [
+  {
+    names: ['gzip'],
+    options: gzipOptions,
+    effects: ['read', 'write', 'delete'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: gzip,
+  },
+  {
+    names: ['gunzip'],
+    options: gzipOptions,
+    effects: ['read', 'write', 'delete'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: gunzip,
+  },
+  {
+    names: ['zcat'],
+    options: gzipOptions,
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: zcat,
+  },
+  {
+    names: ['zip'],
+    options: [
+      // Compress-Archive always recurses directory inputs; -q is already quiet.
+      { short: 'r', support: 'implemented' },
+      { short: 'q', support: 'implemented' },
+      { short: 'x', long: '--exclude', takesValue: true, support: 'unsupported', reason: 'exclude patterns' },
+    ],
+    effects: ['read', 'write'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: zip,
+  },
+  {
+    names: ['unzip'],
+    options: [
+      { short: 'l', support: 'implemented' },
+      { short: 'o', support: 'implemented' },
+      { short: 'q', support: 'implemented' },
+      { short: 'd', long: '--directory', takesValue: true, support: 'implemented' },
+    ],
+    effects: ['read', 'write'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: unzip,
+  },
+];
 
 export const handlers: Record<string, Handler> = {
   tar,

--- a/src/commands/install-all.ts
+++ b/src/commands/install-all.ts
@@ -4,7 +4,7 @@ import { handlers as textFilters, specs as textFilterSpecs } from './text-filter
 import { handlers as textIo, specs as textIoSpecs } from './text-io.js';
 import { handlers as sysinfo } from './sysinfo.js';
 import { handlers as net } from './net.js';
-import { handlers as archive } from './archive.js';
+import { handlers as archive, specs as archiveSpecs } from './archive.js';
 
 /** Register every built-in Linux command translator. Side-effectful import. */
 export function installAll(): void {
@@ -17,6 +17,7 @@ export function installAll(): void {
   registerSpecs(fileSpecs);
   registerSpecs(textIoSpecs);
   registerSpecs(textFilterSpecs);
+  registerSpecs(archiveSpecs);
 }
 
 installAll();

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -965,6 +965,18 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(back.stdout).toContain('apple pie');
   });
 
+  it('gzip -k keeps the source; unknown gzip flags fail usage', async () => {
+    await run('cp fruits.txt gk.txt');
+    const k = await run('gzip -k gk.txt');
+    expect(k.exitCode).toBe(0);
+    expect(existsSync(join(dir, 'gk.txt'))).toBe(true);
+    expect(existsSync(join(dir, 'gk.txt.gz'))).toBe(true);
+    const z = await run('gzip -Z gk.txt');
+    expect(z.exitCode).toBe(1);
+    expect(z.stderr).toContain("invalid option -- 'Z'");
+    expect(z.stdout).toBe('');
+  });
+
   it('printf CRLF without a trailing LF is preserved on redirect', async () => {
     const r = await run("printf 'a\\r\\nb' > cr.txt; wc -c cr.txt");
     expect(r.exitCode).toBe(0);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1258,6 +1258,70 @@ describe('CommandSpec text-filters leftovers (#143)', () => {
   });
 });
 
+describe('CommandSpec archive leftovers (#143)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+
+  it('gzip/gunzip/zcat/zip/unzip are spec\'d; tar stays unspec\'d', () => {
+    expect(lookupSpec('gzip')).toBeTruthy();
+    expect(lookupSpec('gunzip')).toBeTruthy();
+    expect(lookupSpec('zcat')).toBeTruthy();
+    expect(lookupSpec('zip')).toBeTruthy();
+    expect(lookupSpec('unzip')).toBeTruthy();
+    expect(lookupSpec('tar')).toBeUndefined();
+    expect(lookupSpec('find')).toBeUndefined();
+  });
+
+  it('gzip unknown flags fail usage; -k/-c still translate', () => {
+    const z = bodyOf('gzip -Z f');
+    expect(z).toContain("invalid option -- ''Z''");
+    expect(z).toContain('$script:fx_exit = 1');
+    expect(z).toContain("Try ''gzip --help'' for more information.");
+    expect(z).not.toContain('GZipStream');
+    const keep = bodyOf('gzip -k f');
+    expect(keep).toContain('if (-not $true)');
+    expect(keep).not.toContain('invalid option');
+    expect(keep).toContain('GZipStream');
+    const stdout = bodyOf('gzip -c f');
+    expect(stdout).toContain('GetEncoding(28591)');
+    expect(stdout).not.toContain('Remove-Item');
+    expect(bodyOf('gzip --keep f')).toContain('if (-not $true)');
+    expect(bodyOf('gzip f')).toContain('if (-not $false)');
+  });
+
+  it('gzip -f is unsupported (force from terminal)', () => {
+    const f = bodyOf('gzip -f f');
+    expect(f).toContain("option ''-f'' is not supported by fauxnix");
+    expect(f).toContain('force from terminal');
+    expect(f).not.toContain('GZipStream');
+    expect(bodyOf('gzip --force f')).toContain('force from terminal');
+  });
+
+  it('tar unknown GNU flags still forward to tar.exe', () => {
+    const t = bodyOf('tar --numeric-owner -tf a.tar');
+    expect(t).toContain('fx-native');
+    expect(t).toContain('tar.exe');
+    expect(t).not.toContain('unrecognized option');
+    expect(t).not.toContain('invalid option');
+  });
+
+  it('zip -r still translates; -x is unsupported; unknown flags fail', () => {
+    expect(bodyOf('zip -r a.zip f')).toContain('Compress-Archive');
+    expect(bodyOf('zip -r a.zip f')).not.toContain('invalid option');
+    const x = bodyOf('zip -x p a.zip f');
+    expect(x).toContain("option ''-x'' is not supported by fauxnix");
+    expect(x).toContain('exclude patterns');
+    expect(x).not.toContain('Compress-Archive');
+    expect(bodyOf('zip -Z a.zip f')).toContain("invalid option -- ''Z''");
+  });
+
+  it('unzip -l/-o/-d still translate; unknown flags fail', () => {
+    expect(bodyOf('unzip -l a.zip')).toContain('OpenRead');
+    expect(bodyOf('unzip -o a.zip')).toContain('-Force:$true');
+    expect(bodyOf('unzip -d out a.zip')).toContain('$fx_dir');
+    expect(bodyOf('unzip -Z a.zip')).toContain("invalid option -- ''Z''");
+  });
+});
+
 describe('find predicates (#130)', () => {
   const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
   const throws = (cmd: string, msg: string) => {


### PR DESCRIPTION
C-5 archive slice (#143 / #118).

CommandSpec for `gzip` / `gunzip` / `zcat` / `zip` / `unzip`. Unknown and unsupported options fail with GNU-style usage errors instead of being ignored.

- gzip/gunzip/zcat: `-d/--decompress`, `-k/--keep`, `-c/--stdout`, `-t/--test`, `-1..-9`/`--fast`/`--best` implemented. `-f/--force` is unsupported (`force from terminal`) — the tty-stdin path still prints GNU's "Use -f to force" wording, but `parseGzipArgs` treated `f` as a silent no-op. `-q/-v/-n/-r/-S` likewise fail loud rather than looking like they work.
- zip: `-r`/`-q` implemented (Compress-Archive always recurses directory inputs; output is already quiet). `-x/--exclude` unsupported (`exclude patterns`).
- unzip: `-l`/`-o`/`-q`/`-d`/`--directory` implemented.

`tar` stays unspec'd: it is fx-native to `tar.exe` (Windows-shipped bsdtar). Spec'ing it would reject unknown GNU flags (`--numeric-owner`, …) in `registerSpec` before they reach bsdtar — same rationale class as `find`. Registry fail-loud semantics are unchanged.

Not merging.
