### PR TITLE
feat: array assignment and param replace/slice (C-2 / #118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ same metadata.
 - **archives**: `tar gzip gunzip zcat zip unzip`
 
 Plus shell syntax: pipes, `&&` / `||` / `;`, redirections (`> >> 2> 2>&1 < &>`, `/dev/null`),
-quoting, `$VAR` `$(...)` command substitution, `VAR=x cmd` prefixes, `~` expansion, and
-POSIX-style path normalization (`/tmp`, `/d/foo` → `D:\foo`).
+quoting, `$VAR` `${name:-word}` `${name//pat/str}` `${name:off:len}` `${name[n]}` `${#name[@]}`,
+`A=(x y z)` array assignment, `$(...)` command substitution, `VAR=x cmd` prefixes, `~` expansion,
+and POSIX-style path normalization (`/tmp`, `/d/foo` → `D:\foo`).
 
 Exit codes follow bash conventions: 0 ok, 1 fail, 2 usage/serious, 127 command not found,
 124 timeout.
@@ -219,7 +220,8 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   pipeline stage (`echo hi >f | cat`) are rejected with actionable error
   messages instead of misbehaving.
   (`if/then/elif/else/fi`, `for x in ...`, backtick substitution, `command -v`, pipeline `read`,
-  dotenv-style `source`, and word-level `$((...))` arithmetic expansion are supported.)
+  dotenv-style `source`, word-level `$((...))` arithmetic expansion, `A=(x y z)` arrays, and
+  `${name//pat/str}` / `${name:off:len}` are supported.)
 - `command -v <builtin>` prints `/usr/bin/<name>` where bash prints the bare builtin name;
   exit codes and empty-result semantics match.
 - `chmod` maps only the read-only bit; exec bits are no-ops on Windows. `chown` is a silent no-op

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -6,10 +6,12 @@
  *   - lists:                cmd1 ; cmd2 && cmd3 || cmd4   (newlines act as ';')
  *   - redirections:         > >> 2> 2>> &> 2>&1 1>&2 <
  *   - quoting:              'literal'  "interp $VAR $(cmd)"
- *   - variables:            $VAR ${VAR} ${VAR[n]} plus special cases ($HOME $USER $PATH ...)
+ *   - variables:            $VAR ${VAR} ${VAR[n]} ${name//pat/str} ${name:off:len}
+ *                           plus special cases ($HOME $USER $PATH ...)
  *   - command substitution: $(...) and `...` (recursively translated)
  *   - arithmetic expansion: $((...)) (existing fx-arith engine)
  *   - env assignment prefix: VAR=value cmd
+ *   - array assignment:     A=(x y z)  (sidecar FAUXNIX_ARRS)
  *
  * Explicitly unsupported (parser throws a helpful FauxnixError):
  *   heredocs, subshells (...), background &, while/until/case,
@@ -63,7 +65,10 @@ export interface SimpleCommand {
 
 export interface Assignment {
   name: string;
+  /** Scalar value; for arrays, first element (or empty Word) so export paths stay valid. */
   value: Word;
+  /** Set ⇒ bash array assignment `A=(x y z)`. */
+  values?: Word[];
 }
 
 export type RedirectOp =
@@ -91,6 +96,10 @@ export type WordPart =
       param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string };
       /** `${#name}` / `${#name[@]}` — string/array length expansion. */
       length?: boolean;
+      /** `${name/pat/str}` (first) / `${name//pat/str}` (global). Pattern is a bash glob. */
+      replace?: { global: boolean; pat: string; repl: string };
+      /** `${name:offset}` / `${name:offset:length}` — scalar substring. */
+      slice?: { offset: string; length?: string };
     }
   | { kind: 'CmdSub'; cmd: string }
   | { kind: 'Arith'; parts: WordPart[] };
