### PR TITLE
ci: add a native Windows ARM64 lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,37 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    runs-on: windows-latest
+    name: test (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: windows-x64
+            runner: windows-2025
+            node_arch: x64
+          - name: windows-arm64
+            runner: windows-11-arm
+            node_arch: arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          architecture: ${{ matrix.node_arch }}
+      - name: Verify native Node architecture
+        shell: pwsh
+        run: |
+          $actual = node -p process.arch
+          if ($actual -ne '${{ matrix.node_arch }}') {
+            throw "expected Node architecture ${{ matrix.node_arch }}, got $actual"
+          }
       - run: npm ci
       - run: npm run typecheck
       - run: npm run build

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1116,6 +1116,11 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('uname -r')).stdout.trim()).toBe('6.8.0-fauxnix');
   });
 
+  it('uname reports the native host architecture', async () => {
+    const expected = process.arch === 'arm64' ? 'ARM64' : 'x86_64';
+    expect((await run('uname -m')).stdout.trim()).toBe(expected);
+  });
+
   it('command -v finds builtins and missing names', async () => {
     expect((await run('command -v echo')).stdout.trim()).toBe('/usr/bin/echo');
     expect((await run('command -v definitely_not_a_cmd_xyz')).exitCode).toBe(1);


### PR DESCRIPTION
## Summary

Adds the native Windows ARM64 lane required by roadmap U-6.

- matrix windows-2025/x64 and windows-11-arm/arm64
- request the matching Node architecture and assert process.arch before install
- run the existing full typecheck, build, test, and package-smoke sequence on both lanes
- add an integration assertion that uname -m reflects the actual Node/host architecture
- pin workflow permissions to contents: read and use fail-fast: false so one architecture cannot hide the other result

## Local verification

- npm ci: 0 vulnerabilities
- npm run typecheck
- npm run build
- npm test: 319 passed, 1 opt-in oracle skipped
- npm run test:package
- Git Bash oracle: 125/126 identical (99.2%)
- workflow YAML parse and actionlint 1.7.12
- git diff --check

## DoD status

The configuration is implemented, but U-6 is not claimed complete until this PR's windows-11-arm lane finishes the full suite successfully. That remote result is the definition-of-done evidence.

Roadmap: #118, U-6.