### PR TITLE
feat: codify the release checklist gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - run: npm run release:check
       - run: npm run typecheck
       - run: npm run build
       - run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,10 +63,59 @@ your own PRs. There is no SLA.
 
 ## Releases
 
-1. Version-bump PR (`package.json` + `src/cli.ts` + `src/mcp.ts`), CI green, merge.
-2. Tag `vX.Y.Z`, push tag.
-3. `npm run test:package` green.
-4. `npm publish` (requires maintainer 2FA).
+Publishing stays maintainer-manual and requires npm 2FA. Do not move or reuse a
+release tag or npm version after it is public.
+
+### Version PR
+
+1. Run `npm version X.Y.Z --no-git-tag-version`. This updates `package.json`
+   and both lockfile version fields; `src/version.ts` supplies the CLI and MCP
+   versions at runtime, so do not hand-edit `src/cli.ts` or `src/mcp.ts`.
+2. Add the new top `CHANGELOG.md` entry (`## vX.Y.Z — YYYY-MM-DD`) and prepare
+   matching GitHub release notes.
+3. Run `npm ci`, `npm run release:check`, `npm run typecheck`, `npm test`, and
+   `npm run test:package`.
+4. Open and merge the version PR only after CI is green on its exact head.
+
+### Publish the merged commit
+
+1. Update local `main` with a fast-forward pull. Confirm the worktree is clean,
+   `package.json` and `package-lock.json` show the intended version, and CI is
+   green for the exact commit to be tagged.
+2. Run `npm whoami` and `npm profile get`; confirm the expected maintainer
+   account has `auth-and-writes` 2FA. Confirm the target version is absent
+   from `npm view fauxnix-cli versions --json`.
+3. Create an annotated local tag (`git tag -a vX.Y.Z -m "vX.Y.Z"`) and run
+   `npm publish --dry-run`. The publish lifecycle repeats the strict tag,
+   typecheck, full-suite, and packed-install checks. Inspect the file manifest.
+4. Push only that tag with `git push origin vX.Y.Z`, then compare the peeled
+   commit from `git ls-remote origin "refs/tags/vX.Y.Z^{}"` with
+   `git rev-list -n 1 vX.Y.Z`. An annotated tag's unpeeled ref is the tag
+   object, not the release commit.
+5. Publish from the same clean checkout, entering the OTP at npm's prompt:
+   - release candidate: `npm publish --tag next`
+   - stable release: `npm publish --tag latest`
+
+   Never publish a release candidate without `--tag next`; npm otherwise moves
+   `latest`, changing what an unversioned install receives.
+6. Read the release back before announcing it:
+   - `npm view fauxnix-cli@X.Y.Z version gitHead dist.integrity`
+   - compare `gitHead` with `git rev-list -n 1 vX.Y.Z`
+   - `npm dist-tag ls fauxnix-cli` (`next` for an RC, `latest` for stable)
+   - `npx --yes --package=fauxnix-cli@X.Y.Z fauxnix --version`
+7. Create the GitHub release from the already-published tag using the prepared
+   CHANGELOG-derived notes (`gh release create ... --verify-tag --notes-file ...`).
+   Add `--prerelease` for release candidates, then read the release page back.
+
+### Failed release or rollback
+
+- Before npm accepts the version, fix authentication/network failures and retry
+  only if the commit and package are unchanged. If code must change after a
+  public tag was pushed, issue a new version; do not move the tag.
+- After npm accepts the version, never unpublish or reuse it. Move the affected
+  channel back with `npm dist-tag add fauxnix-cli@LAST_GOOD latest` (or `next`),
+  run `npm deprecate fauxnix-cli@BAD "upgrade to X.Y.Z: REASON"`, mark its GitHub
+  release clearly, and publish a corrected patch or release candidate.
 
 ## Attribution note
 

