### PR TITLE
fix: keep resident host frames UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Exit codes follow bash conventions: 0 ok, 1 fail, 2 usage/serious, 127 command n
 ```
 bash command ──parser──▶ AST ──translator──▶ PowerShell script ──executor──▶ powershell.exe
                                                                               │
-agent ◀── GNU-style output, bash-style errors ◀── decoder (UTF-8 → GBK fallback) ◀┘
+agent ◀── GNU-style output, bash-style errors ◀── UTF-8 framed host protocol ◀┘
 ```
 
 - **Deterministic translation, zero LLM calls** at runtime.
@@ -218,9 +218,10 @@ agent ◀── GNU-style output, bash-style errors ◀── decoder (UTF-8 →
   "Fauxnix contract": string-per-line stdout, `[Console]::Error.WriteLine` for bash-style
   stderr, `$script:fx_exit` for exit codes, `$input` for stdin.
 - The executor wraps every script with UTF-8 enforcement (`[Console]::OutputEncoding`,
-  `$OutputEncoding`, `chcp 65001`), decodes output as strict-UTF-8 with a GBK(936) fallback for
-  legacy native tools, strips CLIXML serialization and PowerShell noise from stderr, and rewrites
-  common PowerShell errors (including zh-CN locale messages) into bash phrasing.
+  `$OutputEncoding`, `chcp 65001`), decodes native output at the process boundary (UTF-8 by
+  default or GBK(936) in `ansi` mode), keeps host frames UTF-8, strips CLIXML serialization and
+  PowerShell noise from stderr, and rewrites common PowerShell errors (including zh-CN locale
+  messages) into bash phrasing.
 - Scripts run via `-EncodedCommand` (UTF-16LE) and transparently fall back to a temp `.ps1` file
   when the 32 KB command-line limit would be exceeded.
 

