### PR TITLE
test: grow differential corpus + skip-safe weekly oracle (C-7)

### DIFF
--- a/.github/workflows/differential.yml
+++ b/.github/workflows/differential.yml
@@ -1,0 +1,26 @@
+name: Differential
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  oracle:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Run Git Bash oracle (skip-safe)
+        shell: pwsh
+        run: |
+          $bash = 'C:\Program Files\Git\bin\bash.exe'
+          if (Test-Path $bash) {
+            $env:FAUXNIX_DIFF_ORACLE = $bash
+            npx vitest run test/differential.test.ts
+          } else {
+            Write-Output 'differential oracle skipped: git-bash bash.exe missing'
+          }

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ npm run build
 npx tsx scratch/run.mjs "any bash command"   # quick live check
 ```
 
-Differential vs Git Bash is opt-in (`FAUXNIX_DIFF_ORACLE=1`; skips if unset or `bash.exe` is missing — Git Bash is not required). See [`test/differential/README.md`](test/differential/README.md). This is the RFC C-7 scaffold, not the 200-case 1.0 gate.
+Differential vs Git Bash is opt-in (`FAUXNIX_DIFF_ORACLE=1`; skips if unset or `bash.exe` is missing — Git Bash is not required). See [`test/differential/README.md`](test/differential/README.md). This is grown from the 40-case RFC C-7 scaffold, not the 200-case 1.0 gate. The weekly oracle is opt-in via the scheduled workflow (`.github/workflows/differential.yml`) when Git Bash is on the runner.
 
 Architecture map: `src/parser.ts` (bash subset → AST) · `src/translator.ts` (AST → PowerShell +
 executor wrapper) · `src/executor.ts` (spawn, redirects, session persistence) ·

--- a/test/differential.test.ts
+++ b/test/differential.test.ts
@@ -1,9 +1,10 @@
 /**
- * RFC C-7 scaffold: curated fauxnix vs Git Bash identity.
+ * RFC C-7 growth: curated fauxnix vs Git Bash identity.
  *
  * Default `npm test` imports this file and runs the corpus-shape check, then
  * skipIf's the oracle unless FAUXNIX_DIFF_ORACLE is set and git-bash bash.exe
- * exists. Missing Git Bash never fails CI.
+ * exists. Missing Git Bash never fails CI. The weekly schedule in
+ * `.github/workflows/differential.yml` is skip-safe the same way.
  */
 import { describe, expect, it } from 'vitest';
 import {
@@ -19,12 +20,12 @@ const corpus = loadCorpus();
 const skipOracle = !canRunOracle();
 const skipWhy = oracleSkipReason();
 
-describe('differential corpus scaffold (C-7 / #118)', () => {
-  it('loads the curated scaffold, not the 200-case 1.0 gate', () => {
+describe('differential corpus growth (C-7 / #118)', () => {
+  it('loads a grown corpus, not the 200-case 1.0 gate', () => {
     expect(corpus.gate.targetCases).toBe(200);
     expect(corpus.gate.identity).toBe(0.95);
-    expect(corpus.cases.length).toBeGreaterThanOrEqual(15);
-    expect(corpus.cases.length).toBeLessThanOrEqual(40);
+    expect(corpus.cases.length).toBeGreaterThanOrEqual(40);
+    expect(corpus.cases.length).toBeLessThan(200);
     const ids = corpus.cases.map((c) => c.id);
     expect(new Set(ids).size).toBe(ids.length);
     expect(ids).toEqual(expect.arrayContaining([
@@ -38,8 +39,8 @@ describe('differential corpus scaffold (C-7 / #118)', () => {
   });
 });
 
-describe.skipIf(skipOracle)('differential vs Git Bash oracle', { timeout: 180_000 }, () => {
-  it('identity is ≥95% of this small corpus', async () => {
+describe.skipIf(skipOracle)('differential vs Git Bash oracle', { timeout: 300_000 }, () => {
+  it('identity is ≥95% of this corpus', async () => {
     const bashPath = resolveGitBash();
     expect(bashPath).toBeTruthy();
     const run = await runCorpus({ corpus, bashPath: bashPath! });

--- a/test/differential/README.md
+++ b/test/differential/README.md
@@ -1,9 +1,9 @@
-# Differential corpus (RFC C-7 scaffold)
+# Differential corpus (RFC C-7 growth)
 
 Institutional home for fauxnix vs Git Bash identity checks. Tracking:
 [RFC 1.0 C-7](../../docs/rfc-1.0-completeness-usability.md) / [#118](https://github.com/20000419/fauxnix/issues/118).
 
-## This is a scaffold, not the 1.0 gate
+## This is growth from the scaffold, not the 1.0 gate
 
 The **1.0.0 hard gate** is:
 
@@ -11,17 +11,19 @@ The **1.0.0 hard gate** is:
 - ≥ **95%** byte-identical (stdout / stderr / exit, newlines normalized)
 - two consecutive green **scheduled** oracle runs
 
-`corpus.json` is a **high-value subset** (15–40 cases) sourced from already-shipped
-audit repros and integration tests (`echo hi >/dev/null`, `printf … | grep`,
-`head --lines=-1`, `grep -e a -e c`, …). It does **not** claim the 200-case gate.
-Grow it from benchmark transcripts, audit repros, and each merged completeness PR.
+`corpus.json` is a **high-value subset** grown from the 40-case scaffold
+(target ~80–100 here) sourced from already-shipped audit repros and
+integration tests (`if`/`for`, arith, grep/sed/sort/head, redirects, cmdsub,
+`${name:-}` / `${name:+}` / `${#name}`, pipes, `[[ -f ]]`, echo/printf).
+It does **not** claim the 200-case gate. Keep growing it from benchmark
+transcripts, audit repros, and each merged completeness PR.
 
-A weekly GitHub Actions cron is **not** added here. The oracle is opt-in
-(`FAUXNIX_DIFF_ORACLE`) and Git Bash is **not** required on developer machines or
-assumed on GH Windows. Default `npm test` imports `test/differential.test.ts` and
-**skips** the comparison. A commented / `if: false` workflow would be worse than
-this note; add a scheduled job later only when it is skip-safe or the image
-explicitly provides the oracle.
+A skip-safe weekly GitHub Actions cron (`.github/workflows/differential.yml`)
+runs Mondays at 06:00 UTC plus `workflow_dispatch`. It is **not** hooked to
+`pull_request` (fork PRs stay unblocked). The job is skip-safe: if Git Bash
+`bash.exe` is missing the step succeeds; if it is present, identity below 95%
+fails the job. Default `npm test` still imports `test/differential.test.ts`
+and **skips** the comparison unless `FAUXNIX_DIFF_ORACLE` is set.
 
 ## Running the oracle
 
@@ -69,4 +71,4 @@ letters). The comparison is newline-normalized stdout + stderr + exit.
 corpus (so CI imports the file). The oracle `describe` is `skipIf` when the env
 is unset or git-bash `bash.exe` is missing. When the oracle runs, each case goes
 through a fauxnix session **and** `bash.exe`; a summary is printed; the test