--- a/docs/rfc-1.0-completeness-usability.md
+++ b/docs/rfc-1.0-completeness-usability.md
@@ -65,7 +65,7 @@ into a repeatable gate.
 |---|---|---|
 | T-1 | `SECURITY.md` | trust model (local agent shell, same as any harness Bash tool), host-protocol surface, kill semantics, network guard, reporting policy |
 | T-2 | CONTRIBUTING: the RFC rule | when an RFC is required (new surface, protocol change, semantics), template pointer, maintainer turnaround expectation |
-| T-3 | Release checklist | CHANGELOG + tag + release notes + `test:package` green + npm publish steps in CONTRIBUTING (mostly exists; codify) |
+| T-3 | Release checklist | **Complete**: CONTRIBUTING codifies CHANGELOG, tag, release notes, RC/stable npm tags, 2FA publish, readback and rollback; `release:check` gates metadata and strict tagged publishes |
 | T-4 | Stability freeze | at 1.0.0-rc: CLI verbs, MCP tool schema, session env-var contract, host protocol v2 marked frozen; semver from 1.0.0 |
 
 ## Sequencing (each wave = independently reviewable PRs)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",
+    "prepublishOnly": "npm run release:check -- --require-tag && npm run typecheck && npm test && npm run test:package",
+    "release:check": "node scripts/release-check.mjs",
     "test": "vitest run",
     "test:package": "node scripts/package-smoke.mjs",
     "test:watch": "vitest",

--- a/scripts/npm-child-env.mjs
+++ b/scripts/npm-child-env.mjs
@@ -1,0 +1,26 @@
+import { delimiter, resolve } from 'node:path';
+
+/**
+ * Build an environment for nested npm commands run from npm lifecycle hooks.
+ * An outer `npm publish --dry-run` exports npm_config_dry_run; inheriting it
+ * would turn package-smoke's real `npm ci` and `npm pack` checks into no-ops.
+ */
+export function npmChildEnvironment(packageRoot, source = process.env) {
+  const environment = { ...source };
+
+  for (const key of Object.keys(environment)) {
+    const normalized = key.toLowerCase().replaceAll('-', '_');
+    if (normalized === 'npm_config_dry_run' || normalized === 'npm_config_dryrun') {
+      delete environment[key];
+    }
+  }
+
+  const pathKey = Object.keys(environment).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+  const projectBin = resolve(packageRoot, 'node_modules', '.bin');
+  environment[pathKey] = (environment[pathKey] ?? '')
+    .split(delimiter)
+    .filter((entry) => entry && resolve(entry) !== projectBin)
+    .join(delimiter);
+
+  return environment;
+}

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -9,9 +9,10 @@ import {
   rmSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, delimiter, dirname, join, resolve } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { npmChildEnvironment } from './npm-child-env.mjs';
 
 const packageRoot = fileURLToPath(new URL('..', import.meta.url));
 const metadata = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
@@ -37,26 +38,20 @@ function run(command, args, options = {}) {
 }
 
 function runNpm(args, options = {}) {
+  const { env = process.env, ...spawnOptions } = options;
+  const childOptions = {
+    ...spawnOptions,
+    env: npmChildEnvironment(packageRoot, env),
+  };
   if (process.env.npm_execpath) {
-    return run(process.execPath, [process.env.npm_execpath, ...args], options);
+    return run(process.execPath, [process.env.npm_execpath, ...args], childOptions);
   }
 
   const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
   return run(npmCommand, args, {
     shell: process.platform === 'win32',
-    ...options,
+    ...childOptions,
   });
-}
-
-function withoutProjectBin() {
-  const environment = { ...process.env };
-  const pathKey = Object.keys(environment).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
-  const projectBin = resolve(packageRoot, 'node_modules', '.bin');
-  environment[pathKey] = (environment[pathKey] ?? '')
-    .split(delimiter)
-    .filter((entry) => entry && resolve(entry) !== projectBin)
-    .join(delimiter);
-  return environment;
 }
 
 const temporaryRoot = mkdtempSync(join(tmpdir(), 'fauxnix-package-smoke-'));