--- a/docs/rfc-persistent-powershell-host.md
+++ b/docs/rfc-persistent-powershell-host.md
@@ -47,7 +47,7 @@ Host → Node:
 {"id":"<uuid>","stdoutB64":"<bytes>","stderrB64":"<bytes>","exitCode":0}
 ```
 
-Captured command streams are the UTF-8 bytes of `[Console]::Out` / `[Console]::Error` after redirecting those writers for the frame. Pipeline objects (`Write-Output` / `fx-write` line mode) are `WriteLine`d to the same `Console.Out` as they arrive so `echo -n` / `printf` exact writes still interleave correctly. Node runs the existing `decodeOutput` + `normalizeHostNewlines` path on those bytes.
+Captured command streams are the UTF-8 bytes of `[Console]::Out` / `[Console]::Error` after redirecting those writers for the frame. Pipeline objects (`Write-Output` / `fx-write` line mode) are `WriteLine`d to the same `Console.Out` as they arrive so `echo -n` / `printf` exact writes still interleave correctly. Node always decodes these framed bytes as UTF-8. Bytes written directly to the host's OS stderr pipe stay separate and use the selected native-tool decoder before both strings are normalized and joined.
 
 The per-frame script is `wrapScript(body, { mode: 'host' })`: same cwd/env persist files and try/catch as spawn mode, **no `exit`**, **no helper re-emit** (the bootstrap already defined every `fx-*`).
 

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -545,8 +545,14 @@ async function runPlans(
     // GNU line discipline: the PS host terminates Write-Output lines with
     // CRLF. Exact writers (fx-write / printf / echo -n) must keep embedded
     // CR so `printf 'a\r\nb' > out` stays 4 bytes.
-    const segOut = normalizeHostNewlines(decodeOutput(inv.stdout, decodePref));
-    let segErr = normalizeHostNewlines(normalizeStderr(decodeOutput(inv.stderr, decodePref)));
+    // Captured protocol frames are always UTF-8. FAUXNIX_NATIVE_ENCODING is
+    // consumed at the native-process boundary inside fx-native; applying it
+    // again here double-decodes every translated/non-ASCII frame. Only bytes
+    // written directly to the host's OS stderr pipe retain a native encoding.
+    const segOut = normalizeHostNewlines(decodeOutput(inv.stdout, 'utf8'));
+    const framedErr = decodeOutput(inv.stderr, 'utf8');
+    const nativeErr = decodeOutput(inv.nativeStderr ?? Buffer.alloc(0), decodePref);
+    let segErr = normalizeHostNewlines(normalizeStderr(framedErr + nativeErr));
 
     if (inv.timedOut) {
       segErr += timeoutMessage;

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -15,7 +15,10 @@ export const DEFAULT_STDERR_LIMIT = 1_048_576;
 
 export interface HostInvokeResult {
   stdout: Buffer;
+  /** UTF-8 stderr captured inside the JSON-framed host protocol. */
   stderr: Buffer;
+  /** Bytes written directly to the PowerShell process stderr OS pipe. */
+  nativeStderr?: Buffer;
   exitCode: number;
   timedOut: boolean;
   cancelled: boolean;
@@ -241,7 +244,8 @@ export class PowerShellHost {
       const native = this.drainNativeStderr();
       return {
         stdout: msg.stdout,
-        stderr: native.length ? Buffer.concat([msg.stderr, native]) : msg.stderr,
+        stderr: msg.stderr,
+        nativeStderr: native,
         exitCode: msg.exitCode,
         timedOut: false,
         cancelled: false,
@@ -502,7 +506,8 @@ export class PowerShellHost {
     const n = Number(end.exitCode);
     return {
       stdout: Buffer.from(Buffer.concat(out)),
-      stderr: native.length ? Buffer.from(Buffer.concat([capturedErr, native])) : capturedErr,
+      stderr: capturedErr,
+      nativeStderr: native,
       exitCode: Number.isFinite(n) ? n : 0,
       timedOut: end.timedOut === true,
       cancelled: end.cancelled === true,

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1363,6 +1363,26 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(g.exitCode).toBe(0);
   });
 
+  it('ansi native preference does not re-decode UTF-8 host frames', async () => {
+    const previous = process.env.FAUXNIX_NATIVE_ENCODING;
+    process.env.FAUXNIX_NATIVE_ENCODING = 'ansi';
+    const ansiSession = new FauxnixSession();
+    try {
+      const plans = translateCommandList(
+        parseCommand("printf '中文\\n'; echo '错误' 1>&2; printf '路径\\n' > ansi-zh.txt"),
+      );
+      const result = await ansiSession.run(plans, { cwd: dir });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('中文\n');
+      expect(result.stderr).toBe('错误\n');
+      expect(readFileSync(join(dir, 'ansi-zh.txt'), 'utf8')).toBe('路径\n');
+    } finally {
+      await ansiSession.dispose();
+      if (previous === undefined) delete process.env.FAUXNIX_NATIVE_ENCODING;
+      else process.env.FAUXNIX_NATIVE_ENCODING = previous;
+    }
+  });
+
   it('yes | head terminates (no hang)', async () => {
     const r = await run('yes | head -3');
     expect(r.stdout.split(/\r?\n/).filter((l) => l === 'y').length).toBe(3);


### PR DESCRIPTION
## Problem

`FAUXNIX_NATIVE_ENCODING=ansi` currently decodes every resident-host response as GBK even though captured protocol frames are already UTF-8. Translated output is therefore decoded twice:

- expected: `printf '中文\n'` -> `中文`
- current ansi mode: -> `涓枃`

The same corruption reaches stderr and redirected files. This reproduces on both Windows PowerShell 5.1 and PowerShell 7.

## Fix

- keep framed stdout/stderr and raw OS stderr as separate buffers
- always decode framed protocol data as UTF-8
- apply the selected native decoder only to bytes written directly to the host OS stderr pipe
- document the byte boundary in the host RFC and README

`FAUXNIX_NATIVE_ENCODING=ansi` still controls native-process decoding inside `fx-native`; it no longer reinterprets the UTF-8 transport afterward.

## Verification

- regression covers Chinese stdout, stderr, and a redirected file in ansi mode
- npm ci
- npm run typecheck
- npm test: 319 passed, 1 opt-in oracle skipped
- npm run test:package
- Git Bash oracle: 125/126 identical (99.2%)
- tested on the real resident PowerShell host
- git diff --check