-fails if identity is below 95% of **this** small corpus.
+fails if identity is below 95% of **this** corpus.

--- a/test/differential/corpus.json
+++ b/test/differential/corpus.json
@@ -2,13 +2,16 @@
   "gate": {
     "targetCases": 200,
     "identity": 0.95,
-    "note": "RFC 1.0 C-7 / #118. The 1.0 hard gate is ≥200 curated cases at ≥95% byte-identical on scheduled oracle runs. This file is a high-value scaffold sourced from already-shipped audit repros, not that gate."
+    "note": "RFC 1.0 C-7 / #118. The 1.0 hard gate is ≥200 curated cases at ≥95% byte-identical on scheduled oracle runs. This file is deliberate growth from the 40-case scaffold, sourced from already-shipped audit repros and integration tests — not that gate."
   },
   "files": {
     "fruits.txt": "apple\nBanana\napple pie\ncherry\n",
     "letters.txt": "a\nb\nc\n",
     "three.txt": "one\ntwo\nthree\n",
-    "abc.txt": "abc"
+    "abc.txt": "abc",
+    "nums.txt": "1 2\n3 4\n5 6\n",
+    "dups.txt": "aaa\naaa\nbbb\n",
+    "dotenv.env": "FOO=bar\nexport BAZ=qux\n"
   },
   "cases": [
     {
@@ -210,6 +213,311 @@
       "id": "echo-pipe-grep",
       "cmd": "echo hi | grep hi",
       "source": "#153"
+    },
+    {
+      "id": "if-false-else",
+      "cmd": "if false; then echo A; else echo B; fi",
+      "source": "#112 / integration: if/then/else/fi follows the test exit code"
+    },
+    {
+      "id": "if-true-else",
+      "cmd": "if true; then echo A; else echo B; fi",
+      "source": "#112 / integration: if/then/else/fi follows the test exit code"
+    },
+    {
+      "id": "if-false-empty",
+      "cmd": "if false; then echo YES; fi",
+      "source": "#112 / integration: if/then/else/fi follows the test exit code"
+    },
+    {
+      "id": "elif-else-c",
+      "cmd": "if false; then echo A; elif false; then echo B; else echo C; fi",
+      "source": "#120 / integration: elif takes the first true branch"
+    },
+    {
+      "id": "elif-chain-c",
+      "cmd": "if false; then echo A; elif false; then echo B; elif true; then echo C; fi",
+      "source": "#120 / integration: elif takes the first true branch"
+    },
+    {
+      "id": "for-nums",
+      "cmd": "for x in 1 2; do echo $x; done",
+      "source": "#112 / integration: for x in words; do ...; done"
+    },
+    {
+      "id": "arith-var",
+      "cmd": "x=3; echo $((x+1))",
+      "source": "#119 / integration: word-level $((...)) evaluates through fx-arith"
+    },
+    {
+      "id": "arith-empty",
+      "cmd": "echo $(())",
+      "source": "#119 / integration: word-level $((...)) evaluates through fx-arith"
+    },
+    {
+      "id": "arith-div",
+      "cmd": "echo $((10/3))",
+      "source": "#119"
+    },
+    {
+      "id": "arith-pow",
+      "cmd": "echo $((2**3))",
+      "source": "#119"
+    },
+    {
+      "id": "param-default-empty",
+      "cmd": "X=; echo ${X:-def}",
+      "source": "#112 / integration: ${name:-word} and ${name:+word}"
+    },
+    {
+      "id": "param-default-set",
+      "cmd": "X=hi; echo ${X:-def}",
+      "source": "#112 / integration: ${name:-word} and ${name:+word}"
+    },
+    {
+      "id": "param-alt",
+      "cmd": "X=hi; echo ${X:+on}",
+      "source": "#112 / integration: ${name:-word} and ${name:+word}"
+    },
+    {
+      "id": "param-alt-unset",
+      "cmd": "unset X; echo [${X:+on}]",
+      "source": "#112 / integration: ${name:-word} and ${name:+word}"
+    },
+    {
+      "id": "strlen-unset",
+      "cmd": "unset Z; echo ${#Z}",
+      "source": "#112 / integration: ${#name} is string length"
+    },
+    {
+      "id": "cmdsub-list",
+      "cmd": "echo $(echo a; echo b)",
+      "source": "#179 / integration: variables and command substitution"
+    },
+    {
+      "id": "cmdsub-quoted-list",
+      "cmd": "echo \"$(echo a; echo b)\"",
+      "source": "#179 / integration: variables and command substitution"
+    },
+    {
+      "id": "cmdsub-and",
+      "cmd": "echo $(true && echo y)",
+      "source": "#179 / integration: variables and command substitution"
+    },
+    {
+      "id": "cmdsub-backtick",
+      "cmd": "echo `echo nested`",
+      "source": "#112 / integration: variables and command substitution"
+    },
+    {
+      "id": "true-and",
+      "cmd": "true && echo Y",
+      "source": "integration: && and || short-circuit like bash"
+    },
+    {
+      "id": "false-or",
+      "cmd": "false || echo Y",
+      "source": "integration: && and || short-circuit like bash"
+    },
+    {
+      "id": "pipe-or-last-true",
+      "cmd": "false | true || echo FALLBACK",
+      "source": "#124 / integration: pipeline exit status controls following && and ||"
+    },
+    {
+      "id": "status-true",
+      "cmd": "true; echo $?",
+      "source": "integration: $? reflects the previous segment"
+    },
+    {
+      "id": "bracket-dir",
+      "cmd": "[[ -d . ]] && echo dir",
+      "source": "#80 / integration: [[ ]] file and string tests"
+    },
+    {
+      "id": "bracket-not-dir",
+      "cmd": "[[ -d fruits.txt ]] && echo yes; echo after",
+      "source": "#80 / integration: [[ ]] file and string tests"
+    },
+    {
+      "id": "bracket-gt",
+      "cmd": "[[ 2 -gt 1 ]] && echo yes",
+      "source": "#80 / integration: [[ ]] file and string tests"
+    },
+    {
+      "id": "bracket-regex",
+      "cmd": "[[ abc =~ ^a ]] && echo match",
+      "source": "#80 / integration: [[ ]] file and string tests"
+    },
+    {
+      "id": "if-bracket-file",
+      "cmd": "if [[ -f fruits.txt ]]; then echo yes; fi",
+      "source": "#112 / #80"
+    },
+    {
+      "id": "sort-n",
+      "cmd": "printf '10\\n2\\n1\\n' | sort -n",
+      "source": "#177 / integration: sort -n and uniq -c"
+    },
+    {
+      "id": "sort-fruits",
+      "cmd": "sort fruits.txt",
+      "source": "#177 / integration: cat | grep | sort"
+    },
+    {
+      "id": "uniq-c",
+      "cmd": "sort dups.txt | uniq -c",
+      "source": "#177 / integration: sort -n and uniq -c"
+    },
+    {
+      "id": "cut-f1",
+      "cmd": "cut -d ' ' -f1 nums.txt",
+      "source": "#177 / integration: cut -d -f and tr -d still work"
+    },
+    {
+      "id": "tr-d",
+      "cmd": "printf 'abc\\n' | tr -d b",
+      "source": "#177 / integration: cut -d -f and tr -d still work"
+    },
+    {
+      "id": "tr-map",
+      "cmd": "printf 'abc\\n' | tr a A",
+      "source": "#177"
+    },
+    {
+      "id": "awk-field",
+      "cmd": "awk '{print $1}' fruits.txt",
+      "source": "integration: awk field printing and sum"
+    },
+    {
+      "id": "awk-sum",
+      "cmd": "awk '{sum += $1} END {print sum}' nums.txt",
+      "source": "integration: awk field printing and sum"
+    },
+    {
+      "id": "cat-fruits",
+      "cmd": "cat fruits.txt",
+      "source": "integration: cat reads files"
+    },
+    {
+      "id": "head-n-2",
+      "cmd": "head -n 2 fruits.txt",
+      "source": "#141 / integration: head/tail/wc"
+    },
+    {
+      "id": "tail-1",
+      "cmd": "tail -1 fruits.txt",
+      "source": "integration: head/tail/wc"
+    },
+    {
+      "id": "tail-n-2",
+      "cmd": "tail -n 2 fruits.txt",
+      "source": "integration: head/tail/wc"
+    },
+    {
+      "id": "wc-l-stdin",
+      "cmd": "wc -l < fruits.txt",
+      "source": "integration: head/tail/wc"
+    },
+    {
+      "id": "grep-n",
+      "cmd": "grep -n apple fruits.txt",
+      "source": "integration: grep + exit codes"
+    },
+    {
+      "id": "grep-i",
+      "cmd": "grep -i banana fruits.txt",
+      "source": "integration: cat | grep | sort"
+    },
+    {
+      "id": "grep-e-apple",
+      "cmd": "grep -e apple fruits.txt",
+      "source": "#152 / integration: grep -m1 stops after the first match"
+    },
+    {
+      "id": "grep-regexp-eq",
+      "cmd": "grep --regexp=a --regexp=c letters.txt",
+      "source": "#152 / integration: grep --regexp repeats OR-accumulate"
+    },
+    {
+      "id": "grep-Fo-overlap",
+      "cmd": "printf 'aaa\\n' | grep -F -o -e a -e aa",
+      "source": "#162 / integration: grep -F -o -e a -e b emits matches left-to-right"
+    },
+    {
+      "id": "echo-hello",
+      "cmd": "echo hello world",
+      "source": "integration: echo/printf semantics"
+    },
+    {
+      "id": "redirect-append",
+      "cmd": "echo one > o.txt; echo two >> o.txt; cat o.txt",
+      "source": "integration: redirects: > >> 2> /dev/null 2>&1"
+    },
+    {
+      "id": "last-pipe-redirect",
+      "cmd": "echo hi | cat > lastpipe.txt; cat lastpipe.txt",
+      "source": "#147 / integration: last-stage stdout redirect still writes"
+    },
+    {
+      "id": "head-to-file",
+      "cmd": "head -2 fruits.txt > hout.txt; cat hout.txt",
+      "source": "integration: redirects write LF line endings (GNU parity)"
+    },
+    {
+      "id": "printf-to-file-cat",
+      "cmd": "printf 'alpha\\nbeta\\n' > w.txt; cat w.txt",
+      "source": "integration: redirect byte counts match GNU"
+    },
+    {
+      "id": "mkdir-file-cat",
+      "cmd": "mkdir -p rt-dir; echo x > rt-dir/f.txt; cat rt-dir/f.txt",
+      "source": "integration: cat reads files"
+    },
+    {
+      "id": "touch-then-test",
+      "cmd": "touch created.txt; [[ -f created.txt ]] && echo yes",
+      "source": "#130 / integration: touch -c does not create a missing file; plain touch does"
+    },
+    {
+      "id": "tee-print",
+      "cmd": "printf B | tee tee-out.txt",
+      "source": "#130 / integration: tee --append appends instead of truncating"
+    },
+    {
+      "id": "cp-then-cat",
+      "cmd": "cp letters.txt letters.copy.txt; cat letters.copy.txt",
+      "source": "#130 / integration: cp without -n overwrites dest"
+    },
+    {
+      "id": "source-dotenv",
+      "cmd": "source dotenv.env; echo $FOO $BAZ; unset FOO BAZ",
+      "source": "#112 / integration: source reads NAME=VALUE files into the session"
+    },
+    {
+      "id": "sed-delete-line",
+      "cmd": "sed '1d' fruits.txt",
+      "source": "integration: sed substitution"
+    },
+    {
+      "id": "sed-n-first",
+      "cmd": "sed -n '1p' fruits.txt",
+      "source": "integration: sed substitution"
+    },
+    {
+      "id": "arith-mod",
+      "cmd": "echo $((10%3))",
+      "source": "#119"
+    },
+    {
+      "id": "test-file",
+      "cmd": "test -f fruits.txt && echo yes",
+      "source": "#80 / integration: [[ ]] file and string tests"
+    },
+    {
+      "id": "posix-test-file",
+      "cmd": "[ -f fruits.txt ] && echo yes",
+      "source": "#80 / integration: [[ ]] file and string tests"
     }
   ]
 }

