### PR TITLE
feat: case ... esac (RFC 1.0 C-1 slice)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,12 +213,13 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   word expansion precedes the temporary environment).
 - `yes` is capped at 65,536 lines — PS 5.1 pipelines cannot signal upstream producers to stop, so
   an unbounded `yes | head` would hang.
-- `tail -f`, `eval`, `alias`, heredocs, `while`/`until`/`case`,
+- `tail -f`, `eval`, `alias`, heredocs, `while`/`until`,
   `env -i`/`--ignore-environment`,
   background `&`, and stdout redirects (`>` `>>` `&>` `&>>`) on a non-last
   pipeline stage (`echo hi >f | cat`) are rejected with actionable error
   messages instead of misbehaving.
-  (`if/then/elif/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
+  (`if/then/elif/else/fi`, `for x in ...`, `case ... esac` (`;;` only; `;&`/`;;&` fail loud),
+  backtick substitution, `command -v`, pipeline `read`,
   dotenv-style `source`, and word-level `$((...))` arithmetic expansion are supported.)
 - `command -v <builtin>` prints `/usr/bin/<name>` where bash prints the bare builtin name;
   exit codes and empty-result semantics match.

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -12,7 +12,7 @@
  *   - env assignment prefix: VAR=value cmd
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
- *   heredocs, subshells (...), background &, while/until/case,
+ *   heredocs, subshells (...), background &, while/until,
  *   globs inside quotes, process substitution <(...).
  */
 
@@ -28,7 +28,7 @@ export interface ListSegment {
   op: ';' | '&&' | '||';
 }
 
-export type ShellCommand = SimpleCommand | IfCommand | ForCommand;
+export type ShellCommand = SimpleCommand | IfCommand | ForCommand | CaseCommand;
 
 export interface Pipeline {
   kind: 'Pipeline';
@@ -48,6 +48,18 @@ export interface ForCommand {
   name: string;
   words: Word[];
   body: CommandList;
+  redirects: Redirect[];
+}
+
+export interface CaseArm {
+  patterns: Word[];
+  body: CommandList;
+}
+
+export interface CaseCommand {
+  kind: 'Case';
+  word: Word;
+  arms: CaseArm[];
   redirects: Redirect[];
 }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -39,7 +39,7 @@ Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), e
 
 Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
-Not supported: heredocs, while/until/case, env -i/--ignore-environment, background jobs. if/then/elif/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
+Not supported: heredocs, while/until, env -i/--ignore-environment, background jobs. if/then/elif/else/fi, for-in loops, case ... esac, and word-level \$((...)) arithmetic expansion are supported.
 
 CWD, environment variables, export/unset and cd persist across calls within this session — a resident PowerShell 5.1 host is started when the MCP session begins (and after reset), so the first bash tool call is already warm.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout, 130 cancelled). The tool also returns structuredContent (schemaVersion 1) with stdout/stderr/exitCode/timedOut/cancelled/truncated/sessionId.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -9,6 +9,8 @@ import {
   SimpleCommand,
   IfCommand,
   ForCommand,
+  CaseCommand,
+  CaseArm,
   ShellCommand,
   Word,
   WordPart,
@@ -31,7 +33,7 @@ interface Token {
 }
 
 const OPERATORS = [
-  '&&', '||', '>>', '<<', '2>&1', '1>&2', '2>', '&>>', '&>', '>', '<', '|', ';',
+  '&&', '||', '>>', '<<', '2>&1', '1>&2', '2>', '&>>', '&>', '>', '<', '|', ';;', ';',
 ] as const;
 
 export function tokenize(input: string): Token[] {
@@ -624,15 +626,39 @@ export function parseCommand(input: string): CommandList {
 
   const isListSep = (o?: string) => o === ';' || o === '\n';
 
+  const isAmpWord = (t: Token | undefined): boolean =>
+    !!t && t.type === 'WORD' && !!t.parts && isUnquotedLiteral(t.parts, '&');
+
+  const isCaseFallthrough = (): boolean => {
+    const t = peek();
+    if (t.type !== 'OP') return false;
+    return (t.op === ';' || t.op === ';;') && isAmpWord(tokens[pos + 1]);
+  };
+
+  const throwUnexpectedDsemi = (): never => {
+    throw new FauxnixParseError("fauxnix: syntax error near unexpected token `;;'");
+  };
+
+  const throwCaseFallthrough = (): never => {
+    throw new FauxnixParseError(
+      'fauxnix: case fallthrough (;& / ;;&) is not supported; use ;; (no fallthrough) or duplicate the body',
+    );
+  };
+
   /** Consume `;` / newline / `&&` / `||`. Trailing `&&`/`||` and `;;` fail loud (bash). */
   const consumeListOp = (stops?: Set<string>): ';' | '&&' | '||' | null => {
     const t = peek();
     if (t.type !== 'OP') return null;
+    if (t.op === ';;') {
+      if (stops && stops.has(';;')) return null;
+      throwUnexpectedDsemi();
+    }
     if (!(t.op === '&&' || t.op === '||' || isListSep(t.op))) return null;
     if (t.op === ';') {
+      if (stops && stops.has(';;') && isAmpWord(tokens[pos + 1])) return null;
       next();
-      if (peek().type === 'OP' && peek().op === ';') {
-        throw new FauxnixParseError("fauxnix: syntax error near unexpected token `;;'");
+      if (peek().type === 'OP' && (peek().op === ';' || peek().op === ';;')) {
+        throwUnexpectedDsemi();
       }
       return ';';
     }
@@ -663,16 +689,18 @@ export function parseCommand(input: string): CommandList {
     const segments: ListSegment[] = [];
     let op: ';' | '&&' | '||' = ';';
     while (peek().type === 'OP' && isListSep(peek().op)) {
-      if (peek().op === ';' && tokens[pos + 1]?.type === 'OP' && tokens[pos + 1]?.op === ';') {
-        throw new FauxnixParseError("fauxnix: syntax error near unexpected token `;;'");
+      if (peek().op === ';' && tokens[pos + 1]?.type === 'OP' && (tokens[pos + 1]?.op === ';' || tokens[pos + 1]?.op === ';;')) {
+        throwUnexpectedDsemi();
       }
       next();
     }
     while (peek().type !== 'EOF') {
+      if (peek().type === 'OP' && peek().op === ';;') throwUnexpectedDsemi();
       const pipeline = parsePipeline();
       segments.push({ pipeline, op });
       const nextOp = consumeListOp();
       if (nextOp === null) {
+        if (peek().type === 'OP' && peek().op === ';;') throwUnexpectedDsemi();
         if (peek().type === 'EOF') break;
         throw new FauxnixParseError('fauxnix: unexpected token after pipeline');
       }
@@ -696,6 +724,11 @@ export function parseCommand(input: string): CommandList {
           throw new FauxnixParseError('fauxnix: for in a pipeline is not supported');
         }
         commands.push(parseFor());
+      } else if (kw === 'case') {
+        if (commands.length > 0) {
+          throw new FauxnixParseError('fauxnix: case in a pipeline is not supported');
+        }
+        commands.push(parseCase());
       } else {
         commands.push(parseSimple());
       }
@@ -724,7 +757,9 @@ export function parseCommand(input: string): CommandList {
       s === 'in' ||
       s === 'do' ||
       s === 'done' ||
-      s === 'while'
+      s === 'while' ||
+      s === 'case' ||
+      s === 'esac'
     ) {
       return s;
     }
@@ -743,21 +778,27 @@ export function parseCommand(input: string): CommandList {
     const segments: ListSegment[] = [];
     let op: ';' | '&&' | '||' = ';';
     while (peek().type === 'OP' && isListSep(peek().op)) {
-      if (peek().op === ';' && tokens[pos + 1]?.type === 'OP' && tokens[pos + 1]?.op === ';') {
-        throw new FauxnixParseError("fauxnix: syntax error near unexpected token `;;'");
+      if (peek().op === ';' && tokens[pos + 1]?.type === 'OP' && (tokens[pos + 1]?.op === ';' || tokens[pos + 1]?.op === ';;')) {
+        throwUnexpectedDsemi();
       }
       next();
     }
     while (peek().type !== 'EOF') {
+      if (stop.has(';;') && isCaseFallthrough()) break;
       const kw = peekKw();
       if (kw && stop.has(kw)) break;
+      const stopOp = peek();
+      if (stopOp.type === 'OP' && stopOp.op && stop.has(stopOp.op)) break;
+      if (stopOp.type === 'OP' && stopOp.op === ';;') throwUnexpectedDsemi();
       const pipeline = parsePipeline();
       segments.push({ pipeline, op });
+      if (stop.has(';;') && isCaseFallthrough()) break;
       const nextOp = consumeListOp(stop);
       if (nextOp === null) break;
       op = nextOp;
     }
     if (segments.length === 0) {
+      if (stop.has(';;')) return { kind: 'CommandList', segments: [] };
       throw new FauxnixParseError('fauxnix: empty command');
     }
     return { kind: 'CommandList', segments };
@@ -817,6 +858,77 @@ export function parseCommand(input: string): CommandList {
     const body = parseListUntil(['done']);
     expectKw('done');
     return { kind: 'For', name, words, body, redirects: [] };
+  };
+
+  const skipCaseSeps = (): void => {
+    while (peek().type === 'OP' && isListSep(peek().op)) {
+      if (peek().op === ';' && isAmpWord(tokens[pos + 1])) break;
+      next();
+    }
+  };
+
+  /** Strip a trailing unquoted `)` that closes a case pattern list. */
+  const stripTrailingUnquotedParen = (w: Word): Word | null => {
+    if (w.length === 0) return null;
+    const last = w[w.length - 1];
+    if (last.kind !== 'Text' || last.escaped || !last.text.endsWith(')')) return null;
+    const rest = last.text.slice(0, -1);
+    if (rest.length === 0) return w.slice(0, -1);
+    return [...w.slice(0, -1), { kind: 'Text', text: rest, escaped: last.escaped }];
+  };
+
+  const parseCasePatterns = (): Word[] => {
+    const patterns: Word[] = [];
+    for (;;) {
+      while (peek().type === 'OP' && (peek().op === '|' || peek().op === '\n')) next();
+      if (peekKw() === 'esac') {
+        throw new FauxnixParseError("fauxnix: expected `)'");
+      }
+      const t = peek();
+      if (t.type !== 'WORD' || !t.parts) {
+        throw new FauxnixParseError('fauxnix: `case` expected a pattern');
+      }
+      const stripped = stripTrailingUnquotedParen(t.parts);
+      if (stripped !== null) {
+        next();
+        if (stripped.length > 0) patterns.push(stripped);
+        if (patterns.length === 0) {
+          throw new FauxnixParseError('fauxnix: `case` expected a pattern');
+        }
+        return patterns;
+      }
+      patterns.push(t.parts);
+      next();
+    }
+  };
+
+  const parseCase = (): CaseCommand => {
+    expectKw('case');
+    skipCaseSeps();
+    const wt = peek();
+    if (wt.type !== 'WORD' || !wt.parts) {
+      throw new FauxnixParseError('fauxnix: `case` expected a word');
+    }
+    const word = wt.parts;
+    next();
+    skipCaseSeps();
+    expectKw('in');
+    const arms: CaseArm[] = [];
+    skipCaseSeps();
+    while (peek().type !== 'EOF' && peekKw() !== 'esac') {
+      if (isCaseFallthrough()) throwCaseFallthrough();
+      const patterns = parseCasePatterns();
+      const body = parseListUntil(['esac', ';;']);
+      if (isCaseFallthrough()) throwCaseFallthrough();
+      if (peek().type === 'OP' && peek().op === ';;') {
+        next();
+        if (isAmpWord(peek())) throwCaseFallthrough();
+      }
+      arms.push({ patterns, body });
+      skipCaseSeps();
+    }
+    expectKw('esac');
+    return { kind: 'Case', word, arms, redirects: [] };
   };
 
   const parseSimple = (): SimpleCommand => {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -7,6 +7,7 @@ import {
   SimpleCommand,
   IfCommand,
   ForCommand,
+  CaseCommand,
   Word,
   WordPart,
   isUnquotedLiteral,
@@ -851,6 +852,22 @@ function translateIf(cmd: IfCommand): string {
   return lines.join('\n');
 }
 
+function translateCase(cmd: CaseCommand): string {
+  const lines = ['$script:fx_exit = 0', '$fx_cw = ' + exprOfWord(cmd.word)];
+  for (let i = 0; i < cmd.arms.length; i++) {
+    const arm = cmd.arms[i];
+    const pats = arm.patterns.map((w) => exprOfWord(w)).join(',');
+    const head = i === 0 ? 'if' : 'elseif';
+    lines.push(head + ' (fx-casematch $fx_cw @(' + pats + ')) {');
+    const body = translateListInline(arm.body);
+    if (body) {
+      for (const l of body.split('\n')) lines.push(l ? '  ' + l : l);
+    }
+    lines.push('}');
+  }
+  return lines.join('\n');
+}
+
 function translateFor(cmd: ForCommand): string {
   const n = cmd.name.replace(/'/g, "''");
   const lines = [
@@ -910,7 +927,7 @@ function rejectNonLastStdoutRedirects(commands: ShellCommand[]): void {
 }
 
 export function translatePipelineBody(p: {
-  commands: Array<SimpleCommand | IfCommand | ForCommand>;
+  commands: Array<SimpleCommand | IfCommand | ForCommand | CaseCommand>;
 }): PipelineParts {
   // Last-stage `>` is Node apply; a non-last `>` would truncate the file and
   // still feed the pipe. Fail loud until in-stage writes (#157).
@@ -929,6 +946,7 @@ export function translatePipelineBody(p: {
       i === 0 ? 'first' : i === p.commands.length - 1 ? 'last' : 'middle';
     if (c.kind === 'If') bodies.push(translateIf(c));
     else if (c.kind === 'For') bodies.push(translateFor(c));
+    else if (c.kind === 'Case') bodies.push(translateCase(c));
     else bodies.push(translateSimple(c, position, hasStdin));
   }
 
@@ -1060,6 +1078,7 @@ const WRAP_HELPER_ORDER = [
   'fx-arrput',
   'fx-arrclr',
   'fx-subget',
+  'fx-casematch',
   'fx-winargv',
   'fx-native',
 ] as const;
@@ -1081,6 +1100,7 @@ const WRAP_HELPER_DEPS: Record<WrapHelper, WrapHelper[]> = {
   'fx-arrput': ['fx-arrdrop', 'fx-svenc'],
   'fx-arrclr': ['fx-arrdrop'],
   'fx-subget': ['fx-arrload', 'fx-ifs1'],
+  'fx-casematch': [],
   'fx-winargv': [],
   'fx-native': ['fx-winargv'],
 };
@@ -1371,6 +1391,19 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '  if (-not [int]::TryParse($ix, [ref]$i)) { return \'\' }',
       "  if ($i -lt 0 -or $i -ge $arr.Count) { return '' }",
       '  return [string]$arr[$i]',
+      '}',
+    ],
+    'fx-casematch': [
+      'function fx-casematch($w, $pats) {',
+      '  $w = [string]$w',
+      '  foreach ($p in @($pats)) {',
+      '    $pat = [string]$p',
+      '    try {',
+      '      $wp = [WildcardPattern]::new($pat, [System.Management.Automation.WildcardOptions]::None)',
+      '      if ($wp.IsMatch($w)) { return $true }',
+      '    } catch {}',
+      '  }',
+      '  return $false',
       '}',
     ],
     'fx-winargv': [

--- a/test/differential.test.ts
+++ b/test/differential.test.ts
@@ -24,7 +24,7 @@ describe('differential corpus scaffold (C-7 / #118)', () => {
     expect(corpus.gate.targetCases).toBe(200);
     expect(corpus.gate.identity).toBe(0.95);
     expect(corpus.cases.length).toBeGreaterThanOrEqual(15);
-    expect(corpus.cases.length).toBeLessThanOrEqual(40);
+    expect(corpus.cases.length).toBeLessThan(200);
     const ids = corpus.cases.map((c) => c.id);
     expect(new Set(ids).size).toBe(ids.length);
     expect(ids).toEqual(expect.arrayContaining([

--- a/test/differential/corpus.json
+++ b/test/differential/corpus.json
@@ -210,6 +210,31 @@
       "id": "echo-pipe-grep",
       "cmd": "echo hi | grep hi",
       "source": "#153"
+    },
+    {
+      "id": "case-hit",
+      "cmd": "case x in x) echo HIT;; esac",
+      "source": "#118 C-1 case"
+    },
+    {
+      "id": "case-alt",
+      "cmd": "case x in a|x) echo HIT;; esac",
+      "source": "#118 C-1 case"
+    },
+    {
+      "id": "case-star",
+      "cmd": "case z in a) echo A;; *) echo D;; esac",
+      "source": "#118 C-1 case"
+    },
+    {
+      "id": "case-nomatch-status",
+      "cmd": "case x in y) echo NO;; esac; echo $?",
+      "source": "#118 C-1 case"
+    },
+    {
+      "id": "case-false-status",
+      "cmd": "case x in x) false;; esac; echo $?",
+      "source": "#118 C-1 case"
     }
   ]
 }

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1178,6 +1178,17 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     );
   });
 
+  it('case ... esac matches the first arm and keeps compound status', async () => {
+    const hit = await run('case x in x) echo HIT;; esac');
+    expect(hit.stdout.trim()).toBe('HIT');
+    expect(hit.exitCode).toBe(0);
+    expect((await run('case x in a|x) echo HIT;; esac')).stdout.trim()).toBe('HIT');
+    expect((await run('case z in a) echo A;; *) echo D;; esac')).stdout.trim()).toBe('D');
+    expect((await run('case x in y) echo NO;; esac; echo $?')).stdout.trim()).toBe('0');
+    expect((await run('case x in x) false;; esac; echo $?')).stdout.trim()).toBe('1');
+    expect((await run('if true; then case x in x) echo Y;; esac; fi')).stdout.trim()).toBe('Y');
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -164,6 +164,46 @@ describe('parser', () => {
     expect(c.words).toHaveLength(3);
   });
 
+  it('parses case x in x) echo HIT;; esac', () => {
+    const list = parse('case x in x) echo HIT;; esac');
+    expect(list.segments).toHaveLength(1);
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('Case');
+    if (c.kind !== 'Case') return;
+    expect(wordToString(c.word)).toBe('x');
+    expect(c.arms).toHaveLength(1);
+    expect(c.arms[0].patterns.map(wordToString)).toEqual(['x']);
+  });
+
+  it('parses case pattern alternation a|x)', () => {
+    const list = parse('case x in a|x) echo HIT;; esac');
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('Case');
+    if (c.kind !== 'Case') return;
+    expect(c.arms).toHaveLength(1);
+    expect(c.arms[0].patterns.map(wordToString)).toEqual(['a', 'x']);
+  });
+
+  it('parses case default *) arm', () => {
+    const list = parse('case x in *) echo D;; esac');
+    const c = list.segments[0].pipeline.commands[0];
+    expect(c.kind).toBe('Case');
+    if (c.kind !== 'Case') return;
+    expect(c.arms).toHaveLength(1);
+    expect(c.arms[0].patterns.map(wordToString)).toEqual(['*']);
+  });
+
+  it('rejects case fallthrough ;& / ;;&', () => {
+    expect(() => parse('case x in x) echo HIT;& esac')).toThrow(/case fallthrough/);
+    expect(() => parse('case x in x) echo HIT;;& esac')).toThrow(/case fallthrough/);
+  });
+
+  it('rejects case in a pipeline', () => {
+    expect(() => parse('echo hi | case x in x) echo y;; esac')).toThrow(
+      /case in a pipeline is not supported/,
+    );
+  });
+
   it('parses ${name[index]} subscripts', () => {
     const cmd = parse('echo ${BASH_REMATCH[1]} ${PATH[0]} ${x[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'BASH_REMATCH', index: '1' }]);
@@ -222,6 +262,9 @@ describe('parser', () => {
     expect(() => parse('echo A;; echo B')).toThrow(/unexpected token `;;'/);
     expect(() => parse('echo A; ; echo B')).toThrow(/unexpected token `;;'/);
     expect(parse('echo A; echo B').segments).toHaveLength(2);
+    const toks = tokenize('echo A;; echo B');
+    expect(toks.filter((t) => t.type === 'OP' && t.op === ';;')).toHaveLength(1);
+    expect(toks.filter((t) => t.type === 'OP' && t.op === ';')).toHaveLength(0);
   });
 
   it('env -i is a loud usage error, not a silent ignore', () => {
@@ -522,6 +565,18 @@ describe('translator', () => {
     expect(s).not.toContain('function fx-csub');
     expect(s).not.toContain('function fx-readlines');
     expect(s).not.toContain('function fx-subget');
+  });
+
+  it('translates case to fx-casematch if/elseif', () => {
+    const one = translateCommandList(parse('case x in x) echo HIT;; esac'))[0];
+    expect(one.body).toContain('fx-casematch');
+    expect(one.body).toMatch(/if \(fx-casematch/);
+    expect(one.body).not.toContain('elseif (fx-casematch');
+    expect(one.script).toContain('function fx-casematch');
+    const two = translateCommandList(parse('case z in a) echo A;; *) echo D;; esac'))[0];
+    expect(two.body).toContain('fx-casematch');
+    expect(two.body).toMatch(/if \(fx-casematch/);
+    expect(two.body).toContain('elseif (fx-casematch');
   });
 
   it('emits only the wrapScript helpers a translation actually calls', () => {


### PR DESCRIPTION
RFC 1.0 **C-1 slice: `case` only** (tracking #118).

## What this is

`case WORD in PAT [| PAT]...) list ;; … esac` as a compound command, on top of current `main` (v0.10.0). `while`/`until` stay unsupported here.

This is **not** a merge of C-1 as a whole, and it is **not** stacked on #182.

## `;&` fallthrough decision

The RFC asked us to decide the `;&` fallthrough question. **Fail-loud, not silent-wrong:**

- `;;` is implemented (end the arm; no fallthrough; first match wins).
- `;&` and `;;&` throw:
  `fauxnix: case fallthrough (;& / ;;&) is not supported; use ;; (no fallthrough) or duplicate the body`

So an agent that emits bash-4 fallthrough gets an actionable one-line alternative (U-3) instead of matching the wrong arm.

## Out of scope (do not merge as “C-1 done”)

- `while` / `until` remain loud-unsupported on this branch. That work is the separate open PR **#182**.
- No `find` CommandSpec / no reopening #131.
- No version bump.

Please **do not merge** until a maintainer has reviewed this slice on its own.

## Implementation

- **Tokenizer:** `;;` is a longest-first operator *before* `;`, so `echo A;; echo B` is one `;;` token and still a syntax error outside `case`. `)` is **not** a global operator (would break `[[ ]]` grouping); case patterns end with `)` glued to a word (`foo)`) or as a tight-left word `)`.
- **AST:** `CaseCommand` / `CaseArm`; `ShellCommand` includes `Case`. Header “explicitly unsupported” drops `case`, keeps `while`/`until`.
- **Parser:** `case` cannot sit in a pipeline (same as `if`/`for`). Pattern `|` is alternation, not a pipe — `parseCase` does not call `parsePipeline` for the pattern list. `parseListUntil` can stop on operator `;;` without letting `if`/`for` swallow `;;`.
- **Translator:** `if` / `elseif` chain of `fx-casematch $fx_cw @(pats)`. Helper is case-sensitive glob (`WildcardPattern` + `WildcardOptions.None`). Unmatched `case` exits 0; a taken arm’s last command owns `$script:fx_exit`; empty body → 0.
- **Docs:** README known deviations and MCP `TOOL_DESCRIPTION` list `case` as supported; `while`/`until` still not.

## Tests

- Unit: parse one-arm / `a|x` / `*`; `echo A;; echo B` still throws `;;`; `;&` / `;;&` throw fallthrough; translate emits `fx-casematch` + `if`/`elseif`.
- Integration: HIT, alternation, default `*`, unmatched status 0, taken `false` status 1, `if … then case … fi`.
- Differential: five corpus rows, source `#118 C-1 case`; scaffold upper bound raised to `< 200`.

`npx tsc --noEmit` clean. `npx vitest run --dir test`: **277 passed, 1 skipped** (oracle skip without `FAUXNIX_DIFF_ORACLE`).
