### PR TITLE
feat: cover the agent-daily 60 with CommandSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,15 +181,14 @@ development:
   translate time (unsupported constructs throw named errors, never silently misbehave)
 - **text I/O**: `echo printf cat head tail wc tee nl tac md5sum sha1sum sha256sum base64 seq yes xargs`
 
-`cp` / `mv` / `rm` / `touch` / `du` / `ls` / `ll` / `mkdir` / `rmdir` / `mktemp` / `ln` /
-`readlink` / `realpath` / `basename` / `dirname` / `stat` / `file` / `df` / `chmod` / `chown` /
-`diff` / `tee` / `grep` / `head` / `echo` / `printf` / `cat` / `tail` / `wc` / `sort` / `uniq` /
-`cut` / `tr` / `gzip` / `gunzip` / `zcat` / `zip` / `unzip` carry a `CommandSpec`: unknown options fail with a GNU-style
-usage error instead of being ignored (`find` stays unspec'd so predicates like `-name` still
-compile; `sed`/`awk`/`egrep` stay unspec'd; `tar` stays unspec'd because it is fx-native to
-`tar.exe` and unknown GNU flags must reach bsdtar). Implemented GNU holes: `cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` /
-`head --lines` / `du --max-depth`. `fauxnix list --json` and `docs/command-specs.md` dump the
-same metadata.
+The curated **agent-daily 60** carry a `CommandSpec`: unknown options fail with a GNU-style
+usage error instead of being ignored. The generated [`docs/command-specs.md`](docs/command-specs.md)
+is the exact list, coverage count, option table, and exclusion rationale; `fauxnix list --json`
+exposes the same per-command metadata. `find` stays unspec'd so predicates like `-name` still
+compile; `sed`/`awk`/`egrep` keep their command-specific parsers; `tar` remains native to
+`tar.exe` so supported bsdtar options reach the executable. Implemented GNU holes include
+`cp -n` / `mv -n` / `touch -c` / `tee --append` / `grep -m` / `head --lines` /
+`du --max-depth` / `env -u` / `ps -f` / `command -V` / `date --date=@SECONDS`.
 - **shell/system**: `cd pwd export unset env printenv ps kill pkill pgrep sleep which type whoami
   id groups date uname hostname uptime free nproc clear true false test [ [[ : pushd popd dirs sudo
   timeout man history less more source . eval exit alias set shift`

--- a/docs/command-specs.md
+++ b/docs/command-specs.md
@@ -2,6 +2,23 @@
 
 Generated from `CommandSpec`. Unlisted commands still use unchecked `parseWords` (unknown flags ignored). Spec'd commands fail loud on unknown or unsupported options.
 
+## Agent-daily 60 (C-5)
+
+Curated command names: `basename`, `cat`, `cd`, `chmod`, `chown`, `clear`, `command`, `cp`, `cut`, `date`, `df`, `diff`, `dirname`, `du`, `echo`, `env`, `export`, `file`, `free`, `grep`, `groups`, `gunzip`, `gzip`, `head`, `hostname`, `id`, `ll`, `ln`, `ls`, `mkdir`, `mktemp`, `mv`, `nproc`, `printenv`, `printf`, `ps`, `pwd`, `readlink`, `realpath`, `rm`, `rmdir`, `sleep`, `sort`, `stat`, `tail`, `tee`, `timeout`, `touch`, `tr`, `type`, `uname`, `uniq`, `unset`, `unzip`, `uptime`, `wc`, `which`, `whoami`, `zcat`, `zip`
+
+Coverage: **60 / 60 spec'd**.
+
+## Intentional CommandSpec exclusions
+
+These commands stay outside the generic option walker by design. This is a structural rationale, not a claim that every command-specific option path is already strict.
+
+| Command | Rationale |
+| --- | --- |
+| `find` | option-looking predicates are parsed by the find expression compiler; generic short-option bundling would misread -name |
+| `sed`, `awk` | program text and option grammar require command-specific parsing; any remaining unchecked options must be fixed there rather than treated as generic flags |
+| `egrep` | semantic alias injects grep -E through its own handler; it must not be wrapped as an independent generic option parser |
+| `tar` | argv is passed to Windows bsdtar; rejecting unlisted GNU/bsdtar options before native dispatch would reduce compatibility |
+
 ## `cp`
 
 Effects: `read`, `write`
@@ -440,6 +457,246 @@ Effects: `read`, `write`
 | `-q` | flag | implemented |
 | `-d`, `--directory` | required | implemented |
 
+## `cd`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-L` | flag | implemented |
+| `-P` | flag | unsupported (physical symlink/junction resolution) |
+| `-e` | flag | unsupported (physical-resolution failure mode) |
+| `-@` | flag | unsupported (extended-attribute directory view) |
+
+## `pwd`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-L` | flag | implemented |
+| `-P` | flag | unsupported (physical symlink/junction resolution) |
+| `-W` | flag | unsupported (MSYS Windows-path output) |
+
+## `export`
+
+Effects: `read`, `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-f` | flag | unsupported (shell functions are not supported) |
+| `-n` | flag | unsupported (all fauxnix variables live in the session environment) |
+| `-p` | flag | unsupported (declare-style shell output) |
+
+## `unset`
+
+Effects: `write`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-v` | flag | implemented |
+| `-f` | flag | unsupported (shell functions are not supported) |
+| `-n` | flag | unsupported (nameref variables are not supported) |
+
+## `env`
+
+Effects: `process`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-u`, `--unset` | required | implemented (literal variable names only) |
+| `-i`, `--ignore-environment` | flag | unsupported (would silently keep inherited secrets; use env -u NAME or unset first) |
+| `-0`, `--null` | flag | unsupported (NUL-terminated output) |
+| `-C`, `--chdir` | required | unsupported (temporary working directory) |
+| `-S`, `--split-string` | required | unsupported (shell-like string splitting) |
+
+## `printenv`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-0`, `--null` | flag | unsupported (NUL-terminated output) |
+
+## `ps`
+
+Effects: `process`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-e`, `--everyone` | flag | implemented |
+| `-A`, `--all` | flag | implemented |
+| `-f` | flag | implemented |
+| `-a` | flag | unsupported (terminal-based process selection) |
+| `-x` | flag | unsupported (terminal-based process selection) |
+| `-u` | flag | unsupported (BSD user-oriented format) |
+| `--user` | required | unsupported (user filtering) |
+| `-p`, `--pid` | required | unsupported (PID filtering) |
+| `-o`, `--format` | required | unsupported (custom output columns) |
+| `--sort` | required | unsupported (custom process ordering) |
+
+## `sleep`
+
+Effects: `process`
+
+No options declared.
+
+## `which`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-a`, `--all` | flag | unsupported (all matching PATH entries) |
+| `-s` | flag | unsupported (silent status-only mode) |
+
+## `type`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-a` | flag | unsupported (all matching definitions) |
+| `-f` | flag | unsupported (shell functions are not supported) |
+| `-P` | flag | unsupported (forced PATH lookup) |
+| `-p` | flag | unsupported (PATH-only lookup) |
+| `-t` | flag | unsupported (type-name-only output) |
+
+## `command`
+
+Effects: `process`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-v` | flag | implemented |
+| `-V` | flag | implemented |
+| `-p` | flag | unsupported (guaranteed default utility PATH) |
+
+## `whoami`
+
+Effects: `read`
+
+No options declared.
+
+## `id`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-u` | flag | implemented |
+| `-g` | flag | implemented |
+| `-n` | flag | implemented |
+| `-G` | flag | unsupported (supplementary group ID mapping) |
+| `-r` | flag | unsupported (real versus effective IDs) |
+| `-z` | flag | unsupported (NUL-terminated output) |
+| `-Z` | flag | unsupported (SELinux security context) |
+
+## `groups`
+
+Effects: `read`
+
+No options declared.
+
+## `date`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-u`, `--utc` | flag | implemented |
+| `-d`, `--date` | required | implemented (@SECONDS input only) |
+| `-I`, `--iso-8601` | flag | unsupported (ISO precision selection) |
+| `-R`, `--rfc-email` | flag | unsupported (RFC email formatting) |
+| `--rfc-3339` | required | unsupported (RFC 3339 precision selection) |
+| `-r`, `--reference` | required | unsupported (file timestamp lookup) |
+| `-s`, `--set` | required | unsupported (changing the system clock) |
+
+## `uname`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-a`, `--all` | flag | implemented |
+| `-s`, `--kernel-name` | flag | implemented |
+| `-n`, `--nodename` | flag | implemented |
+| `-r`, `--kernel-release` | flag | implemented |
+| `-v`, `--kernel-version` | flag | implemented |
+| `-m`, `--machine` | flag | implemented |
+| `-p`, `--processor` | flag | implemented |
+| `-o`, `--operating-system` | flag | implemented |
+| `-i`, `--hardware-platform` | flag | unsupported (hardware-platform distinction) |
+
+## `hostname`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-s`, `--short` | flag | unsupported (short-name selection) |
+| `-f`, `--fqdn` | flag | unsupported (FQDN lookup) |
+| `-d`, `--domain` | flag | unsupported (DNS domain lookup) |
+| `-i`, `--ip-address` | flag | unsupported (address lookup) |
+| `-I`, `--all-ip-addresses` | flag | unsupported (all-address lookup) |
+| `-F`, `--file` | required | unsupported (changing the hostname from a file) |
+
+## `uptime`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-p`, `--pretty` | flag | unsupported (pretty duration output) |
+| `-s`, `--since` | flag | unsupported (boot timestamp output) |
+
+## `free`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-h`, `--human` | flag | implemented |
+| `-k`, `--kibi` | flag | implemented |
+| `-m`, `--mebi` | flag | implemented |
+| `-g`, `--gibi` | flag | implemented |
+| `-b`, `--bytes` | flag | unsupported (byte-unit output) |
+| `--si` | flag | unsupported (powers-of-1000 units) |
+| `-t`, `--total` | flag | unsupported (total row) |
+| `-w`, `--wide` | flag | unsupported (wide buffer/cache columns) |
+| `-s`, `--seconds` | required | unsupported (repeating output) |
+| `-c`, `--count` | required | unsupported (repeating output) |
+
+## `nproc`
+
+Effects: `read`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `--all` | flag | unsupported (installed versus available processor distinction) |
+| `--ignore` | required | unsupported (processor-count subtraction) |
+
+## `clear`
+
+Effects: none
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-x` | flag | unsupported (scrollback-preserving terminal control) |
+| `-T` | required | unsupported (alternate terminal type) |
+
+## `timeout`
+
+Effects: `process`
+
+| Option | Value | Support |
+| --- | --- | --- |
+| `-s`, `--signal` | required | unsupported (signal selection) |
+| `-k`, `--kill-after` | required | unsupported (two-phase termination) |
+| `--preserve-status` | flag | unsupported (child-status preservation after timeout) |
+| `--foreground` | flag | unsupported (interactive foreground process groups) |
+| `-v`, `--verbose` | flag | unsupported (signal diagnostics) |
+
 ## Unspec'd commands
 
-`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `cd`, `clear`, `command`, `curl`, `date`, `dig`, `dirs`, `egrep`, `env`, `eval`, `exit`, `export`, `false`, `find`, `free`, `groups`, `history`, `host`, `hostname`, `id`, `ifconfig`, `ip`, `kill`, `less`, `man`, `md5sum`, `more`, `netstat`, `nl`, `nproc`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `printenv`, `ps`, `pushd`, `pwd`, `read`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `shift`, `sleep`, `source`, `ss`, `sudo`, `tac`, `tar`, `test`, `timeout`, `true`, `type`, `uname`, `unset`, `uptime`, `wget`, `which`, `whoami`, `xargs`, `yes`
+`.`, `:`, `[`, `[[`, `alias`, `awk`, `base64`, `curl`, `dig`, `dirs`, `egrep`, `eval`, `exit`, `false`, `find`, `history`, `host`, `ifconfig`, `ip`, `kill`, `less`, `man`, `md5sum`, `more`, `netstat`, `nl`, `nslookup`, `pgrep`, `ping`, `pkill`, `popd`, `pushd`, `read`, `sed`, `seq`, `set`, `sha1sum`, `sha256sum`, `shift`, `source`, `ss`, `sudo`, `tac`, `tar`, `test`, `true`, `wget`, `xargs`, `yes`