@@ -122,6 +131,23 @@ function partToString(p: WordPart): string {
     case 'DoubleQuoted':
       return p.parts.map(partToString).join('');
     case 'Var':
+      if (p.replace) {
+        const sep = p.replace.global ? '//' : '/';
+        return `\${${p.name}${sep}${p.replace.pat}/${p.replace.repl}}`;
+      }
+      if (p.slice) {
+        return p.slice.length !== undefined
+          ? `\${${p.name}:${p.slice.offset}:${p.slice.length}}`
+          : `\${${p.name}:${p.slice.offset}}`;
+      }
+      if (p.length) {
+        return p.index !== undefined
+          ? `\${#${p.name}[${p.index}]}`
+          : `\${#${p.name}}`;
+      }
+      if (p.param) {
+        return `\${${p.name}${p.param.op}${p.param.word}}`;
+      }
       return p.index !== undefined ? `\${${p.name}[${p.index}]}` : `$${p.name}`;
     case 'CmdSub':
       return '$(' + p.cmd + ')';

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -13,6 +13,7 @@ import {
   pathExpr,
   paramExpr,
   varExpr,
+  varExtraOf,
   arithExpr,
   setArithHelperPreamble,
 } from '../translator.js';
@@ -1501,6 +1502,10 @@ function kshExprOfWord(w: Word): string {
     return arithExpr(expanded[0].parts);
   }
   if (!tilde && expanded.length === 1 && expanded[0].kind === 'Var') {
+    const extra = varExtraOf(expanded[0]);
+    if (extra && (extra.replace || extra.slice)) {
+      return varExpr(expanded[0].name, expanded[0].index, expanded[0].param, expanded[0].length === true, extra);
+    }
     if (expanded[0].param) {
       return paramExpr(expanded[0].name, expanded[0].param.op, expanded[0].param.word);
     }
@@ -1529,14 +1534,21 @@ function kshExprOfWord(w: Word): string {
       case 'DoubleQuoted':
         for (const q of p.parts) emitPart(q);
         break;
-      case 'Var':
-        out +=
-          p.param
-            ? '$(' + paramExpr(p.name, p.param.op, p.param.word) + ')'
-            : p.index !== undefined
-            ? '$(fx-subget ' + psStr(p.name) + ' ' + psStr(p.index) + ')'
-            : '$(fx-envget ' + psStr(p.name) + ')';
+      case 'Var': {
+        const extra = varExtraOf(p);
+        if (extra && (extra.replace || extra.slice)) {
+          out += '$(' + varExpr(p.name, p.index, p.param, p.length === true, extra) + ')';
+        } else if (p.param) {
+          out += '$(' + paramExpr(p.name, p.param.op, p.param.word) + ')';
+        } else if (p.length) {
+          out += '$(' + varExpr(p.name, p.index, undefined, true) + ')';
+        } else if (p.index !== undefined) {
+          out += '$(fx-subget ' + psStr(p.name) + ' ' + psStr(p.index) + ')';
+        } else {
+          out += '$(fx-envget ' + psStr(p.name) + ')';
+        }
         break;
+      }
       case 'CmdSub':
         // [[ ]] does not IFS-split, so keep the newline contract.
         out += '$(' + translateCmdSub(p.cmd, true) + ')';

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -37,7 +37,7 @@ const TOOL_DESCRIPTION = `Execute a Linux/bash-style command on this Windows mac
 Commands are deterministically translated to PowerShell and executed natively — no WSL or VM.
 Output is formatted to look like GNU/Linux tooling (ls -l, ps aux, df -h ...), errors look like bash errors, and text encoding (UTF-8/GBK) is handled automatically.
 
-Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
+Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), variables ($VAR $HOME ~), array assignment A=(x y z), \${name[n]} \${#name[@]} \${name//pat/str} \${name:off:len}, command substitution $(...), and ${registeredNames().length}+ coreutils-style commands (${registeredNames().slice(0, 18).join(', ')}...).
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
 Not supported: heredocs, while/until/case, env -i/--ignore-environment, background jobs. if/then/elif/else/fi, for-in loops, and word-level \$((...)) arithmetic expansion are supported.
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -286,6 +286,52 @@ function readArithParts(input: string): WordPart[] {
   return parts;
 }
 
+/** Integer or `$name` operand of `${name:offset:length}`. */
+function readSliceNum(s: string, i: number): { val: string; next: number } | null {
+  while (i < s.length && (s[i] === ' ' || s[i] === '\t')) i++;
+  if (i >= s.length) return null;
+  if (s[i] === '$') {
+    const j = i + 1;
+    if (j < s.length && isNameStart(s[j])) {
+      let k = j + 1;
+      while (k < s.length && isNameChar(s[k])) k++;
+      return { val: s.slice(i, k), next: k };
+    }
+    if (j < s.length && (/[0-9]/.test(s[j]) || s[j] === '?' || s[j] === '$')) {
+      return { val: s.slice(i, j + 1), next: j + 1 };
+    }
+    return null;
+  }
+  let sign = '';
+  if (s[i] === '-' || s[i] === '+') {
+    sign = s[i];
+    i++;
+  }
+  if (i >= s.length || !/[0-9]/.test(s[i])) return null;
+  let k = i;
+  while (k < s.length && /[0-9]/.test(s[k])) k++;
+  return { val: sign + s.slice(i, k), next: k };
+}
+
+/** Parse `offset` / `offset:length` after `${name:`. Null if not a slice. */
+function parseSliceSpec(after: string): { offset: string; length?: string } | null {
+  const off = readSliceNum(after, 0);
+  if (!off) return null;
+  let i = off.next;
+  while (i < after.length && (after[i] === ' ' || after[i] === '\t')) i++;
+  if (i >= after.length) return { offset: off.val };
+  if (after[i] !== ':') return null;
+  i++;
+  while (i < after.length && (after[i] === ' ' || after[i] === '\t')) i++;
+  if (i >= after.length) return { offset: off.val, length: '0' };
+  const len = readSliceNum(after, i);
+  if (!len) return null;
+  i = len.next;
+  while (i < after.length && (after[i] === ' ' || after[i] === '\t')) i++;
+  if (i !== after.length) return null;
+  return { offset: off.val, length: len.val };
+}
+
 /** Parse $VAR, ${VAR}, $(cmd substitution), $((arith)). Returns null when not a valid dollar construct. */
 function readDollar(input: string, i: number): { part: WordPart; next: number } | null {
   const n = input.length;
@@ -297,31 +343,86 @@ function readDollar(input: string, i: number): { part: WordPart; next: number } 
   if (input[j] === '{') {
     const end = input.indexOf('}', j);
     if (end === -1) throw new FauxnixParseError('fauxnix: unclosed ${');
-    const name = input.slice(j + 1, end);
-    const sub = name.match(/^([A-Za-z_][A-Za-z0-9_]*)\[([0-9]+|@|\*)\]$/);
-    if (sub) {
-      return { part: { kind: 'Var', name: sub[1], index: sub[2] }, next: end + 1 };
-    }
-    const pm = name.match(/^([A-Za-z_][A-Za-z0-9_]*)(:?[-+?])(.*)$/);
-    if (pm) {
-      const op = pm[2] as ':-' | ':+' | ':?' | '-' | '+' | '?';
-      return {
-        part: { kind: 'Var', name: pm[1], param: { op, word: pm[3] } },
-        next: end + 1,
-      };
-    }
-    const hash = name.match(/^#([A-Za-z_][A-Za-z0-9_]*)(\[([0-9]+|@|\*)\])?$/);
+    const inner = input.slice(j + 1, end);
+    const nextPos = end + 1;
+
+    const hash = inner.match(/^#([A-Za-z_][A-Za-z0-9_]*)(\[([0-9]+|@|\*)\])?$/);
     if (hash) {
       return {
         part: { kind: 'Var', name: hash[1], index: hash[3], length: true },
-        next: end + 1,
+        next: nextPos,
       };
     }
-    if (!name || !isNameStart(name[0]) || !name.split('').every(isNameChar)) {
-      // ${VAR:=default} etc. still raw text
-      return { part: { kind: 'Text', text: input.slice(i, end + 1) }, next: end + 1 };
+
+    const sub = inner.match(/^([A-Za-z_][A-Za-z0-9_]*)\[([0-9]+|@|\*)\]$/);
+    if (sub) {
+      return { part: { kind: 'Var', name: sub[1], index: sub[2] }, next: nextPos };
     }
-    return { part: { kind: 'Var', name }, next: end + 1 };
+
+    if (/^[A-Za-z_][A-Za-z0-9_]*\[([0-9]+|@|\*)\]/.test(inner)) {
+      throw new FauxnixParseError(
+        'fauxnix: ${name[@]:offset:length} subarray slice is not supported; use ${name:offset:length} on a scalar or ${name[i]} per element',
+      );
+    }
+
+    const ident = inner.match(/^([A-Za-z_][A-Za-z0-9_]*)/);
+    if (ident) {
+      const nm = ident[1];
+      const rest = inner.slice(nm.length);
+
+      if (rest.startsWith('/#') || rest.startsWith('/%')) {
+        throw new FauxnixParseError(
+          'fauxnix: ${name/#pat/str} and ${name/%pat/str} are not supported; use ${name//pat/str} instead',
+        );
+      }
+
+      if (rest.startsWith('/')) {
+        const global = rest.startsWith('//');
+        const body = rest.slice(global ? 2 : 1);
+        const slash = body.indexOf('/');
+        const pat = slash === -1 ? body : body.slice(0, slash);
+        const repl = slash === -1 ? '' : body.slice(slash + 1);
+        return {
+          part: { kind: 'Var', name: nm, replace: { global, pat, repl } },
+          next: nextPos,
+        };
+      }
+
+      if (rest.startsWith(':')) {
+        const after = rest.slice(1);
+        let t = 0;
+        while (t < after.length && (after[t] === ' ' || after[t] === '\t')) t++;
+        const lead = t < after.length ? after[t] : '';
+        const hadSpace = t > 0;
+        const paramLead =
+          lead === '+' || lead === '?' || lead === '=' || (lead === '-' && !hadSpace);
+        if (!paramLead && lead !== '') {
+          const sl = parseSliceSpec(after);
+          if (sl) {
+            return { part: { kind: 'Var', name: nm, slice: sl }, next: nextPos };
+          }
+        }
+      }
+
+      const pm = inner.match(/^([A-Za-z_][A-Za-z0-9_]*)(:?[-+?])(.*)$/);
+      if (pm) {
+        const op = pm[2] as ':-' | ':+' | ':?' | '-' | '+' | '?';
+        return {
+          part: { kind: 'Var', name: pm[1], param: { op, word: pm[3] } },
+          next: nextPos,
+        };
+      }
+
+      if (rest === '') {
+        return { part: { kind: 'Var', name: nm }, next: nextPos };
+      }
+    }
+
+    if (!inner || !isNameStart(inner[0]) || !inner.split('').every(isNameChar)) {
+      // ${VAR:=default} etc. still raw text
+      return { part: { kind: 'Text', text: input.slice(i, end + 1) }, next: nextPos };
+    }
+    return { part: { kind: 'Var', name: inner }, next: nextPos };
   }
 
   // $((...)) arithmetic expansion — distinct from `$( (cmd) )` (space after
@@ -609,6 +710,67 @@ function pendingPatternOp(args: Word[]): '=~' | '==' | null {
     if (isUnquotedLiteral(w, '&&') || isUnquotedLiteral(w, '||')) return null;
   }
   return null;
+}
+
+/** Unquoted `(` / `)` net depth in a word (quoted / escaped parens ignored). */
+function unquotedParenDelta(w: Word): number {
+  let d = 0;
+  for (const p of w) {
+    if (p.kind !== 'Text' || p.escaped) continue;
+    for (const c of p.text) {
+      if (c === '(') d++;
+      else if (c === ')') d--;
+    }
+  }
+  return d;
+}
+
+function startsWithUnquotedOpenParen(w: Word): boolean {
+  if (w.length === 0) return false;
+  const p = w[0];
+  return p.kind === 'Text' && !p.escaped && p.text.startsWith('(');
+}
+
+/** `NAME+=` (scalar or array append) — out of scope for C-2. */
+function isAppendAssignment(w: Word): boolean {
+  let s = '';
+  for (const p of w) {
+    if (p.kind === 'Text' && !p.escaped) s += p.text;
+    else break;
+    if (/^[A-Za-z_][A-Za-z0-9_]*\+=/.test(s)) return true;
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(s)) return false;
+  }
+  return /^[A-Za-z_][A-Za-z0-9_]*\+=/.test(s);
+}
+
+function cloneWord(w: Word): Word {
+  return w.map((p) => {
+    if (p.kind === 'Text' || p.kind === 'SingleQuoted') return { ...p };
+    if (p.kind === 'DoubleQuoted') return { kind: 'DoubleQuoted' as const, parts: p.parts.slice() };
+    return p;
+  });
+}
+
+/** Strip the opening `(` and closing `)` that wrap an array assignment value. */
+function stripArrayParens(words: Word[]): Word[] {
+  if (words.length === 0) return [];
+  const ws = words.map(cloneWord);
+  const first = ws[0];
+  if (first.length > 0 && first[0].kind === 'Text' && first[0].text.startsWith('(')) {
+    first[0] = { kind: 'Text', text: first[0].text.slice(1), escaped: first[0].escaped };
+    if (first[0].text === '') first.shift();
+  }
+  const last = ws[ws.length - 1];
+  for (let i = last.length - 1; i >= 0; i--) {
+    const p = last[i];
+    if (p.kind === 'Text' && !p.escaped && p.text.endsWith(')')) {
+      const trimmed = p.text.slice(0, -1);
+      if (trimmed === '') last.splice(i, 1);
+      else last[i] = { kind: 'Text', text: trimmed, escaped: p.escaped };
+      break;
+    }
+  }
+  return ws.filter((w) => w.length > 0);
 }
 
 /* ------------------------------------------------------------------ */
@@ -941,10 +1103,37 @@ export function parseCommand(input: string): CommandList {
       const word = t.parts!;
 
       // assignment prefix before command name?
+      if (name === null && isAppendAssignment(word)) {
+        throw new FauxnixParseError(
+          'fauxnix: `+=` append is not supported; use `A=(${A[@]} x)` or `A=(x y)` instead',
+        );
+      }
       if (name === null && isAssignment(word)) {
         next();
         const split = splitAssignment(word);
         if (split) {
+          if (startsWithUnquotedOpenParen(split.value)) {
+            const elems: Word[] = [split.value];
+            let depth = unquotedParenDelta(split.value);
+            while (depth > 0 && peek().type === 'WORD' && peek().parts) {
+              const nxt = peek().parts!;
+              elems.push(nxt);
+              depth += unquotedParenDelta(nxt);
+              next();
+            }
+            if (depth > 0) {
+              throw new FauxnixParseError(
+                'fauxnix: unclosed array assignment; close with `)` or use A=value for a scalar',
+              );
+            }
+            const values = stripArrayParens(elems);
+            assignments.push({
+              name: split.name,
+              value: values.length > 0 ? values[0] : [],
+              values,
+            });
+            continue;
+          }
           assignments.push(split);
           continue;
         }

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -61,13 +61,58 @@ export function paramExpr(
   );
 }
 
+function sliceArgExpr(s: string): string {
+  if (s.length > 0 && s[0] === '$') {
+    return '(fx-scalar0 ' + psStr(s.slice(1)) + ')';
+  }
+  return psStr(s);
+}
+
+export function varExtraOf(p: WordPart): {
+  replace?: { global: boolean; pat: string; repl: string };
+  slice?: { offset: string; length?: string };
+} | undefined {
+  if (p.kind !== 'Var') return undefined;
+  if (!p.replace && !p.slice) return undefined;
+  const extra: {
+    replace?: { global: boolean; pat: string; repl: string };
+    slice?: { offset: string; length?: string };
+  } = {};
+  if (p.replace) extra.replace = p.replace;
+  if (p.slice) extra.slice = p.slice;
+  return extra;
+}
+
 /** Map a bash $VAR name to a PowerShell expression (usable inside $(...)). */
 export function varExpr(
   name: string,
   index?: string,
   param?: { op: ':-' | ':=' | ':+' | ':?' | '-' | '+' | '?'; word: string },
   length = false,
+  extra?: {
+    replace?: { global: boolean; pat: string; repl: string };
+    slice?: { offset: string; length?: string };
+  },
 ): string {
+  if (extra && extra.replace) {
+    const r = extra.replace;
+    return (
+      '(fx-subst (fx-scalar0 ' +
+      psStr(name) +
+      ') ' +
+      psStr(r.pat) +
+      ' ' +
+      psStr(r.repl) +
+      ' ' +
+      (r.global ? '$true' : '$false') +
+      ')'
+    );
+  }
+  if (extra && extra.slice) {
+    const off = sliceArgExpr(extra.slice.offset);
+    const len = extra.slice.length !== undefined ? sliceArgExpr(extra.slice.length) : '$null';
+    return '(fx-slice (fx-scalar0 ' + psStr(name) + ') ' + off + ' ' + len + ')';
+  }
   if (param) return paramExpr(name, param.op, param.word);
   if (length) {
     if (index === '@' || index === '*') {
@@ -183,7 +228,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
   // single bare variable → bare expression
   if (expanded.length === 1 && expanded[0].kind === 'Var') {
     const v = expanded[0];
-    return varExpr(v.name, v.index, v.param, v.length === true);
+    return varExpr(v.name, v.index, v.param, v.length === true, varExtraOf(v));
   }
   // Bare `$(...)` must not sit inside a PS expandable string: the
   // substitution body contains `"` / `$_` that would break interpolation.
@@ -214,7 +259,7 @@ export function exprOfWord(w: Word, opts?: { preserveCmdSub?: boolean }): string
         for (const q of p.parts) emitPart(q, true);
         break;
       case 'Var':
-        out += '$(' + varExpr(p.name, p.index, p.param, p.length === true) + ')';
+        out += '$(' + varExpr(p.name, p.index, p.param, p.length === true, varExtraOf(p)) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd, quoted || opts?.preserveCmdSub === true) + ')';
@@ -271,7 +316,7 @@ function arithSourceExpr(parts: WordPart[]): string {
         for (const q of p.parts) emit(q);
         break;
       case 'Var':
-        out += '$(' + varExpr(p.name, p.index, p.param, p.length === true) + ')';
+        out += '$(' + varExpr(p.name, p.index, p.param, p.length === true, varExtraOf(p)) + ')';
         break;
       case 'CmdSub':
         out += '$(' + translateCmdSub(p.cmd, true) + ')';
@@ -418,11 +463,21 @@ export function translateSimple(
   // deviation: shell var vs exported var are indistinguishable here).
   if (cmd.name === null) {
     const exportHandler = lookup('export');
-    const words = cmd.assignments.map((a) => [
-      { kind: 'Text' as const, text: a.name + '=' },
-      ...a.value,
-    ]);
-    return exportHandler ? exportHandler(words, { position, hasStdin }) : '';
+    const chunks: string[] = [];
+    for (const a of cmd.assignments) {
+      if (a.values) {
+        chunks.push(
+          'fx-arrput ' +
+            psStr(a.name) +
+            ' ' +
+            argListExpr(a.values, (w) => exprOfWord(w, { preserveCmdSub: true })),
+        );
+      } else {
+        const words = [[{ kind: 'Text' as const, text: a.name + '=' }, ...a.value]];
+        if (exportHandler) chunks.push(exportHandler(words, { position, hasStdin }));
+      }
+    }
+    return chunks.join('\n');
   }
 
   const nameLit = literalOfWord(cmd.name);
@@ -602,10 +657,21 @@ export function wrapTempEnv(
     lines.push(arrSave + '[' + psStr(n) + '] = (fx-arrpackget ' + psStr(n) + ')');
   }
   const valVars: string[] = [];
+  const valIsArr: boolean[] = [];
   for (let i = 0; i < sets.length; i++) {
     const vn = '$fx_ev' + id + '_' + i;
     valVars.push(vn);
-    lines.push(vn + ' = ' + exprOfWord(sets[i].value, { preserveCmdSub: true }));
+    if (sets[i].values) {
+      valIsArr.push(true);
+      lines.push(
+        vn +
+          ' = ' +
+          argListExpr(sets[i].values!, (w) => exprOfWord(w, { preserveCmdSub: true })),
+      );
+    } else {
+      valIsArr.push(false);
+      lines.push(vn + ' = ' + exprOfWord(sets[i].value, { preserveCmdSub: true }));
+    }
   }
   lines.push('try {');
   for (const u of unsets) {
@@ -639,6 +705,10 @@ export function wrapTempEnv(
   for (let i = 0; i < sets.length; i++) {
     const n = sets[i].name;
     const nq = n.replace(/'/g, "''");
+    if (valIsArr[i]) {
+      lines.push('  fx-arrput ' + psStr(n) + ' ' + valVars[i]);
+      continue;
+    }
     lines.push('  $env:' + n + ' = ' + valVars[i]);
     lines.push('  fx-arrdrop ' + psStr(n));
     lines.push(
@@ -1060,6 +1130,8 @@ const WRAP_HELPER_ORDER = [
   'fx-arrput',
   'fx-arrclr',
   'fx-subget',
+  'fx-subst',
+  'fx-slice',
   'fx-winargv',
   'fx-native',
 ] as const;
@@ -1081,6 +1153,8 @@ const WRAP_HELPER_DEPS: Record<WrapHelper, WrapHelper[]> = {
   'fx-arrput': ['fx-arrdrop', 'fx-svenc'],
   'fx-arrclr': ['fx-arrdrop'],
   'fx-subget': ['fx-arrload', 'fx-ifs1'],
+  'fx-subst': [],
+  'fx-slice': [],
   'fx-winargv': [],
   'fx-native': ['fx-winargv'],
 };
@@ -1253,8 +1327,10 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '    $fx_eq = $fx_pair.IndexOf([char]61)',
       '    if ($fx_eq -lt 1) { continue }',
       '    if ($fx_pair.Substring(0, $fx_eq) -cne $n) { continue }',
+      '    $pay = $fx_pair.Substring($fx_eq + 1)',
+      '    if ($pay -eq [string][char]1) { return @() }',
       '    $out = @()',
-      '    foreach ($el in @($fx_pair.Substring($fx_eq + 1) -split [string][char]30)) { $out += ,(fx-svdec $el) }',
+      '    foreach ($el in @($pay -split [string][char]30)) { $out += ,(fx-svdec $el) }',
       '    return $out',
       '  }',
       '  $s0 = fx-scalar0 $n',
@@ -1336,9 +1412,12 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
     'fx-arrput': [
       'function fx-arrput($n, $vals) {',
       '  $n = [string]$n',
-      '  $vals = @($vals)',
+      '  if ($null -eq $vals) { $vals = @() } else { $vals = @($vals) }',
       '  fx-arrdrop $n',
-      '  if ($vals.Count -eq 0) { } else {',
+      '  if ($vals.Count -eq 0) {',
+      // SOH payload: empty array, distinct from scalar '' and from A=('')
+      "    $env:FAUXNIX_ARRS = ((@($env:FAUXNIX_ARRS -split [string][char]10 | Where-Object { $_ -ne '' }) + ($n + [string][char]61 + [string][char]1)) -join [string][char]10)",
+      '  } else {',
       '    $encs = @(); foreach ($v in $vals) { $encs += (fx-svenc $v) }',
       "    $env:FAUXNIX_ARRS = ((@($env:FAUXNIX_ARRS -split [string][char]10 | Where-Object { $_ -ne '' }) + ($n + [string][char]61 + ($encs -join [string][char]30))) -join [string][char]10)",
       '  }',
@@ -1371,6 +1450,57 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '  if (-not [int]::TryParse($ix, [ref]$i)) { return \'\' }',
       "  if ($i -lt 0 -or $i -ge $arr.Count) { return '' }",
       '  return [string]$arr[$i]',
+      '}',
+    ],
+    'fx-subst': [
+      'function fx-subst($s, $pat, $repl, $all) {',
+      '  if ($null -eq $s) { return \'\' }',
+      '  $s = [string]$s',
+      '  $pat = [string]$pat',
+      '  $repl = [string]$repl',
+      '  if ($pat -eq \'\') { return $s }',
+      '  $glob = $false',
+      '  foreach ($fx_c in $pat.ToCharArray()) {',
+      '    if ($fx_c -eq [char]42 -or $fx_c -eq [char]63) { $glob = $true; break }',
+      '  }',
+      '  if (-not $glob) {',
+      '    if ($all) { return $s.Replace($pat, $repl) }',
+      '    $i = $s.IndexOf($pat)',
+      '    if ($i -lt 0) { return $s }',
+      '    return $s.Substring(0, $i) + $repl + $s.Substring($i + $pat.Length)',
+      '  }',
+      '  $sb = New-Object System.Text.StringBuilder',
+      '  foreach ($fx_c in $pat.ToCharArray()) {',
+      '    if ($fx_c -eq [char]42) { [void]$sb.Append(\'.*\'); continue }',
+      '    if ($fx_c -eq [char]63) { [void]$sb.Append(\'.\'); continue }',
+      '    [void]$sb.Append([regex]::Escape([string]$fx_c))',
+      '  }',
+      '  $rx = New-Object System.Text.RegularExpressions.Regex($sb.ToString(), [System.Text.RegularExpressions.RegexOptions]::Singleline)',
+      '  $fx_rep = $repl.Replace([string][char]36, ([string][char]36 + [string][char]36))',
+      '  if ($all) { return $rx.Replace($s, $fx_rep) }',
+      '  return $rx.Replace($s, $fx_rep, 1)',
+      '}',
+    ],
+    'fx-slice': [
+      'function fx-slice($s, $off, $len) {',
+      '  if ($null -eq $s) { return \'\' }',
+      '  $s = [string]$s',
+      '  $n = $s.Length',
+      '  $o = 0',
+      '  if (-not [int]::TryParse([string]$off, [ref]$o)) { return \'\' }',
+      '  if ($o -lt 0) { $o = $n + $o }',
+      '  if ($o -lt 0 -or $o -ge $n) { return \'\' }',
+      '  if ($null -eq $len -or [string]$len -eq \'\') { return $s.Substring($o) }',
+      '  $l = 0',
+      '  if (-not [int]::TryParse([string]$len, [ref]$l)) { return \'\' }',
+      '  if ($l -lt 0) {',
+      '    $fx_end = $n + $l',
+      '    if ($fx_end -lt $o) { return \'\' }',
+      '    $l = $fx_end - $o',
+      '  }',
+      '  if ($l -le 0) { return \'\' }',
+      '  if (($o + $l) -gt $n) { $l = $n - $o }',
+      '  return $s.Substring($o, $l)',
       '}',
     ],
     'fx-winargv': [

--- a/test/differential.test.ts
+++ b/test/differential.test.ts
@@ -24,7 +24,7 @@ describe('differential corpus scaffold (C-7 / #118)', () => {
     expect(corpus.gate.targetCases).toBe(200);
     expect(corpus.gate.identity).toBe(0.95);
     expect(corpus.cases.length).toBeGreaterThanOrEqual(15);
-    expect(corpus.cases.length).toBeLessThanOrEqual(40);
+    expect(corpus.cases.length).toBeLessThan(200);
     const ids = corpus.cases.map((c) => c.id);
     expect(new Set(ids).size).toBe(ids.length);
     expect(ids).toEqual(expect.arrayContaining([

--- a/test/differential/corpus.json
+++ b/test/differential/corpus.json
@@ -210,6 +210,66 @@
       "id": "echo-pipe-grep",
       "cmd": "echo hi | grep hi",
       "source": "#153"
+    },
+    {
+      "id": "arr-index-1",
+      "cmd": "A=(a b c); echo ${A[1]}",
+      "source": "#118 C-2"
+    },
+    {
+      "id": "arr-len",
+      "cmd": "A=(a b c); echo ${#A[@]}",
+      "source": "#118 C-2"
+    },
+    {
+      "id": "arr-empty-len",
+      "cmd": "A=(); echo ${#A[@]}",
+      "source": "#118 C-2"
+    },
+    {
+      "id": "arr-one-elem",
+      "cmd": "A=(x); echo ${A[0]} ${#A[@]}",
+      "source": "#118 C-2"
+    },
+    {
+      "id": "arr-spaces",
+      "cmd": "A=( x y z ); echo ${A[0]} ${A[2]}",
+      "source": "#118 C-2"
+    },
+    {
+      "id": "subst-global-l",
+      "cmd": "X=hello; echo ${X//l/L}",
+      "source": "#118 C-2"
+    },
+    {
+      "id": "subst-first-l",
+      "cmd": "X=hello; echo ${X/l/L}",
+      "source": "#118 C-2"
+    },
+    {
+      "id": "subst-delete-l",
+      "cmd": "X=hello; echo ${X//l}",
+      "source": "#118 C-2"
+    },
+    {
+      "id": "slice-0-2",
+      "cmd": "X=abcd; echo ${X:0:2}",
+      "source": "#118 C-2"
+    },
+    {
+      "id": "slice-neg1",
+      "cmd": "X=abcd; echo ${X: -1}",
+      "source": "#118 C-2"
+    },
+    {
+      "id": "slice-from-2",
+      "cmd": "X=abcd; echo ${X:2}",
+      "source": "#118 C-2"
+    },
+    {
+      "id": "subst-glob-star",
+      "cmd": "X=hello; echo ${X//l*/X}",
+      "source": "#118 C-2"
     }
   ]
 }

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1178,6 +1178,34 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     );
   });
 
+  it('array assignment A=(x y z) indexes and counts elements', async () => {
+    expect((await run('A=(a b c); echo ${A[1]}')).stdout.trim()).toBe('b');
+    expect((await run('A=(a b c); echo ${#A[@]}')).stdout.trim()).toBe('3');
+    expect((await run('A=(); echo ${#A[@]}')).stdout.trim()).toBe('0');
+    await run('unset A');
+  });
+
+  it('array assignment persists in the FAUXNIX_ARRS sidecar across run() calls', async () => {
+    expect((await run('A=(a b c)')).exitCode).toBe(0);
+    expect((await run('echo ${A[1]}')).stdout.trim()).toBe('b');
+    expect((await run('echo ${#A[@]}')).stdout.trim()).toBe('3');
+    await run('unset A');
+    expect((await run('echo ${#A[@]}')).stdout.trim()).toBe('0');
+  });
+
+  it('prefix A=(x y) cmd is command-scoped via fx-arrput', async () => {
+    expect((await run('A=(x y) echo ${A[1]}')).stdout.trim()).toBe('y');
+    expect((await run('echo ${#A[@]}')).stdout.trim()).toBe('0');
+  });
+
+  it('${name//pat/str} and ${name:off:len} follow bash replace/slice rules', async () => {
+    expect((await run('X=hello; echo ${X//l/L}; unset X')).stdout.trim()).toBe('heLLo');
+    expect((await run('X=hello; echo ${X/l/L}; unset X')).stdout.trim()).toBe('heLlo');
+    expect((await run('X=abcd; echo ${X:0:2}; unset X')).stdout.trim()).toBe('ab');
+    expect((await run('X=abcd; echo ${X: -1}; unset X')).stdout.trim()).toBe('d');
+    expect((await run('X=abcd; echo ${X:2}; unset X')).stdout.trim()).toBe('cd');
+  });
+
   it('date format tokens', async () => {
     expect((await run('date +%Y')).stdout).toMatch(/^\d{4}/);
   });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -128,6 +128,68 @@ describe('parser', () => {
     expect(cmd.args[2]).toEqual([{ kind: 'Var', name: 'Z', param: { op: ':?', word: 'err' } }]);
   });
 
+  it('parses A=(x y z) as an array assignment', () => {
+    const cmd = parse('A=(x y z)').segments[0].pipeline.commands[0];
+    expect(cmd.kind).toBe('SimpleCommand');
+    if (cmd.kind !== 'SimpleCommand') return;
+    expect(cmd.name).toBeNull();
+    expect(cmd.assignments).toHaveLength(1);
+    expect(cmd.assignments[0].name).toBe('A');
+    expect(cmd.assignments[0].values).toHaveLength(3);
+    const texts = cmd.assignments[0].values!.map((w) =>
+      w.map((p) => ('text' in p ? p.text : '')).join(''),
+    );
+    expect(texts).toEqual(['x', 'y', 'z']);
+  });
+
+  it('parses A=() / A=(x) / A=( x y z ) and keeps quoted ( ) as scalar', () => {
+    const empty = parse('A=()').segments[0].pipeline.commands[0];
+    expect(empty.kind).toBe('SimpleCommand');
+    if (empty.kind !== 'SimpleCommand') return;
+    expect(empty.assignments[0].values).toEqual([]);
+    const one = parse('A=(x)').segments[0].pipeline.commands[0];
+    if (one.kind !== 'SimpleCommand') return;
+    expect(one.assignments[0].values).toHaveLength(1);
+    const spaced = parse('A=( x y z )').segments[0].pipeline.commands[0];
+    if (spaced.kind !== 'SimpleCommand') return;
+    expect(spaced.assignments[0].values).toHaveLength(3);
+    const q = parse("A='(x y)'").segments[0].pipeline.commands[0];
+    if (q.kind !== 'SimpleCommand') return;
+    expect(q.assignments[0].values).toBeUndefined();
+    const dq = parse('A="(x y)"').segments[0].pipeline.commands[0];
+    if (dq.kind !== 'SimpleCommand') return;
+    expect(dq.assignments[0].values).toBeUndefined();
+  });
+
+  it('parses ${X//a/b} and ${X:0:2} as Var replace/slice, not Text', () => {
+    const cmd = parse('echo ${X//a/b} ${X:0:2} ${X/l/L} ${X: -1}').segments[0].pipeline.commands[0];
+    expect(cmd.args[0]).toEqual([
+      { kind: 'Var', name: 'X', replace: { global: true, pat: 'a', repl: 'b' } },
+    ]);
+    expect(cmd.args[1]).toEqual([{ kind: 'Var', name: 'X', slice: { offset: '0', length: '2' } }]);
+    expect(cmd.args[2]).toEqual([
+      { kind: 'Var', name: 'X', replace: { global: false, pat: 'l', repl: 'L' } },
+    ]);
+    expect(cmd.args[3]).toEqual([{ kind: 'Var', name: 'X', slice: { offset: '-1' } }]);
+    expect(cmd.args[0][0].kind).not.toBe('Text');
+  });
+
+  it('does not steal ${X:-def} as a slice', () => {
+    const cmd = parse('echo ${X:-def} ${Y:+on} ${Z:?err}').segments[0].pipeline.commands[0];
+    expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'X', param: { op: ':-', word: 'def' } }]);
+    expect(cmd.args[1][0].kind).toBe('Var');
+    if (cmd.args[1][0].kind !== 'Var') return;
+    expect(cmd.args[1][0].slice).toBeUndefined();
+  });
+
+  it('rejects A+=(x) and ${name/#} / ${arr[@]:0:2} with an alternative', () => {
+    expect(() => parse('A+=(x)')).toThrow(/\$\{A\[@\]\} x/);
+    expect(() => parse('A+=(x)')).toThrow(/A=\(x y\)/);
+    expect(() => parse('echo ${X/#a/b}')).toThrow(/\$\{name\/\/pat\/str\}/);
+    expect(() => parse('echo ${X/%a/b}')).toThrow(/\$\{name\/\/pat\/str\}/);
+    expect(() => parse('echo ${A[@]:0:2}')).toThrow(/\$\{name:offset:length\}/);
+  });
+
   it('parses ${#name} and ${#name[@]}', () => {
     const cmd = parse('echo ${#X} ${#Y[@]}').segments[0].pipeline.commands[0];
     expect(cmd.args[0]).toEqual([{ kind: 'Var', name: 'X', length: true }]);
@@ -203,6 +265,16 @@ describe('parser', () => {
     expect(varExpr('bash_rematch', '0')).toContain('fx-subget');
     expect(varExpr('bash_rematch', '0')).not.toMatch(/\$env:bash_rematch/i);
     expect(varExpr('PWD', '0')).toContain('fx-subget');
+  });
+
+  it('translates A=(a b c) via fx-arrput, not export A=(', () => {
+    const body = translateCommandList(parse('A=(a b c)'))[0].body;
+    expect(body).toContain('fx-arrput');
+    expect(body).not.toMatch(/\$env:A\s*=\s*.*\(a/);
+    expect(body).not.toContain("export");
+    const prefix = translateCommandList(parse('A=(x y) echo z'))[0].body;
+    expect(prefix).toContain('fx-arrput');
+    expect(prefix).toContain('fx-arrpackget');
   });
 
   it('rejects heredocs with a helpful message', () => {
@@ -532,6 +604,11 @@ describe('translator', () => {
     expect(splat).toContain('function fx-arrload');
     expect(splat).toContain('function fx-scalar0');
     expect(splat).not.toContain('function fx-csub');
+    const subst = translateCommandList(parse('echo ${X//a/b}'))[0].script;
+    expect(subst).toContain('function fx-subst');
+    expect(subst).toContain('function fx-scalar0');
+    const slice = translateCommandList(parse('echo ${X:0:2}'))[0].script;
+    expect(slice).toContain('function fx-slice');
     const csub = translateCommandList(parse('echo $(echo a)'))[0].script;
     expect(csub).toContain('function fx-csub');
     const stdin = translateCommandList(parse('wc -l < f.txt'))[0].script;


### PR DESCRIPTION
RFC 1.0 **C-2** / #118. Array assignment and scalar `${name//pat/str}` / `${name:off:len}`.

## What landed

- `A=(x y z)`, `A=( x y z )`, `A=(x)`, `A=()` parse as `Assignment.values` and emit `fx-arrput` into the existing `FAUXNIX_ARRS` sidecar (not `export A=(x`). Quoted `A='(x y)'` / `A="(x y)"` stay scalar.
- Prefix `A=(x y) cmd` goes through `wrapTempEnv` via `fx-arrput` + the existing `fx-arrpackget` save/restore.
- `${name//pat/str}` (global) and `${name/pat/str}` (first); pattern is a bash glob, implemented as `fx-subst`. Missing replacement deletes matches.
- `${name:offset}` / `${name:offset:length}` as `fx-slice` (negative offset from end, out-of-range → empty). `${name:-word}` / `:+` / `:?` are unchanged; `:=` still raw Text.
- README + MCP tool description mention the new surface. `while`/`case` are still unsupported.

## Non-goals

- `A+=(x)` — loud-reject; use `A=(${A[@]} x)` or `A=(x y)`
- `${arr[@]:0:2}` subarray slice — loud-reject; use `${name:offset:length}` on a scalar or `${name[i]}`
- `${name/#pat/str}` / `${name/%pat/str}` — loud-reject; use `${name//pat/str}`

## Tests

- Unit: parse `A=(x y z)` / replace / slice; `${X:-def}` still `:-`; translate contains `fx-arrput`
- Integration: index, `${#A[@]}`, empty array, sidecar persist across `run()`, `${X//l/L}`, `${X:0:2}`, `${X: -1}`, prefix restore
- Differential: 12 corpus cases sourced `#118 C-2`. Upper bound relaxed to `< 200` so the scaffold can grow; this is not the 200-case 1.0 gate.

`npx tsc --noEmit` and `npx vitest run --dir test`: 280 passed, 1 skipped (oracle).

Not merging.