@@ -76,7 +71,7 @@ try {
   }
   cpSync(join(packageRoot, 'src'), join(sourceDirectory, 'src'), { recursive: true });
 
-  const cleanEnvironment = withoutProjectBin();
+  const cleanEnvironment = npmChildEnvironment(packageRoot);
   runNpm(['ci', '--no-audit', '--no-fund'], {
     cwd: sourceDirectory,
     env: cleanEnvironment,

--- a/scripts/release-check.mjs
+++ b/scripts/release-check.mjs
@@ -1,0 +1,145 @@
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const prereleaseIdentifier = String.raw`(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)`;
+const semverPattern = new RegExp(
+  String.raw`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+    String.raw`(?:-${prereleaseIdentifier}(?:\.${prereleaseIdentifier})*)?` +
+    String.raw`(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`,
+);
+
+function readJson(path, label, problems) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    problems.push(`${label} is not valid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function runGit(root, args) {
+  const result = spawnSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+    shell: false,
+    windowsHide: true,
+  });
+
+  if (result.error || result.status !== 0) {
+    const detail = [result.stderr, result.stdout].filter(Boolean).join('\n').trim();
+    throw new Error(
+      `git ${args.join(' ')} failed${result.error ? `: ${result.error.message}` : ''}` +
+        `${detail ? `: ${detail}` : ''}`,
+    );
+  }
+
+  return result.stdout.trim();
+}
+
+export function checkRelease(root = packageRoot, { requireTag = false } = {}) {
+  const problems = [];
+  const metadata = readJson(resolve(root, 'package.json'), 'package.json', problems);
+  const lock = readJson(resolve(root, 'package-lock.json'), 'package-lock.json', problems);
+  const version = metadata?.version;
+
+  if (typeof version !== 'string' || !semverPattern.test(version)) {
+    problems.push(`package.json version must be valid SemVer (found ${JSON.stringify(version)})`);
+  }
+
+  if (lock && version) {
+    if (lock.version !== version) {
+      problems.push(
+        `package-lock.json version ${JSON.stringify(lock.version)} does not match package.json ${version}`,
+      );
+    }
+    if (lock.packages?.['']?.version !== version) {
+      problems.push(
+        `package-lock.json root package version ${JSON.stringify(lock.packages?.['']?.version)} ` +
+          `does not match package.json ${version}`,
+      );
+    }
+  }
+
+  try {
+    const changelog = readFileSync(resolve(root, 'CHANGELOG.md'), 'utf8');
+    const firstHeading = changelog.split(/\r?\n/).find((line) => line.startsWith('## '));
+    const firstEntry = firstHeading?.match(/^## v([^\s]+)\s+—\s+(\d{4}-\d{2}-\d{2})\s*$/);
+    if (!firstEntry) {
+      problems.push('CHANGELOG.md must start with a "## vX.Y.Z — YYYY-MM-DD" release entry');
+    } else if (version && firstEntry[1] !== version) {
+      problems.push(
+        `first CHANGELOG.md release is v${firstEntry[1]}, but package.json is ${version}`,
+      );
+    }
+  } catch (error) {
+    problems.push(`CHANGELOG.md could not be read: ${error.message}`);
+  }
+
+  if (requireTag && typeof version === 'string' && semverPattern.test(version)) {
+    try {
+      const dirty = runGit(root, ['status', '--porcelain=v1', '--untracked-files=all']);
+      if (dirty) {
+        problems.push('release worktree is not clean');
+      }
+
+      const head = runGit(root, ['rev-parse', 'HEAD']);
+      const expectedTag = `v${version}`;
+      let tagCommit = null;
+      try {
+        tagCommit = runGit(root, ['rev-parse', `${expectedTag}^{commit}`]);
+      } catch {
+        problems.push(`required release tag ${expectedTag} does not exist`);
+      }
+
+      if (tagCommit && tagCommit !== head) {
+        problems.push(`release tag ${expectedTag} does not point at HEAD ${head}`);
+      }
+
+      const tagsAtHead = [];
+      const releaseTags = runGit(root, ['tag', '--list', 'v*'])
+        .split(/\r?\n/)
+        .filter((tag) => semverPattern.test(tag.slice(1)));
+      for (const tag of releaseTags) {
+        if (runGit(root, ['rev-parse', `${tag}^{commit}`]) === head) tagsAtHead.push(tag);
+      }
+      if (tagsAtHead.length !== 1 || tagsAtHead[0] !== expectedTag) {
+        problems.push(
+          `HEAD must have exactly one SemVer release tag (${expectedTag}); found ` +
+            (tagsAtHead.length ? tagsAtHead.join(', ') : 'none'),
+        );
+      }
+    } catch (error) {
+      problems.push(`strict tag check failed: ${error.message}`);
+    }
+  }
+
+  return { problems, version };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const unknown = args.filter((arg) => arg !== '--require-tag');
+  if (unknown.length) {
+    console.error(`release-check: unknown argument(s): ${unknown.join(', ')}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const requireTag = args.includes('--require-tag');
+  const { problems, version } = checkRelease(packageRoot, { requireTag });
+  if (problems.length) {
+    for (const problem of problems) console.error(`release-check: ${problem}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `release check passed: fauxnix-cli v${version} ` +
+      (requireTag ? '(metadata, changelog, clean tagged commit)' : '(metadata and changelog)'),
+  );
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -1,0 +1,140 @@
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { npmChildEnvironment } from '../scripts/npm-child-env.mjs';
+
+const checkerSource = fileURLToPath(new URL('../scripts/release-check.mjs', import.meta.url));
+let fixture = '';
+
+function git(args: string[]): void {
+  const result = spawnSync('git', args, { cwd: fixture, encoding: 'utf8', shell: false });
+  if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+}
+
+function runChecker(...args: string[]) {
+  return spawnSync(process.execPath, [join(fixture, 'scripts', 'release-check.mjs'), ...args], {
+    cwd: fixture,
+    encoding: 'utf8',
+    shell: false,
+  });
+}
+
+describe('release-check', () => {
+  beforeEach(() => {
+    fixture = mkdtempSync(join(tmpdir(), 'fauxnix-release-check-'));
+    mkdirSync(join(fixture, 'scripts'));
+    copyFileSync(checkerSource, join(fixture, 'scripts', 'release-check.mjs'));
+    writeFileSync(
+      join(fixture, 'package.json'),
+      JSON.stringify({ name: 'fauxnix-cli', version: '1.2.3' }, null, 2),
+    );
+    writeFileSync(
+      join(fixture, 'package-lock.json'),
+      JSON.stringify(
+        { name: 'fauxnix-cli', version: '1.2.3', lockfileVersion: 3, packages: { '': { version: '1.2.3' } } },
+        null,
+        2,
+      ),
+    );
+    writeFileSync(join(fixture, 'CHANGELOG.md'), '# Changelog\n\n## v1.2.3 — 2026-09-02\n');
+    git(['init', '--quiet']);
+    git(['config', 'user.name', 'Release Check']);
+    git(['config', 'user.email', 'release-check@example.invalid']);
+    git(['add', '.']);
+    git(['commit', '--quiet', '-m', 'fixture']);
+  });
+
+  afterEach(() => {
+    rmSync(fixture, { recursive: true, force: true });
+  });
+
+  it('accepts matching package, lockfile, and changelog metadata', () => {
+    const result = runChecker();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('release check passed');
+  });
+
+  it('rejects lockfile version drift', () => {
+    const lockPath = join(fixture, 'package-lock.json');
+    const lock = JSON.parse(readFileSync(lockPath, 'utf8'));
+    lock.packages[''].version = '1.2.2';
+    writeFileSync(lockPath, JSON.stringify(lock, null, 2));
+
+    const result = runChecker();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('root package version "1.2.2" does not match');
+  });
+
+  it('rejects a stale changelog heading', () => {
+    writeFileSync(join(fixture, 'CHANGELOG.md'), '# Changelog\n\n## v1.2.2 — 2026-09-02\n');
+    const result = runChecker();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('first CHANGELOG.md release is v1.2.2');
+  });
+
+  it.each(['1.0.0-01', '1.0.0-alpha.01'])('rejects invalid SemVer %s', (version) => {
+    writeFileSync(
+      join(fixture, 'package.json'),
+      JSON.stringify({ name: 'fauxnix-cli', version }, null, 2),
+    );
+    const lock = JSON.parse(readFileSync(join(fixture, 'package-lock.json'), 'utf8'));
+    lock.version = version;
+    lock.packages[''].version = version;
+    writeFileSync(join(fixture, 'package-lock.json'), JSON.stringify(lock, null, 2));
+    writeFileSync(join(fixture, 'CHANGELOG.md'), `# Changelog\n\n## v${version} — 2026-09-02\n`);
+
+    const result = runChecker();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('package.json version must be valid SemVer');
+  });
+
+  it('does not inherit an outer npm publish dry-run into package-smoke child commands', () => {
+    const environment = npmChildEnvironment(fixture, {
+      PATH: process.env.PATH,
+      npm_config_dry_run: 'true',
+      'NPM_CONFIG_DRY-RUN': 'true',
+      npm_config_registry: 'https://registry.npmjs.org/',
+    });
+    expect(environment.npm_config_dry_run).toBeUndefined();
+    expect(environment['NPM_CONFIG_DRY-RUN']).toBeUndefined();
+    expect(environment.npm_config_registry).toBe('https://registry.npmjs.org/');
+  });
+
+  it('requires the matching tag in strict mode', () => {
+    const result = runChecker('--require-tag');
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('required release tag v1.2.3 does not exist');
+  });
+
+  it('accepts one matching tag on a clean commit in strict mode', () => {
+    git(['tag', '-a', 'v1.2.3', '-m', 'v1.2.3']);
+    const result = runChecker('--require-tag');
+    expect(result.status).toBe(0);
+  });
+
+  it('rejects a dirty release worktree in strict mode', () => {
+    git(['tag', 'v1.2.3']);
+    writeFileSync(join(fixture, 'untracked.txt'), 'dirty');
+    const result = runChecker('--require-tag');
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('release worktree is not clean');
+  });
+
+  it('rejects two release tags pointing at the same commit', () => {
+    git(['tag', 'v1.2.2']);
+    git(['tag', 'v1.2.3']);
+    const result = runChecker('--require-tag');
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('found v1.2.2, v1.2.3');
+  });
+});


### PR DESCRIPTION
## Summary

Implements roadmap T-3 as an executable release gate rather than a prose-only checklist.

- add release:check for package/lock/changelog SemVer consistency
- require a clean HEAD with exactly the matching release tag during publish
- run the gate in CI and from prepublishOnly together with typecheck, full tests, and package smoke
- document version PR, annotated tag, RC/stable dist-tag, 2FA, readback, and rollback steps
- keep nested package-smoke npm commands real when an outer npm publish --dry-run exports npm_config_dry_run

## Failure modes covered

- lockfile or CHANGELOG version drift
- invalid numeric prerelease identifiers such as 1.0.0-01
- missing, moved, or duplicate SemVer tags at HEAD
- dirty publish checkout
- annotated-tag object versus peeled commit confusion
- RC accidentally published onto latest
- outer dry-run silently disabling nested npm ci/npm pack validation

## Verification

- npm run release:check
- npm run typecheck
- npm run build
- npm test: 328 passed, 1 opt-in oracle skipped
- inherited npm_config_dry_run=true + npm run test:package: clean source install and tarball install passed
- focused release gate tests: 10/10
- git diff --check

Roadmap: #118, T-3.