--- a/test/differential/run.ts
+++ b/test/differential/run.ts
@@ -174,7 +174,7 @@ export function formatSummary(run: CorpusRun): string {
   const pct = (run.identity * 100).toFixed(1);
   const lines = [
     `differential: ${run.identical}/${run.total} identical (${pct}%) vs ${run.bashPath}`,
-    `gate for this corpus: ≥${(run.gate * 100).toFixed(0)}%  |  1.0 gate: ≥200 cases at ≥95% (not this scaffold)`,
+    `gate for this corpus: ≥${(run.gate * 100).toFixed(0)}%  |  1.0 gate: ≥200 cases at ≥95% (not this corpus)`,
   ];
   const mismatches = run.results.filter((r) => !r.identical);
   for (const m of mismatches) {


### PR DESCRIPTION
C-7 / #118. Grow the differential corpus from the 40-case scaffold and add a skip-safe weekly Git Bash oracle. **Not merging.**

## What

- Corpus **40 → 101** unique cases, sourced from already-shipped integration tests and audit repros on v0.10.0 main (`if`/`for`, arith, grep/sed/sort/uniq/cut/tr, head/tail/wc, redirects, C-4 cmdsub lists, `${name:-}` / `${:+}` / `${#name}`, pipes, `[[ ]]`, echo/printf, mkdir/touch/tee/cp).
- Unit assertion is now `>= 40` and `< 200`. This is **not** the 200-case 1.0 gate; it is deliberate growth from the 40-case scaffold.
- `.github/workflows/differential.yml` is **schedule-only** (Monday 06:00 UTC) plus `workflow_dispatch`. It is **not** on `pull_request`, so fork PRs stay unblocked.
- Job is skip-safe: if `C:\Program Files\Git\bin\bash.exe` is missing the step succeeds; if it is present, identity below 95% fails the job.
- Not added to `.github/workflows/ci.yml`.

## Local oracle

Ran with Git Bash at `C:\Program Files\Git\bin\bash.exe`: **100/101 identical (99.0%)**. The remaining miss is the scaffold case `or-fallback` (`cat missing.txt || echo FELLBACK`) — fauxnix stderr lacks the trailing newline Git Bash prints. Cases that mismatched (pipeline `read` subshell, prefix assignment expansion, `tr` without a trailing newline, Git Bash `md5sum *` binary marker, cmdsub exit from `false; echo x`) were dropped.

## Not this PR

- Not the ≥200-case 1.0 hard gate.
- No version bump.
- No parser/translator changes.