--- a/src/commands/install-all.ts
+++ b/src/commands/install-all.ts
@@ -2,7 +2,7 @@ import { registerAll, registerSpecs } from '../registry.js';
 import { handlers as files, specs as fileSpecs } from './files.js';
 import { handlers as textFilters, specs as textFilterSpecs } from './text-filters.js';
 import { handlers as textIo, specs as textIoSpecs } from './text-io.js';
-import { handlers as sysinfo } from './sysinfo.js';
+import { handlers as sysinfo, specs as sysinfoSpecs } from './sysinfo.js';
 import { handlers as net } from './net.js';
 import { handlers as archive, specs as archiveSpecs } from './archive.js';
 
@@ -18,6 +18,7 @@ export function installAll(): void {
   registerSpecs(textIoSpecs);
   registerSpecs(textFilterSpecs);
   registerSpecs(archiveSpecs);
+  registerSpecs(sysinfoSpecs);
 }
 
 installAll();

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -1,8 +1,9 @@
 import { FauxnixParseError, Word, WordPart, isUnquotedLiteral, wordToString } from '../ast.js';
-import { Handler, lookup, parseWords, psStr, registeredNames } from '../registry.js';
+import { CommandSpec, Handler, lookup, parseWords, psErr, psStr, registeredNames } from '../registry.js';
 import {
   argListExpr,
   exprOfWord,
+  literalOfWord,
   operandExpr,
   translateSimple,
   wrapTempEnv,
@@ -87,6 +88,31 @@ function splitAssignWord(w: Word): AssignSplit | null {
   return null;
 }
 
+/** Remove an unquoted literal option prefix while preserving dynamic Word parts. */
+function wordAfterPrefix(w: Word, prefix: string): Word | null {
+  let remaining = prefix;
+  const out: Word = [];
+  for (const part of w) {
+    if (remaining === '') {
+      out.push(part);
+      continue;
+    }
+    if (part.kind !== 'Text') return null;
+    if (remaining.startsWith(part.text)) {
+      remaining = remaining.slice(part.text.length);
+      continue;
+    }
+    if (part.text.startsWith(remaining)) {
+      const tail = part.text.slice(remaining.length);
+      if (tail !== '') out.push({ kind: 'Text', text: tail });
+      remaining = '';
+      continue;
+    }
+    return null;
+  }
+  return remaining === '' ? out : null;
+}
+
 /** Text Words -> PS array expression. */
 function textArgs(words: Word[]): string {
   return argListExpr(words, exprOfWord);
@@ -129,10 +155,10 @@ const PS_WHICH_FN = [
   "  foreach ($fx_d in ($env:PATH -split ';')) {",
   "    if ($fx_d -eq '') { continue }",
   '    $fx_c = Join-Path $fx_d $n',
-  '    if (Test-Path -LiteralPath $fx_c) { return $fx_c }',
+  '    if (Test-Path -LiteralPath $fx_c -PathType Leaf) { return $fx_c }',
   "    $fx_exts = @(($env:PATHEXT -split ';') + '.exe') | Select-Object -Unique",
   '    foreach ($fx_e in $fx_exts) {',
-  '      if (Test-Path -LiteralPath ($fx_c + $fx_e)) { return ($fx_c + $fx_e) }',
+  '      if (Test-Path -LiteralPath ($fx_c + $fx_e) -PathType Leaf) { return ($fx_c + $fx_e) }',
   '    }',
   '  }',
   "  return ''",
@@ -148,23 +174,24 @@ const PS_MON_FN =
 /* ------------------------------------------------------------------ */
 
 const cd: Handler = (args) => {
-  if (args.length === 0) {
+  const { operandWords } = parseWords(args);
+  if (operandWords.length === 0) {
     return [
       'try { Set-Location -LiteralPath $HOME }',
       "catch { [Console]::Error.WriteLine('bash: cd: ' + $_.Exception.Message); $script:fx_exit = 1 }",
     ].join('\n');
   }
-  if (args.length > 1) {
+  if (operandWords.length > 1) {
     return "[Console]::Error.WriteLine('bash: cd: too many arguments'); $script:fx_exit = 1";
   }
-  if (wordToString(args[0]) === '-') {
+  if (wordToString(operandWords[0]) === '-') {
     return [
       "if (-not $env:FAUXNIX_OLDPWD) { [Console]::Error.WriteLine('bash: cd: OLDPWD not set'); $script:fx_exit = 1 }",
       'else { try { Set-Location -LiteralPath $env:FAUXNIX_OLDPWD } catch { [Console]::Error.WriteLine("bash: cd: " + $env:FAUXNIX_OLDPWD + ": No such file or directory"); $script:fx_exit = 1 } }',
     ].join('\n');
   }
   return [
-    '$fx_ds = ' + argListExpr([args[0]]),
+    '$fx_ds = ' + argListExpr([operandWords[0]]),
     "if ($fx_ds.Count -ne 1) { [Console]::Error.WriteLine('bash: cd: too many arguments'); $script:fx_exit = 1 }",
     'else { $fx_d = [string]$fx_ds[0]',
     'if (-not (Test-Path -LiteralPath $fx_d)) { [Console]::Error.WriteLine("bash: cd: " + $fx_d + ": No such file or directory"); $script:fx_exit = 1 }',
@@ -174,7 +201,9 @@ const cd: Handler = (args) => {
 };
 
 const pwd: Handler = (args) => {
-  void args; // -P accepted; physical == logical for Windows providers
+  const { operandWords } = parseWords(args);
+  if (operandWords.length > 0) return psErr('pwd', "extra operand '" + wordToString(operandWords[0]) + "'. Try 'pwd --help'.");
+  // -L is the default. CommandSpec rejects -P because junctions make it distinct.
   return "(Get-Location).Path.Replace('\\', '/')";
 };
 
@@ -190,7 +219,8 @@ const exportCmd: Handler = (args) => {
   const sets: AssignSplit[] = [];
   for (const w of args) {
     const t = wordToString(w);
-    if (t.startsWith('-')) continue; // -n / -f accepted and ignored
+    if (t === '-') return psErr('export', "invalid option '-'. Try 'export --help'.");
+    if (t.startsWith('-')) continue; // validated by CommandSpec
     const sp = splitAssignWord(w);
     if (sp === null) continue; // `export VAR` (bare name) -> no-op success
     if (!NAME_RE.test(sp.name)) {
@@ -245,34 +275,76 @@ const env: Handler = (args, ctx) => {
   const unsets: string[] = [];
   let i = 0;
   let cmdIdx = -1;
-  while (i < raw.length) {
-    const t = raw[i];
-    if (t === '--') {
-      cmdIdx = i + 1;
-      break;
-    }
-    if (t === '-i' || t === '--ignore-environment') {
+  let optionsDone = false;
+  const addUnset = (word: Word | undefined): string | null => {
+    const name = word ? literalOfWord(word) : null;
+    if (name === null || !NAME_RE.test(name)) {
       return (
         '[Console]::Error.WriteLine(' +
         psStr(
-          'fauxnix: env -i/--ignore-environment is not supported (would silently keep inherited secrets). Use env -u NAME or unset first instead.',
+          'env: -u/--unset requires a literal variable name in fauxnix; expand and unset the name in a separate command instead',
         ) +
-        '); $script:fx_exit = 2'
+        '); $script:fx_exit = 125'
       );
     }
-    if (t === '-u' || t === '--unset') {
-      if (i + 1 < raw.length) unsets.push(raw[i + 1]);
-      i += 2;
-      continue;
-    }
-    if (t.startsWith('-u=') || t.startsWith('--unset=')) {
-      unsets.push(t.slice(t.indexOf('=') + 1));
-      i++;
-      continue;
-    }
-    if (t.startsWith('-')) {
-      i++; // unknown flags ignored
-      continue;
+    unsets.push(name);
+    return null;
+  };
+  while (i < raw.length) {
+    const t = raw[i];
+    if (!optionsDone) {
+      if (t === '-') {
+        return (
+          '[Console]::Error.WriteLine(' +
+          psStr(
+            'env: option - (ignore environment) is not supported by fauxnix; use env -u NAME or unset first',
+          ) +
+          '); $script:fx_exit = 125'
+        );
+      }
+      if (t === '--') {
+        optionsDone = true;
+        i++;
+        continue;
+      }
+      if (t === '-i' || t === '--ignore-environment') {
+        return (
+          '[Console]::Error.WriteLine(' +
+          psStr(
+            'fauxnix: env -i/--ignore-environment is not supported (would silently keep inherited secrets). Use env -u NAME or unset first instead.',
+          ) +
+          '); $script:fx_exit = 2'
+        );
+      }
+      if (t === '-u' || t === '--unset') {
+        const err = addUnset(args[i + 1]);
+        if (err) return err;
+        i += 2;
+        continue;
+      }
+      if (t.startsWith('-u=')) {
+        const err = addUnset(wordAfterPrefix(args[i], '-u=') ?? undefined);
+        if (err) return err;
+        i++;
+        continue;
+      }
+      if (t.startsWith('--unset=')) {
+        const err = addUnset(wordAfterPrefix(args[i], '--unset=') ?? undefined);
+        if (err) return err;
+        i++;
+        continue;
+      }
+      if (t.startsWith('-u') && t.length > 2) {
+        const err = addUnset(wordAfterPrefix(args[i], '-u') ?? undefined);
+        if (err) return err;
+        i++;
+        continue;
+      }
+      if (t.startsWith('-')) {
+        i++; // unknown flags are rejected by CommandSpec
+        continue;
+      }
+      optionsDone = true;
     }
     const sp = splitAssignWord(args[i]);
     if (sp !== null && NAME_RE.test(sp.name)) {
@@ -301,7 +373,7 @@ const env: Handler = (args, ctx) => {
 };
 
 const printenv: Handler = (args) => {
-  const names = stripFlags(args);
+  const { operandWords: names } = parseWords(args);
   if (names.length === 0) return ENV_LIST_PS;
   return [
     '$fx_ns = ' + textArgs(names),
@@ -317,12 +389,12 @@ const printenv: Handler = (args) => {
 /* ------------------------------------------------------------------ */
 
 const ps: Handler = (args) => {
-  const raw = args.map(wordToString);
   const { flags, operandWords } = parseWords(args);
-  const full =
-    operandWords.some((w) => wordToString(w) === 'aux') ||
-    (flags.has('e') && flags.has('f')) ||
-    raw.includes('-ef');
+  const badOperand = operandWords.find((w) => wordToString(w) !== 'aux');
+  if (badOperand) {
+    return psErr('ps', "unsupported operand '" + wordToString(badOperand) + "'. Use 'ps', 'ps -ef', or 'ps aux'.");
+  }
+  const full = operandWords.some((w) => wordToString(w) === 'aux') || flags.has('f');
 
   if (full) {
     return [
@@ -576,7 +648,7 @@ const sleep: Handler = (args) => {
 
 const which: Handler = (args) => {
   const ws = stripFlags(args);
-  if (ws.length === 0) return '';
+  if (ws.length === 0) return psErr('which', "missing command name. Try 'which --help'.");
   return [
     PS_WHICH_FN,
     '$fx_b = @(' + builtinNames().map(psStr).join(', ') + ')',
@@ -590,7 +662,7 @@ const which: Handler = (args) => {
 };
 
 const type: Handler = (args) => {
-  const ws = stripFlags(args);
+  const { operandWords: ws } = parseWords(args);
   if (ws.length === 0) return '';
   return [
     PS_WHICH_FN,
@@ -610,11 +682,16 @@ const type: Handler = (args) => {
 /** `command -v name` (and bare `command name args` as a no-alias run). */
 const commandCmd: Handler = (args, ctx) => {
   let i = 0;
-  let identify = false;
+  let identify: 'path' | 'verbose' | null = null;
   while (i < args.length) {
     const t = wordToString(args[i]);
-    if (t === '-v' || t === '-V') {
-      identify = true;
+    if (t === '-v') {
+      identify = 'path';
+      i++;
+      continue;
+    }
+    if (t === '-V') {
+      identify = 'verbose';
       i++;
       continue;
     }
@@ -622,25 +699,29 @@ const commandCmd: Handler = (args, ctx) => {
       i++;
       break;
     }
-    if (t.startsWith('-')) {
+    if (t.startsWith('-') && t !== '-') {
       i++;
       continue;
     }
     break;
   }
   const rest = args.slice(i);
-  if (identify) {
+  if (identify !== null) {
     if (rest.length === 0) return '';
     return [
       PS_WHICH_FN,
       '$fx_b = @(' + builtinNames().map(psStr).join(', ') + ')',
       '$fx_ns = ' + textArgs(rest),
       'foreach ($fx_n in $fx_ns) {',
-      "  if ($fx_b -contains $fx_n) { '/usr/bin/' + $fx_n }",
+      identify === 'verbose'
+        ? "  if ($fx_b -contains $fx_n) { $fx_n + ' is /usr/bin/' + $fx_n }"
+        : "  if ($fx_b -contains $fx_n) { '/usr/bin/' + $fx_n }",
       '  else {',
       '    $fx_w = fx-which $fx_n',
       "    if ($fx_w -eq '') { $script:fx_exit = 1 }",
-      "    else { $fx_w.Replace('\\', '/') }",
+      identify === 'verbose'
+        ? "    else { $fx_n + ' is ' + $fx_w.Replace('\\', '/') }"
+        : "    else { $fx_w.Replace('\\', '/') }",
       '  }',
       '}',
     ].join('\n');
@@ -663,11 +744,21 @@ const commandCmd: Handler = (args, ctx) => {
 /* whoami / id / groups                                                */
 /* ------------------------------------------------------------------ */
 
-const whoami: Handler = () => '$env:USERNAME.ToLower()';
+const whoami: Handler = (args) => {
+  const { operandWords } = parseWords(args);
+  if (operandWords.length > 0) return psErr('whoami', "extra operand '" + wordToString(operandWords[0]) + "'. Try 'whoami --help'.");
+  return '$env:USERNAME.ToLower()';
+};
 
 const id: Handler = (args) => {
-  const { flags } = parseWords(args);
-  const wantNum = flags.has('u') || flags.has('g') || flags.has('G');
+  const { flags, operandWords } = parseWords(args);
+  if (operandWords.length > 0) {
+    return psErr('id', 'user operands are not supported; omit USER to inspect the current account');
+  }
+  const selectors = ['u', 'g', 'G'].filter((flag) => flags.has(flag));
+  if (selectors.length > 1) return psErr('id', 'cannot print multiple ID selectors together');
+  if (flags.has('n') && selectors.length === 0) return psErr('id', "option '-n' requires -u or -g");
+  const wantNum = selectors.length === 1;
   const wantName = flags.has('n');
   const uidPs = [
     '$fx_sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value',
@@ -683,7 +774,11 @@ const id: Handler = (args) => {
   ].join('\n');
 };
 
-const groups: Handler = () => {
+const groups: Handler = (args) => {
+  const { operandWords } = parseWords(args);
+  if (operandWords.length > 0) {
+    return psErr('groups', 'user operands are not supported; omit USER to inspect the current account');
+  }
   return [
     '$fx_id = [System.Security.Principal.WindowsIdentity]::GetCurrent()',
     '$fx_gs = @()',
@@ -769,8 +864,8 @@ const DATE_FNS = [
 ].join('\n');
 
 const date: Handler = (args) => {
-  const { flags, operandWords } = parseWords(args, ['d']);
-  const utc = flags.has('u');
+  const { flags, longs, operandWords } = parseWords(args, ['d'], ['--date']);
+  const utc = flags.has('u') || longs.has('--utc');
   // find the -d value as a Word (so dynamic values stay PS expressions)
   const raw = args.map(wordToString);
   let dWord: Word | null = null;
@@ -779,8 +874,27 @@ const date: Handler = (args) => {
       dWord = args[k + 1] ?? null;
       break;
     }
+    if (raw[k].startsWith('--date=')) {
+      dWord = wordAfterPrefix(args[k], '--date=');
+      break;
+    }
+    if (raw[k].startsWith('-') && !raw[k].startsWith('--')) {
+      const body = raw[k].slice(1);
+      const dIndex = body.indexOf('d');
+      if (dIndex >= 0) {
+        const prefix = '-' + body.slice(0, dIndex + 1);
+        const attached = wordAfterPrefix(args[k], prefix);
+        dWord = attached && attached.length > 0 ? attached : (args[k + 1] ?? null);
+        break;
+      }
+    }
   }
-  const fmtWord = operandWords.find((w) => wordToString(w).startsWith('+'));
+  const fmtWords = operandWords.filter((w) => wordToString(w).startsWith('+'));
+  const badOperand = operandWords.find((w) => !wordToString(w).startsWith('+'));
+  if (badOperand || fmtWords.length > 1) {
+    return psErr('date', "extra operand '" + wordToString(badOperand ?? fmtWords[1]) + "'. Try 'date --help'.");
+  }
+  const fmtWord = fmtWords[0];
 
   const lines: string[] = [DATE_FNS];
   lines.push('$fx_d = ' + (utc ? '[DateTime]::UtcNow' : 'Get-Date'));
@@ -789,7 +903,7 @@ const date: Handler = (args) => {
     lines.push('$fx_ds = ' + exprOfWord(dWord));
     lines.push("if ($fx_ds -like '@*') {");
     lines.push(
-      "  try { $fx_n = [long]($fx_ds.Substring(1)); $fx_d = ([datetime]'1970-01-01').AddSeconds($fx_n)" +
+      "  try { $fx_n = [long]($fx_ds.Substring(1)); $fx_epoch = [DateTime]::SpecifyKind([datetime]'1970-01-01', [DateTimeKind]::Utc); $fx_d = $fx_epoch.AddSeconds($fx_n)" +
         (utc ? ' }' : '.ToLocalTime() }'),
     );
     lines.push('  catch { $fx_ok = $false }');
@@ -817,8 +931,10 @@ const date: Handler = (args) => {
 const ARCH_PS = "($(if ($env:PROCESSOR_ARCHITECTURE -like 'ARM*') { 'ARM64' } else { 'x86_64' }))";
 
 const uname: Handler = (args) => {
-  const { flags } = parseWords(args);
-  if (flags.has('a')) {
+  const { flags, longs, operandWords } = parseWords(args);
+  if (operandWords.length > 0) return psErr('uname', "extra operand '" + wordToString(operandWords[0]) + "'. Try 'uname --help'.");
+  const has = (short: string, long: string) => flags.has(short) || longs.has(long);
+  if (has('a', '--all')) {
     return (
       "('Linux ' + $env:COMPUTERNAME + ' 6.8.0-fauxnix #1 SMP PREEMPT_DYNAMIC ' + " +
       ARCH_PS +
@@ -826,19 +942,27 @@ const uname: Handler = (args) => {
     );
   }
   const parts: string[] = [];
-  if (flags.has('s') || flags.size === 0) parts.push("'Linux'");
-  if (flags.has('n')) parts.push('$env:COMPUTERNAME');
-  if (flags.has('r')) parts.push("'6.8.0-fauxnix'");
-  if (flags.has('v')) parts.push("'#1 SMP PREEMPT_DYNAMIC'");
-  if (flags.has('m') || flags.has('p')) parts.push(ARCH_PS);
-  if (flags.has('o')) parts.push("'GNU/Linux'");
+  if (has('s', '--kernel-name') || (flags.size === 0 && longs.size === 0)) parts.push("'Linux'");
+  if (has('n', '--nodename')) parts.push('$env:COMPUTERNAME');
+  if (has('r', '--kernel-release')) parts.push("'6.8.0-fauxnix'");
+  if (has('v', '--kernel-version')) parts.push("'#1 SMP PREEMPT_DYNAMIC'");
+  if (has('m', '--machine') || has('p', '--processor')) parts.push(ARCH_PS);
+  if (has('o', '--operating-system')) parts.push("'GNU/Linux'");
   if (parts.length === 0) parts.push("'Linux'");
   return '(@(' + parts.join(', ') + ") -join ' ')";
 };
 
-const hostname: Handler = () => '$env:COMPUTERNAME';
+const hostname: Handler = (args) => {
+  const { operandWords } = parseWords(args);
+  if (operandWords.length > 0) {
+    return psErr('hostname', 'setting or selecting a host is not supported; omit operands to print the current hostname');
+  }
+  return '$env:COMPUTERNAME';
+};
 
-const uptime: Handler = () => {
+const uptime: Handler = (args) => {
+  const { operandWords } = parseWords(args);
+  if (operandWords.length > 0) return psErr('uptime', "extra operand '" + wordToString(operandWords[0]) + "'. Try 'uptime --help'.");
   return [
     '$fx_now = Get-Date',
     '$fx_os = Get-CimInstance Win32_OperatingSystem',
@@ -852,8 +976,43 @@ const uptime: Handler = () => {
 };
 
 const free: Handler = (args) => {
-  const { flags } = parseWords(args);
-  const unit = flags.has('h') ? 'h' : flags.has('g') ? 'g' : flags.has('m') ? 'm' : 'k';
+  const { flags, longs, operandWords } = parseWords(args);
+  if (operandWords.length > 0) return psErr('free', "extra operand '" + wordToString(operandWords[0]) + "'. Try 'free --help'.");
+  void flags;
+  void longs;
+  let unit = 'k';
+  let sawHuman = false;
+  let nonHumanUnits = 0;
+  for (const raw of args.map(wordToString)) {
+    if (raw === '--human') {
+      unit = 'h';
+      sawHuman = true;
+    } else if (raw === '--gibi') {
+      unit = 'g';
+      nonHumanUnits++;
+    } else if (raw === '--mebi') {
+      unit = 'm';
+      nonHumanUnits++;
+    } else if (raw === '--kibi') {
+      unit = 'k';
+      nonHumanUnits++;
+    }
+    else if (raw.startsWith('-') && !raw.startsWith('--')) {
+      for (const flag of raw.slice(1)) {
+        if (flag === 'h') {
+          unit = 'h';
+          sawHuman = true;
+        } else if (flag === 'g' || flag === 'm' || flag === 'k') {
+          unit = flag;
+          nonHumanUnits++;
+        }
+      }
+    }
+  }
+  if (!sawHuman && nonHumanUnits > 1) {
+    return psErr('free', 'multiple unit options are not supported together; choose one of -k, -m, or -g');
+  }
+  if (sawHuman) unit = 'h';
   // value converter for KB-based memory values
   let conv: (v: string) => string;
   if (unit === 'k') conv = (v) => '[string]' + v;
@@ -906,13 +1065,20 @@ const free: Handler = (args) => {
   return lines.join('\n');
 };
 
-const nproc: Handler = () => '[string][Environment]::ProcessorCount';
+const nproc: Handler = (args) => {
+  const { operandWords } = parseWords(args);
+  if (operandWords.length > 0) return psErr('nproc', "extra operand '" + wordToString(operandWords[0]) + "'. Try 'nproc --help'.");
+  return '[string][Environment]::ProcessorCount';
+};
 
 /* ------------------------------------------------------------------ */
 /* clear / true / false / :                                            */
 /* ------------------------------------------------------------------ */
 
-const clear: Handler = () => "([char]27 + '[2J' + [char]27 + '[H')";
+const clear: Handler = (args) => {
+  if (args.length > 0) return psErr('clear', "extra operand '" + wordToString(args[0]) + "'. Try 'clear --help'.");
+  return "([char]27 + '[2J' + [char]27 + '[H')";
+};
 
 const trueCmd: Handler = () => '';
 
@@ -2723,6 +2889,322 @@ const shiftCmd: Handler = (args) => {
 };
 
 /* ------------------------------------------------------------------ */
+
+export const specs: CommandSpec[] = [
+  {
+    names: ['cd'],
+    options: [
+      { short: 'L', support: 'implemented' },
+      { short: 'P', support: 'unsupported', reason: 'physical symlink/junction resolution' },
+      { short: 'e', support: 'unsupported', reason: 'physical-resolution failure mode' },
+      { short: '@', support: 'unsupported', reason: 'extended-attribute directory view' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    usageExit: 2,
+    handler: cd,
+  },
+  {
+    names: ['pwd'],
+    options: [
+      { short: 'L', support: 'implemented' },
+      { short: 'P', support: 'unsupported', reason: 'physical symlink/junction resolution' },
+      { short: 'W', support: 'unsupported', reason: 'MSYS Windows-path output' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    usageExit: 2,
+    handler: pwd,
+  },
+  {
+    names: ['export'],
+    options: [
+      { short: 'f', support: 'unsupported', reason: 'shell functions are not supported' },
+      { short: 'n', support: 'unsupported', reason: 'all fauxnix variables live in the session environment' },
+      { short: 'p', support: 'unsupported', reason: 'declare-style shell output' },
+    ],
+    effects: ['read', 'write'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    usageExit: 2,
+    handler: exportCmd,
+  },
+  {
+    names: ['unset'],
+    options: [
+      { short: 'v', support: 'implemented' },
+      { short: 'f', support: 'unsupported', reason: 'shell functions are not supported' },
+      { short: 'n', support: 'unsupported', reason: 'nameref variables are not supported' },
+    ],
+    effects: ['write'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    usageExit: 2,
+    handler: unset,
+  },
+  {
+    names: ['env'],
+    options: [
+      {
+        short: 'u',
+        long: '--unset',
+        takesValue: true,
+        support: 'implemented',
+        reason: 'literal variable names only',
+      },
+      {
+        short: 'i',
+        long: '--ignore-environment',
+        support: 'unsupported',
+        reason: 'would silently keep inherited secrets; use env -u NAME or unset first',
+      },
+      { short: '0', long: '--null', support: 'unsupported', reason: 'NUL-terminated output' },
+      { short: 'C', long: '--chdir', takesValue: true, support: 'unsupported', reason: 'temporary working directory' },
+      { short: 'S', long: '--split-string', takesValue: true, support: 'unsupported', reason: 'shell-like string splitting' },
+    ],
+    effects: ['process'],
+    platform: 'windows-ps51',
+    dispatch: 'dynamic',
+    usageExit: 125,
+    leadingOptions: true,
+    handler: env,
+  },
+  {
+    names: ['printenv'],
+    options: [
+      { short: '0', long: '--null', support: 'unsupported', reason: 'NUL-terminated output' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    usageExit: 2,
+    handler: printenv,
+  },
+  {
+    names: ['ps'],
+    options: [
+      { short: 'e', long: '--everyone', support: 'implemented' },
+      { short: 'A', long: '--all', support: 'implemented' },
+      { short: 'f', support: 'implemented' },
+      { short: 'a', support: 'unsupported', reason: 'terminal-based process selection' },
+      { short: 'x', support: 'unsupported', reason: 'terminal-based process selection' },
+      { short: 'u', support: 'unsupported', reason: 'BSD user-oriented format' },
+      { long: '--user', takesValue: true, support: 'unsupported', reason: 'user filtering' },
+      { short: 'p', long: '--pid', takesValue: true, support: 'unsupported', reason: 'PID filtering' },
+      { short: 'o', long: '--format', takesValue: true, support: 'unsupported', reason: 'custom output columns' },
+      { long: '--sort', takesValue: true, support: 'unsupported', reason: 'custom process ordering' },
+    ],
+    effects: ['process'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: ps,
+  },
+  {
+    names: ['sleep'],
+    options: [],
+    effects: ['process'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: sleep,
+  },
+  {
+    names: ['which'],
+    options: [
+      { short: 'a', long: '--all', support: 'unsupported', reason: 'all matching PATH entries' },
+      { short: 's', support: 'unsupported', reason: 'silent status-only mode' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: which,
+  },
+  {
+    names: ['type'],
+    options: [
+      { short: 'a', support: 'unsupported', reason: 'all matching definitions' },
+      { short: 'f', support: 'unsupported', reason: 'shell functions are not supported' },
+      { short: 'P', support: 'unsupported', reason: 'forced PATH lookup' },
+      { short: 'p', support: 'unsupported', reason: 'PATH-only lookup' },
+      { short: 't', support: 'unsupported', reason: 'type-name-only output' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    usageExit: 2,
+    handler: type,
+  },
+  {
+    names: ['command'],
+    options: [
+      { short: 'v', support: 'implemented' },
+      { short: 'V', support: 'implemented' },
+      { short: 'p', support: 'unsupported', reason: 'guaranteed default utility PATH' },
+    ],
+    effects: ['process'],
+    platform: 'windows-ps51',
+    dispatch: 'dynamic',
+    usageExit: 2,
+    leadingOptions: true,
+    handler: commandCmd,
+  },
+  {
+    names: ['whoami'],
+    options: [],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: whoami,
+  },
+  {
+    names: ['id'],
+    options: [
+      { short: 'u', support: 'implemented' },
+      { short: 'g', support: 'implemented' },
+      { short: 'n', support: 'implemented' },
+      { short: 'G', support: 'unsupported', reason: 'supplementary group ID mapping' },
+      { short: 'r', support: 'unsupported', reason: 'real versus effective IDs' },
+      { short: 'z', support: 'unsupported', reason: 'NUL-terminated output' },
+      { short: 'Z', support: 'unsupported', reason: 'SELinux security context' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: id,
+  },
+  {
+    names: ['groups'],
+    options: [],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: groups,
+  },
+  {
+    names: ['date'],
+    options: [
+      { short: 'u', long: '--utc', support: 'implemented' },
+      {
+        short: 'd',
+        long: '--date',
+        takesValue: true,
+        support: 'implemented',
+        reason: '@SECONDS input only',
+      },
+      { short: 'I', long: '--iso-8601', support: 'unsupported', reason: 'ISO precision selection' },
+      { short: 'R', long: '--rfc-email', support: 'unsupported', reason: 'RFC email formatting' },
+      { long: '--rfc-3339', takesValue: true, support: 'unsupported', reason: 'RFC 3339 precision selection' },
+      { short: 'r', long: '--reference', takesValue: true, support: 'unsupported', reason: 'file timestamp lookup' },
+      { short: 's', long: '--set', takesValue: true, support: 'unsupported', reason: 'changing the system clock' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: date,
+  },
+  {
+    names: ['uname'],
+    options: [
+      { short: 'a', long: '--all', support: 'implemented' },
+      { short: 's', long: '--kernel-name', support: 'implemented' },
+      { short: 'n', long: '--nodename', support: 'implemented' },
+      { short: 'r', long: '--kernel-release', support: 'implemented' },
+      { short: 'v', long: '--kernel-version', support: 'implemented' },
+      { short: 'm', long: '--machine', support: 'implemented' },
+      { short: 'p', long: '--processor', support: 'implemented' },
+      { short: 'o', long: '--operating-system', support: 'implemented' },
+      { short: 'i', long: '--hardware-platform', support: 'unsupported', reason: 'hardware-platform distinction' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: uname,
+  },
+  {
+    names: ['hostname'],
+    options: [
+      { short: 's', long: '--short', support: 'unsupported', reason: 'short-name selection' },
+      { short: 'f', long: '--fqdn', support: 'unsupported', reason: 'FQDN lookup' },
+      { short: 'd', long: '--domain', support: 'unsupported', reason: 'DNS domain lookup' },
+      { short: 'i', long: '--ip-address', support: 'unsupported', reason: 'address lookup' },
+      { short: 'I', long: '--all-ip-addresses', support: 'unsupported', reason: 'all-address lookup' },
+      { short: 'F', long: '--file', takesValue: true, support: 'unsupported', reason: 'changing the hostname from a file' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: hostname,
+  },
+  {
+    names: ['uptime'],
+    options: [
+      { short: 'p', long: '--pretty', support: 'unsupported', reason: 'pretty duration output' },
+      { short: 's', long: '--since', support: 'unsupported', reason: 'boot timestamp output' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: uptime,
+  },
+  {
+    names: ['free'],
+    options: [
+      { short: 'h', long: '--human', support: 'implemented' },
+      { short: 'k', long: '--kibi', support: 'implemented' },
+      { short: 'm', long: '--mebi', support: 'implemented' },
+      { short: 'g', long: '--gibi', support: 'implemented' },
+      { short: 'b', long: '--bytes', support: 'unsupported', reason: 'byte-unit output' },
+      { long: '--si', support: 'unsupported', reason: 'powers-of-1000 units' },
+      { short: 't', long: '--total', support: 'unsupported', reason: 'total row' },
+      { short: 'w', long: '--wide', support: 'unsupported', reason: 'wide buffer/cache columns' },
+      { short: 's', long: '--seconds', takesValue: true, support: 'unsupported', reason: 'repeating output' },
+      { short: 'c', long: '--count', takesValue: true, support: 'unsupported', reason: 'repeating output' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: free,
+  },
+  {
+    names: ['nproc'],
+    options: [
+      { long: '--all', support: 'unsupported', reason: 'installed versus available processor distinction' },
+      { long: '--ignore', takesValue: true, support: 'unsupported', reason: 'processor-count subtraction' },
+    ],
+    effects: ['read'],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: nproc,
+  },
+  {
+    names: ['clear'],
+    options: [
+      { short: 'x', support: 'unsupported', reason: 'scrollback-preserving terminal control' },
+      { short: 'T', takesValue: true, support: 'unsupported', reason: 'alternate terminal type' },
+    ],
+    effects: [],
+    platform: 'windows-ps51',
+    dispatch: 'translated',
+    handler: clear,
+  },
+  {
+    names: ['timeout'],
+    options: [
+      { short: 's', long: '--signal', takesValue: true, support: 'unsupported', reason: 'signal selection' },
+      { short: 'k', long: '--kill-after', takesValue: true, support: 'unsupported', reason: 'two-phase termination' },
+      { long: '--preserve-status', support: 'unsupported', reason: 'child-status preservation after timeout' },
+      { long: '--foreground', support: 'unsupported', reason: 'interactive foreground process groups' },
+      { short: 'v', long: '--verbose', support: 'unsupported', reason: 'signal diagnostics' },
+    ],
+    effects: ['process'],
+    platform: 'windows-ps51',
+    dispatch: 'dynamic',
+    usageExit: 125,
+    leadingOptions: true,
+    handler: timeout,
+  },
+];
 
 export const handlers: Record<string, Handler> = {
   cd,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -255,6 +255,98 @@ export interface CommandSpec {
 
 const specs = new Map<string, CommandSpec>();
 
+/**
+ * C-5's curated agent-daily command set. Keep this explicit: a raw count of
+ * CommandSpecs is not enough to prove that the commands agents use every day
+ * are the ones protected by fail-loud option validation.
+ */
+export const AGENT_DAILY_60 = [
+  'basename',
+  'cat',
+  'cd',
+  'chmod',
+  'chown',
+  'clear',
+  'command',
+  'cp',
+  'cut',
+  'date',
+  'df',
+  'diff',
+  'dirname',
+  'du',
+  'echo',
+  'env',
+  'export',
+  'file',
+  'free',
+  'grep',
+  'groups',
+  'gunzip',
+  'gzip',
+  'head',
+  'hostname',
+  'id',
+  'll',
+  'ln',
+  'ls',
+  'mkdir',
+  'mktemp',
+  'mv',
+  'nproc',
+  'printenv',
+  'printf',
+  'ps',
+  'pwd',
+  'readlink',
+  'realpath',
+  'rm',
+  'rmdir',
+  'sleep',
+  'sort',
+  'stat',
+  'tail',
+  'tee',
+  'timeout',
+  'touch',
+  'tr',
+  'type',
+  'uname',
+  'uniq',
+  'unset',
+  'unzip',
+  'uptime',
+  'wc',
+  'which',
+  'whoami',
+  'zcat',
+  'zip',
+] as const;
+
+/** Commands deliberately kept outside generic CommandSpec option walking. */
+export const COMMAND_SPEC_EXCLUSIONS = [
+  {
+    names: ['find'],
+    reason:
+      'option-looking predicates are parsed by the find expression compiler; generic short-option bundling would misread -name',
+  },
+  {
+    names: ['sed', 'awk'],
+    reason:
+      'program text and option grammar require command-specific parsing; any remaining unchecked options must be fixed there rather than treated as generic flags',
+  },
+  {
+    names: ['egrep'],
+    reason:
+      'semantic alias injects grep -E through its own handler; it must not be wrapped as an independent generic option parser',
+  },
+  {
+    names: ['tar'],
+    reason:
+      'argv is passed to Windows bsdtar; rejecting unlisted GNU/bsdtar options before native dispatch would reduce compatibility',
+  },
+] as const;
+
 /** Register a spec'd command. Unknown/unsupported options become GNU-style usage errors. */
 export function registerSpec(spec: CommandSpec): void {
   for (const name of spec.names) {
@@ -290,10 +382,32 @@ export function registeredSpecs(): CommandSpec[] {
 
 /** Markdown dump of every CommandSpec — source for docs/command-specs.md. */
 export function specsMarkdown(): string {
+  const dailySpecd = AGENT_DAILY_60.filter((name) => lookupSpec(name));
+  const dailyMissing = AGENT_DAILY_60.filter((name) => !lookupSpec(name));
   const lines = [
     '# Command specs',
     '',
     'Generated from `CommandSpec`. Unlisted commands still use unchecked `parseWords` (unknown flags ignored). Spec\'d commands fail loud on unknown or unsupported options.',
+    '',
+    '## Agent-daily 60 (C-5)',
+    '',
+    'Curated command names: ' + AGENT_DAILY_60.map((name) => '`' + name + '`').join(', '),
+    '',
+    'Coverage: **' + dailySpecd.length + ' / ' + AGENT_DAILY_60.length + ' spec\'d**.',
+    '',
+    ...(dailyMissing.length
+      ? ['Missing specs: ' + dailyMissing.map((name) => '`' + name + '`').join(', '), '']
+      : []),
+    '## Intentional CommandSpec exclusions',
+    '',
+    'These commands stay outside the generic option walker by design. This is a structural rationale, not a claim that every command-specific option path is already strict.',
+    '',
+    '| Command | Rationale |',
+    '| --- | --- |',
+    ...COMMAND_SPEC_EXCLUSIONS.map(
+      (entry) =>
+        '| ' + entry.names.map((name) => '`' + name + '`').join(', ') + ' | ' + entry.reason + ' |',
+    ),
     '',
   ];
   for (const spec of registeredSpecs()) {
@@ -412,7 +526,12 @@ export function specOptionError(spec: CommandSpec, args: Word[], cmdName: string
       i++;
       continue;
     }
-    if (t.startsWith('-') && t.length > 1 && !/^-?\d/.test(t.slice(1, 2))) {
+    const firstShort = t.slice(1, 2);
+    if (
+      t.startsWith('-') &&
+      t.length > 1 &&
+      (!/^\d$/.test(firstShort) || shorts.has(firstShort))
+    ) {
       const body = t.slice(1);
       for (let c = 0; c < body.length; c++) {
         const ch = body[c];

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -5,7 +5,7 @@
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
 import { getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync, appendFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync, appendFileSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parseCommand } from '../src/parser.js';
@@ -1122,6 +1122,103 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('command echo hi')).stdout.trim()).toBe('hi');
   });
 
+  it('daily-60 sysinfo implemented options preserve their documented semantics', async () => {
+    const logicalPwd = (await run('pwd -L')).stdout.trim();
+    expect(realpathSync.native(logicalPwd).toLowerCase()).toBe(realpathSync.native(dir).toLowerCase());
+    const physical = await run('pwd -P');
+    expect(physical.exitCode).toBe(2);
+    expect(physical.stderr).toContain('physical symlink/junction resolution');
+    expect((await run('ps -f | head -1')).stdout).toMatch(/USER\s+PID/);
+    expect((await run('command -V echo')).stdout.trim()).toBe('echo is /usr/bin/echo');
+    expect((await run('uname --machine')).stdout.trim()).toMatch(/x86_64|ARM64/);
+    expect((await run('free --mebi')).stdout).toContain('Mem:');
+  });
+
+  it('date -d accepts spaced, attached, long, UTC, and bundled @epoch forms', async () => {
+    for (const cmd of [
+      'date -d @0 +%s',
+      'date -d@0 +%s',
+      'date --date @0 +%s',
+      'date --date=@0 +%s',
+      'date -u -d@0 +%s',
+      'date --utc --date=@0 +%s',
+      'date -ud @0 +%s',
+      'date -ud@0 +%s',
+    ]) {
+      const r = await run(cmd);
+      expect(r.exitCode, cmd + ': ' + r.stderr).toBe(0);
+      expect(r.stdout.trim(), cmd).toBe('0');
+    }
+  });
+
+  it('unset -f is fail-loud and cannot delete the PATH environment variable', async () => {
+    const before = (await run('printenv PATH')).stdout;
+    expect(before).not.toBe('');
+    const blocked = await run('unset -f PATH');
+    expect(blocked.exitCode).toBe(2);
+    expect(blocked.stderr).toContain("option '-f' is not supported by fauxnix");
+    expect((await run('printenv PATH')).stdout).toBe(before);
+  });
+
+  it('env value forms work and option scanning stops before assignment-command argv', async () => {
+    for (const form of ['-u', '-uFX_C5', '-u=FX_C5', '--unset=FX_C5']) {
+      const command = form === '-u' ? 'env -u FX_C5 printenv FX_C5' : 'env ' + form + ' printenv FX_C5';
+      const r = await run('export FX_C5=value; ' + command);
+      expect(r.exitCode, form + ': ' + r.stderr).toBe(1);
+      expect(r.stdout).toBe('');
+      expect((await run('printenv FX_C5')).stdout.trim()).toBe('value');
+    }
+    const childOption = await run('env FX_C5=temp -u PATH');
+    expect(childOption.exitCode).toBe(127);
+    expect(childOption.stderr).toContain('bash: -u: command not found');
+    expect((await run('printenv PATH')).stdout).not.toBe('');
+
+    await run('export FX_C5_NAME=PATH');
+    for (const dynamic of ['env -u "$FX_C5_NAME" printenv PATH', 'env -u$FX_C5_NAME printenv PATH']) {
+      const r = await run(dynamic);
+      expect(r.exitCode, dynamic).toBe(125);
+      expect(r.stderr, dynamic).toContain('requires a literal variable name');
+      expect((await run('printenv PATH')).stdout).not.toBe('');
+    }
+    await run('unset FX_C5_NAME');
+    await run('unset FX_C5');
+  });
+
+  it('daily-60 unknown, unsupported, and operand forms fail before silent fallback', async () => {
+    const pwdUnknown = await run('pwd -Q');
+    expect(pwdUnknown.exitCode).toBe(2);
+    expect(pwdUnknown.stderr).toContain("invalid option -- 'Q'");
+
+    const envUnknown = await run('env -Q FOO=bar printenv FOO');
+    expect(envUnknown.exitCode).toBe(125);
+    expect(envUnknown.stdout).toBe('');
+    expect(envUnknown.stderr).toContain("invalid option -- 'Q'");
+
+    expect((await run('printenv -0 PATH')).exitCode).toBe(2);
+    expect((await run('timeout --preserve-status 1 true')).exitCode).toBe(125);
+    expect((await run('id -n')).exitCode).toBe(1);
+    expect((await run('id -ug')).exitCode).toBe(1);
+    expect((await run('id other-user')).exitCode).toBe(1);
+    expect((await run('groups other-user')).exitCode).toBe(1);
+    expect((await run('hostname replacement')).exitCode).toBe(1);
+    expect((await run('free -gm')).exitCode).toBe(1);
+    expect((await run('free -hm')).stdout).toMatch(/Gi|Mi|Ki|B/);
+  });
+
+  it('daily lookup commands reject directories and lone-dash edge cases', async () => {
+    for (const cmd of ['which drivers', 'type drivers', 'command -v drivers']) {
+      const r = await run(cmd);
+      expect(r.exitCode, cmd + ': ' + r.stdout).toBe(1);
+      expect(r.stdout, cmd).toBe('');
+    }
+    expect((await run('env - printenv PATH')).exitCode).toBe(125);
+    expect((await run('export -')).exitCode).toBe(1);
+    expect((await run('printenv -')).exitCode).toBe(1);
+    expect((await run('which -')).exitCode).toBe(1);
+    expect((await run('type -')).exitCode).toBe(1);
+    expect((await run('command -')).exitCode).toBe(127);
+  });
+
   it('source reads NAME=VALUE files into the session', async () => {
     writeFileSync(join(dir, 'dotenv.env'), 'FOO=bar\n# c\nexport BAZ=qux\nQUOT=\"hi\"\n', 'utf8');
     expect((await run('source dotenv.env; echo $FOO $BAZ $QUOT')).stdout.trim()).toBe('bar qux hi');
@@ -1159,8 +1256,8 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
 
   it('env -i fails loudly instead of keeping inherited secrets', async () => {
     const r = await run('env -i echo hi');
-    expect(r.exitCode).toBe(2);
-    expect(r.stderr).toMatch(/env -i\/--ignore-environment is not supported/);
+    expect(r.exitCode).toBe(125);
+    expect(r.stderr).toMatch(/option '-i' is not supported.*inherited secrets/);
     expect(r.stdout.trim()).toBe('');
   });
 

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -18,7 +18,17 @@ import {
   wrapScript,
   hostBootstrapScript,
 } from '../src/translator.js';
-import { listCommandsJson, lookup, lookupSpec, parseWords, psStr } from '../src/registry.js';
+import {
+  AGENT_DAILY_60,
+  COMMAND_SPEC_EXCLUSIONS,
+  listCommandsJson,
+  lookup,
+  lookupSpec,
+  parseWords,
+  psStr,
+  registeredNames,
+  specsMarkdown,
+} from '../src/registry.js';
 import { decodeOutput, encodeCommand, normalizeHostNewlines } from '../src/encoding.js';
 import {
   normalizeStderr,
@@ -33,7 +43,6 @@ import {
   positionalCountFromEnv,
 } from '../src/mcp.js';
 import '../src/commands/install-all.js';
-import { specsMarkdown } from '../src/registry.js';
 
 /* ---------------------------- parser ---------------------------- */
 
@@ -421,9 +430,9 @@ describe('parser', () => {
 
   it('env -i is a loud usage error, not a silent ignore', () => {
     const script = translateCommandList(parse('env -i echo hi'))[0].script;
-    expect(script).toMatch(/env -i\/--ignore-environment is not supported/);
+    expect(script).toMatch(/option ''-i'' is not supported by fauxnix/);
     expect(script).toMatch(/env -u NAME|unset first instead/);
-    expect(script).toContain('$script:fx_exit = 2');
+    expect(script).toContain('$script:fx_exit = 125');
     expect(script).not.toContain("fx-write");
   });
 
@@ -1375,6 +1384,165 @@ describe('command-specs.md (#143)', () => {
       '\n',
     );
     expect(onDisk).toBe(specsMarkdown());
+  });
+});
+
+describe('CommandSpec agent-daily 60 (C-5 / #143)', () => {
+  const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+  const sysinfoDaily = [
+    'cd',
+    'pwd',
+    'export',
+    'unset',
+    'env',
+    'printenv',
+    'ps',
+    'sleep',
+    'which',
+    'type',
+    'command',
+    'whoami',
+    'id',
+    'groups',
+    'date',
+    'uname',
+    'hostname',
+    'uptime',
+    'free',
+    'nproc',
+    'clear',
+    'timeout',
+  ];
+
+  it('defines 60 unique registered daily names and specs every one', () => {
+    expect(AGENT_DAILY_60).toHaveLength(60);
+    expect(new Set(AGENT_DAILY_60).size).toBe(60);
+    const registered = new Set(registeredNames());
+    for (const name of AGENT_DAILY_60) {
+      expect(registered.has(name), name).toBe(true);
+      expect(lookupSpec(name), name).toBeTruthy();
+    }
+    expect(listCommandsJson().filter((row) => row.spec !== null).length).toBeGreaterThanOrEqual(60);
+  });
+
+  it('keeps parser/native exclusions explicit and outside generic CommandSpec', () => {
+    expect(COMMAND_SPEC_EXCLUSIONS.flatMap((entry) => [...entry.names])).toEqual([
+      'find',
+      'sed',
+      'awk',
+      'egrep',
+      'tar',
+    ]);
+    for (const entry of COMMAND_SPEC_EXCLUSIONS) {
+      expect(entry.reason.length).toBeGreaterThan(20);
+      for (const name of entry.names) expect(lookupSpec(name), name).toBeUndefined();
+    }
+    expect(specsMarkdown()).toContain('Coverage: **60 / 60 spec\'d**.');
+    expect(specsMarkdown()).toContain('structural rationale, not a claim');
+  });
+
+  it('specs the 22-command sysinfo slice and rejects unknown options', () => {
+    for (const name of sysinfoDaily) {
+      expect(lookupSpec(name), name).toBeTruthy();
+      const body = bodyOf(name + ' -Q');
+      expect(body, name).toMatch(/invalid option|unrecognized option/);
+      expect(body, name).toContain("Try ''" + name + " --help'' for more information.");
+    }
+  });
+
+  it('accepts implemented aliases and fixes their value/format semantics', () => {
+    expect(bodyOf('cd -L .')).toContain('Set-Location');
+    expect(bodyOf('pwd -L')).toContain('Get-Location');
+    expect(bodyOf('cd -P .')).toContain('physical symlink/junction resolution');
+    expect(bodyOf('pwd -P')).toContain('physical symlink/junction resolution');
+    expect(bodyOf('unset -v FX_C5')).toContain('Remove-Item');
+    for (const cmd of [
+      'env -u FX_C5 printenv FX_C5',
+      'env -uFX_C5 printenv FX_C5',
+      'env -u=FX_C5 printenv FX_C5',
+      'env --unset=FX_C5 printenv FX_C5',
+    ]) {
+      expect(bodyOf(cmd), cmd).toContain("'FX_C5'");
+      expect(bodyOf(cmd), cmd).not.toContain('invalid option');
+    }
+    expect(bodyOf('ps -f')).toContain("'USER','PID','%CPU'");
+    expect(bodyOf('ps -ef')).toContain("'USER','PID','%CPU'");
+    expect(bodyOf('ps aux')).toContain("'USER','PID','%CPU'");
+    expect(bodyOf('command -V node')).toContain("$fx_n + ' is '");
+    expect(bodyOf('command -v node')).not.toContain("$fx_n + ' is '");
+    expect(bodyOf('id -un')).toContain('$env:USERNAME');
+    for (const cmd of [
+      'date -d @0 +%s',
+      'date -d@0 +%s',
+      'date --date=@0 +%s',
+      'date -ud @0 +%s',
+      'date -ud@0 +%s',
+    ]) {
+      expect(bodyOf(cmd), cmd).toContain('$fx_epoch.AddSeconds($fx_n)');
+    }
+    expect(bodyOf('uname --machine')).toContain('PROCESSOR_ARCHITECTURE');
+    expect(bodyOf('free --mebi')).toContain('/ 1KB');
+  });
+
+  it('fails missing values and high-frequency unsupported options before handlers run', () => {
+    const envMissing = bodyOf('env -u');
+    expect(envMissing).toContain("option requires an argument -- ''u''");
+    expect(envMissing).toContain('$script:fx_exit = 125');
+    const dateMissing = bodyOf('date --date');
+    expect(dateMissing).toContain("option ''--date'' requires an argument");
+    expect(dateMissing).toContain('$script:fx_exit = 1');
+
+    const unsetFunction = bodyOf('unset -f PATH');
+    expect(unsetFunction).toContain("option ''-f'' is not supported");
+    expect(unsetFunction).not.toContain('Remove-Item');
+    expect(bodyOf('export -n PATH')).toContain("option ''-n'' is not supported");
+    expect(bodyOf('printenv -0 PATH')).toContain('NUL-terminated output');
+    expect(bodyOf('ps -o pid')).toContain('custom output columns');
+    expect(bodyOf('which -a node')).toContain('all matching PATH entries');
+    expect(bodyOf('type -t node')).toContain('type-name-only output');
+    expect(bodyOf('id -G')).toContain('supplementary group ID mapping');
+    expect(bodyOf('uptime -p')).toContain('pretty duration output');
+    expect(bodyOf('nproc --ignore=1')).toContain('processor-count subtraction');
+    expect(bodyOf('timeout --preserve-status 1 true')).toContain(
+      'child-status preservation after timeout',
+    );
+    expect(bodyOf('which')).toContain('missing command name');
+    expect(bodyOf('env -')).toContain('ignore environment');
+    expect(bodyOf('env -')).toContain('$script:fx_exit = 125');
+    expect(bodyOf('env -u "$FX_NAME" printenv PATH')).toContain('requires a literal variable name');
+    expect(bodyOf('env -u$FX_NAME printenv PATH')).toContain('requires a literal variable name');
+  });
+
+  it('stops env/command/timeout option scanning before child argv', () => {
+    expect(bodyOf('env node -v')).not.toContain('invalid option');
+    expect(bodyOf('env FX_C5=1 node -v')).not.toContain('invalid option');
+    expect(bodyOf('env FX_C5=1 -u PATH')).toContain("fx-native '-u'");
+    expect(bodyOf('command node -v')).not.toContain('invalid option');
+    expect(bodyOf('command -')).toContain("fx-native '-'");
+    expect(bodyOf('timeout 1 echo -n hi')).not.toContain('invalid option');
+  });
+
+  it('rejects ignored operands and invalid id/free option combinations', () => {
+    for (const cmd of [
+      'pwd extra',
+      'whoami extra',
+      'id other-user',
+      'groups other-user',
+      'date extra',
+      'uname extra',
+      'hostname replacement',
+      'uptime extra',
+      'free extra',
+      'nproc extra',
+      'clear extra',
+    ]) {
+      expect(bodyOf(cmd), cmd).toMatch(/extra operand|user operands are not supported|setting or selecting a host/);
+    }
+    expect(bodyOf('id -n')).toContain("option ''-n'' requires -u or -g");
+    expect(bodyOf('id -ug')).toContain('cannot print multiple ID selectors together');
+    expect(bodyOf('free -gm')).toContain('multiple unit options are not supported together');
+    expect(bodyOf('free -mh')).toContain('function fx-fh');
+    expect(bodyOf('free -hm')).toContain('function fx-fh');
   });
 });
 


### PR DESCRIPTION
## Summary

Completes the roadmap C-5 target as an explicit curated set, not a raw CommandSpec count.

- define the 60 agent-daily commands and require every one to be registered and spec'd
- add the remaining 22 sysinfo-family specs
- generate the 60/60 coverage and intentional parser/native exclusions into docs/command-specs.md
- keep find, sed, awk, egrep, and tar outside the generic option walker for documented structural reasons

## Semantic fixes required by the new specs

Adding metadata exposed existing silent behavior that could not honestly be marked implemented. This slice also fixes:

- ps -f / ps -ef output
- command -V distinction from command -v
- date -d/--date @SECONDS in spaced, attached, bundled, and UTC forms
- env -u option scanning and literal-name safety
- unset -f PATH failing before mutation
- ignored user/extra operands and conflicting free/id option combinations
- PATH lookup treating directories as commands
- pwd/cd -P no longer pretending Windows junction resolution is implemented

Non-literal env -u names fail loudly instead of risking an inherited credential remaining visible.

## Verification

- npm ci: 0 vulnerabilities
- npm run typecheck
- npm run build
- npm test: 331 passed, 1 opt-in oracle skipped
- npm run test:package
- Git Bash oracle: 125/126 identical (99.2%)
- generated docs normalized byte-for-byte with fauxnix list --markdown
- registered commands: 109; spec'd daily set: 60/60
- git diff --check

Tracks #143 and roadmap C-5 in #118.