### PR TITLE
fix: reject remaining non-last-stage fd redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,11 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
   an unbounded `yes | head` would hang.
 - `tail -f`, `eval`, `alias`, heredocs,
   `env -i`/`--ignore-environment`,
-  background `&`, and stdout redirects (`>` `>>` `&>` `&>>`) on a non-last
-  pipeline stage (`echo hi >f | cat`) are rejected with actionable error
-  messages instead of misbehaving.
+  background `&`, and output/fd redirects (`>` `>>` `2>` `2>>` `&>` `&>>`
+  `2>&1` `1>&2`) on a non-last pipeline stage (`echo hi >f | cat`) are
+  rejected with operation-specific, actionable error messages instead of
+  misbehaving. Per-stage `<` remains supported; fully routed per-stage output
+  fds are still tracked by #157.
   (`if/then/elif/else/fi`, `for x in ...`, `while`/`until`, `case ... esac` (`;;` only; `;&`/`;;&` fail loud),
   backtick substitution, `command -v`, pipeline `read`,
   dotenv-style `source`, word-level `$((...))` arithmetic expansion, `A=(x y z)` arrays, and

--- a/docs/rfc-redirect-fd-ownership.md
+++ b/docs/rfc-redirect-fd-ownership.md
@@ -25,7 +25,10 @@ the caller's stdout.
 #147 applied last-stage output and per-stage `<`. That made a previously
 accidental identity-pipe look wrong (`echo hi >f | cat` truncated `f` empty
 and printed `hi`). C-6 first slice (#157): **fail loud** at translate time
-for non-last `>` `>>` `&>` `&>>`. Full in-stage writes remain the follow-up.
+for non-last `>` `>>` `&>` `&>>` (#175). The safety-completion slice extends
+that rejection to `2>` `2>>` `2>&1` `1>&2`: those operators are just as
+silently wrong when Node applies only the last stage's fds. Full routed
+in-stage stdout/stderr remains the #157 follow-up; this is not C-6 completion.
 
 ## Contract
 
@@ -41,11 +44,14 @@ for non-last `>` `>>` `&>` `&>>`. Full in-stage writes remain the follow-up.
 - Successive stdout redirects last-win: `>/dev/null >file` writes the command
   output to `file`; `>file >/dev/null` truncates `file` and discards output.
   `2>/dev/null` must not undo a prior `>/dev/null`.
-- Non-last-stage **stdout** redirects (`echo hi >f \| cat`) **fail at
-  translate time** with an actionable alternative (`cmd >f; cat f` or wait
-  for per-stage fds). In-stage writes (the stage writes the file inside
-  PowerShell instead of the pipe) stay the #157 follow-up. `2>` on a
-  non-last stage is still silently wrong and is not rejected in this slice.
+- Every output-affecting redirect on a non-last stage — `>` `>>` `2>` `2>>`
+  `&>` `&>>` `2>&1` `1>&2` — **fails at translate time**. The error gives an
+  operation-specific workaround: spool stdout/stderr and feed the next stage,
+  spool merged output for `2>&1`, or run a `1>&2` stage separately with empty
+  input for the next command. `<` remains supported per-stage.
+- These rejections are fail-loud safety while the executor has only
+  last-stage output ownership. They do not implement routed stage fds and do
+  not close #157/C-6.
 
 ## Non-goals
 
@@ -61,4 +67,7 @@ for non-last `>` `>>` `&>` `&>>`. Full in-stage writes remain the follow-up.
 - `printf x | cat < fruits.txt | head -1` → `apple`.
 - Existing `> >> 2>/dev/null 2>&1` and failed-`>` order tests stay green.
 - `echo hi >f | cat` → translate-time `FauxnixParseError` (C-6 first slice).
+- `cat missing 2>e | cat`, `2>>`, `2>&1`, and `1>&2` on any non-last stage →
+  operation-specific translate-time `FauxnixParseError` (safety completion).
 - `echo hi >f` and last-stage `echo hi | cat >f` still write.
+- Last-stage `2>` `2>>` `2>&1` `1>&2` still execute and match Git Bash.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -34,7 +34,7 @@ interface Token {
 }
 
 const OPERATORS = [
-  '&&', '||', '>>', '<<', '2>&1', '1>&2', '2>', '&>>', '&>', '>', '<', '|', ';;', ';', '&',
+  '&&', '||', '2>>', '>>', '<<', '2>&1', '1>&2', '2>', '&>>', '&>', '>', '<', '|', ';;', ';', '&',
 ] as const;
 
 const BACKGROUND_MSG =
@@ -109,6 +109,11 @@ export function tokenize(input: string): Token[] {
     // try operators (longest first — list above is ordered)
     let matched: string | undefined;
     for (const op of OPERATORS) {
+      // A digit-leading fd operator is only a direct token at a word boundary.
+      // Otherwise consume the digit normally: `file2>>out` is word `file2`
+      // plus stdout `>>out`, while `12>>out` stays one unsupported fd token
+      // and fails loud instead of being stolen by `2>>`.
+      if (cur.length > 0 && /^\d/.test(op)) continue;
       if (input.startsWith(op, i)) {
         matched = op;
         break;
@@ -235,8 +240,10 @@ export function tokenize(input: string): Token[] {
       continue;
     }
 
-    // track leading digits (potential fd number for redirects)
-    if (/[0-9]/.test(ch) && cur.length === 0 && fdDigits.length < 2) {
+    // Track an all-digit word as a potential fd number. Keep consuming every
+    // leading digit so unsupported multi-digit fds stay intact and fail loud
+    // instead of becoming argv plus a different redirect.
+    if (/[0-9]/.test(ch) && (cur.length === 0 || fdDigits.length === cur.length)) {
       beginWordPart();
       fdDigits += ch;
       cur.push({ kind: 'Text', text: ch });

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1035,12 +1035,29 @@ function isStdoutFileRedirect(op: Redirect['op']): boolean {
 
 const NONLAST_STDOUT_REDIRECT_MSG =
   'fauxnix: stdout redirect on a non-last pipeline stage is not supported yet; write the file in a previous list segment (cmd >f; cat f) or wait for per-stage fds (#157)';
+const NONLAST_STDERR_FILE_REDIRECT_MSG =
+  'fauxnix: stderr redirect ({op}) on a non-last pipeline stage is not supported yet; spool the stage first (cmd >out {op}err; cat out | next) or wait for per-stage fds (#157)';
 
-function rejectNonLastStdoutRedirects(commands: ShellCommand[]): void {
+function nonLastFdRedirectMessage(op: Redirect['op']): string | null {
+  if (isStdoutFileRedirect(op)) return NONLAST_STDOUT_REDIRECT_MSG;
+  if (op === '2>' || op === '2>>') {
+    return NONLAST_STDERR_FILE_REDIRECT_MSG.replaceAll('{op}', op);
+  }
+  if (op === '2>&1') {
+    return 'fauxnix: 2>&1 on a non-last pipeline stage is not supported yet; spool the merged output first (cmd >out 2>&1; cat out | next) or wait for per-stage fds (#157)';
+  }
+  if (op === '1>&2') {
+    return 'fauxnix: 1>&2 on a non-last pipeline stage is not supported yet; run the stage separately (cmd 1>&2; next </dev/null) or wait for per-stage fds (#157)';
+  }
+  return null;
+}
+
+function rejectNonLastFdRedirects(commands: ShellCommand[]): void {
   if (commands.length < 2) return;
   for (let i = 0; i < commands.length - 1; i++) {
-    if (commands[i].redirects.some((r) => isStdoutFileRedirect(r.op))) {
-      throw new FauxnixParseError(NONLAST_STDOUT_REDIRECT_MSG);
+    for (const redirect of commands[i].redirects) {
+      const message = nonLastFdRedirectMessage(redirect.op);
+      if (message) throw new FauxnixParseError(message);
     }
   }
 }
@@ -1048,9 +1065,10 @@ function rejectNonLastStdoutRedirects(commands: ShellCommand[]): void {
 export function translatePipelineBody(p: {
   commands: Array<SimpleCommand | IfCommand | ForCommand | WhileCommand | CaseCommand>;
 }): PipelineParts {
-  // Last-stage `>` is Node apply; a non-last `>` would truncate the file and
-  // still feed the pipe. Fail loud until in-stage writes (#157).
-  rejectNonLastStdoutRedirects(p.commands);
+  // Last-stage output fds are applied by Node. On an earlier stage they would
+  // be prepared but not owned by that stage, so output would still reach the
+  // wrong destination. Fail loud until routed in-stage fds land (#157).
+  rejectNonLastFdRedirects(p.commands);
   // Every pipeline stage needs its own status slot. Handlers deliberately use
   // `$script:fx_exit` because their helper functions run in child scopes; in a
   // pipeline that shared flag lets an earlier failure leak into a successful

--- a/test/differential.test.ts
+++ b/test/differential.test.ts
@@ -33,6 +33,12 @@ describe('differential corpus growth (C-7 / #118)', () => {
       'printf-grep-split',
       'head-lines-neg',
       'grep-e-or',
+      'middle-stdin-redirect',
+      'last-stage-stderr-file',
+      'last-stage-stderr-append',
+      'last-stage-stderr-to-stdout',
+      'attached-digit-stdout-append',
+      'last-stage-stdout-to-stderr',
     ]));
     expect(corpus.files['three.txt']?.split('\n').filter(Boolean)).toHaveLength(3);
     if (skipOracle) console.log(`differential oracle skipped: ${skipWhy}`);

--- a/test/differential/corpus.json
+++ b/test/differential/corpus.json
@@ -11,7 +11,8 @@
     "abc.txt": "abc",
     "nums.txt": "1 2\n3 4\n5 6\n",
     "dups.txt": "aaa\naaa\nbbb\n",
-    "dotenv.env": "FOO=bar\nexport BAZ=qux\n"
+    "dotenv.env": "FOO=bar\nexport BAZ=qux\n",
+    "emit-streams.js": "process.stdout.write('OUT\\n');\nprocess.stderr.write('ERR');\n"
   },
   "cases": [
     {
@@ -63,6 +64,31 @@
       "id": "amp-null",
       "cmd": "cat missing.txt &>/dev/null; echo OK",
       "source": "#147"
+    },
+    {
+      "id": "last-stage-stderr-file",
+      "cmd": "node emit-streams.js 2> diff-stderr.txt; wc -c diff-stderr.txt",
+      "source": "#157 fail-loud safety / last-stage compatibility"
+    },
+    {
+      "id": "last-stage-stderr-append",
+      "cmd": "node emit-streams.js 2> diff-stderr-append.txt; node emit-streams.js 2>> diff-stderr-append.txt; wc -c diff-stderr-append.txt",
+      "source": "#157 fail-loud safety / last-stage compatibility"
+    },
+    {
+      "id": "last-stage-stderr-to-stdout",
+      "cmd": "node emit-streams.js 2>&1",
+      "source": "#157 fail-loud safety / last-stage compatibility"
+    },
+    {
+      "id": "attached-digit-stdout-append",
+      "cmd": "printf '' >diff-attached.txt; echo file2>>diff-attached.txt; cat diff-attached.txt",
+      "source": "#157 tokenizer boundary regression"
+    },
+    {
+      "id": "last-stage-stdout-to-stderr",
+      "cmd": "node emit-streams.js 1>&2",
+      "source": "#157 fail-loud safety / last-stage compatibility"
     },
     {
       "id": "pipe-last-true",

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -396,6 +396,27 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     );
   });
 
+  it.each([
+    [
+      'cat missing.txt 2>err.txt | cat',
+      'fauxnix: stderr redirect (2>) on a non-last pipeline stage is not supported yet; spool the stage first (cmd >out 2>err; cat out | next) or wait for per-stage fds (#157)',
+    ],
+    [
+      'cat missing.txt 2>>err.txt | cat',
+      'fauxnix: stderr redirect (2>>) on a non-last pipeline stage is not supported yet; spool the stage first (cmd >out 2>>err; cat out | next) or wait for per-stage fds (#157)',
+    ],
+    [
+      'cat missing.txt 2>&1 | grep missing',
+      'fauxnix: 2>&1 on a non-last pipeline stage is not supported yet; spool the merged output first (cmd >out 2>&1; cat out | next) or wait for per-stage fds (#157)',
+    ],
+    [
+      'echo hi 1>&2 | cat',
+      'fauxnix: 1>&2 on a non-last pipeline stage is not supported yet; run the stage separately (cmd 1>&2; next </dev/null) or wait for per-stage fds (#157)',
+    ],
+  ])('rejects remaining non-last-stage fd redirect in %s', (command, message) => {
+    expect(() => translateCommandList(parseCommand(command))).toThrow(message);
+  });
+
   it('last-stage stdout redirect still writes', async () => {
     const r = await run('echo hi | cat > lastpipe.txt');
     expect(r.exitCode).toBe(0);
@@ -403,6 +424,42 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     const single = await run('echo hi > singleout.txt');
     expect(single.exitCode).toBe(0);
     expect(readFileSync(join(dir, 'singleout.txt'), 'utf8').trim()).toBe('hi');
+  });
+
+  it('keeps an attached word-final 2 as argv before stdout append', async () => {
+    const r = await run('echo file2>>attached-two.txt; cat attached-two.txt');
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe('file2\n');
+    expect(r.stderr).toBe('');
+  });
+
+  it('last-stage stderr and fd-dup redirects still execute through real PowerShell', async () => {
+    const stderrFile = await run('echo hi | cat missing-last-fd.txt 2> last-fd.err');
+    expect(stderrFile.exitCode).toBe(1);
+    expect(stderrFile.stdout).toBe('');
+    expect(stderrFile.stderr).toBe('');
+    expect(readFileSync(join(dir, 'last-fd.err'), 'utf8')).toContain(
+      'cat: missing-last-fd.txt: No such file or directory',
+    );
+
+    const append = await run(
+      'cat missing-append-one.txt 2> last-append.err; cat missing-append-two.txt 2>> last-append.err',
+    );
+    expect(append.exitCode).toBe(1);
+    expect(append.stderr).toBe('');
+    const appended = readFileSync(join(dir, 'last-append.err'), 'utf8');
+    expect(appended).toContain('cat: missing-append-one.txt: No such file or directory');
+    expect(appended).toContain('cat: missing-append-two.txt: No such file or directory');
+
+    const merged = await run('echo hi | cat missing-merged-fd.txt 2>&1');
+    expect(merged.exitCode).toBe(1);
+    expect(merged.stdout).toContain('cat: missing-merged-fd.txt: No such file or directory');
+    expect(merged.stderr).toBe('');
+
+    const stdoutToStderr = await run('printf x | echo last-fd-two 1>&2');
+    expect(stdoutToStderr.exitCode).toBe(0);
+    expect(stdoutToStderr.stdout).toBe('');
+    expect(stdoutToStderr.stderr).toBe('last-fd-two\n');
   });
 
   it(

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -66,12 +66,20 @@ describe('parser', () => {
     expect(cmd.redirects).toEqual([{ op: '>', target: 'out.txt' }]);
   });
 
-  it('parses fd redirects (2>, 2>/dev/null, 2>&1)', () => {
+  it('parses fd redirects (2>, 2>>, 2>/dev/null, 2>&1)', () => {
     expect(parse('x 2> err.txt').segments[0].pipeline.commands[0].redirects[0].op).toBe('2>');
+    expect(parse('x 2>> err.txt').segments[0].pipeline.commands[0].redirects[0].op).toBe('2>>');
     expect(
       parse('x 2> /dev/null').segments[0].pipeline.commands[0].redirects[0].target,
     ).toBe('/dev/null');
     expect(parse('x 2>&1').segments[0].pipeline.commands[0].redirects[0].op).toBe('2>&1');
+  });
+
+  it('keeps a word-final 2 out of 2>> and rejects unsupported multi-digit fds', () => {
+    const command = parse('echo file2>>out.txt').segments[0].pipeline.commands[0];
+    expect(command.args.map(wordToString)).toEqual(['file2']);
+    expect(command.redirects).toEqual([{ op: '>>', target: 'out.txt' }]);
+    expect(() => parse('echo 12>>out.txt')).toThrow(FauxnixParseError);
   });
 
   it('parses stdin redirects', () => {
@@ -955,14 +963,52 @@ describe('translator', () => {
     }
   });
 
-  it('allows last-stage stdout redirect and does not reject 2> on a non-last stage', () => {
+  it.each([
+    [
+      'cat missing.txt 2>err.txt | cat',
+      'fauxnix: stderr redirect (2>) on a non-last pipeline stage is not supported yet; spool the stage first (cmd >out 2>err; cat out | next) or wait for per-stage fds (#157)',
+    ],
+    [
+      'echo x | cat missing.txt 2>>err.txt | cat',
+      'fauxnix: stderr redirect (2>>) on a non-last pipeline stage is not supported yet; spool the stage first (cmd >out 2>>err; cat out | next) or wait for per-stage fds (#157)',
+    ],
+    [
+      'cat missing.txt 2>&1 | grep missing',
+      'fauxnix: 2>&1 on a non-last pipeline stage is not supported yet; spool the merged output first (cmd >out 2>&1; cat out | next) or wait for per-stage fds (#157)',
+    ],
+    [
+      'echo x | echo hi 1>&2 | cat',
+      'fauxnix: 1>&2 on a non-last pipeline stage is not supported yet; run the stage separately (cmd 1>&2; next </dev/null) or wait for per-stage fds (#157)',
+    ],
+  ])('rejects non-last-stage fd redirect in %s', (command, message) => {
+    expect(() => translateCommandList(parse(command))).toThrow(FauxnixParseError);
+    expect(() => translateCommandList(parse(command))).toThrow(message);
+  });
+
+  it('allows all output redirect forms on the last pipeline stage', () => {
     const single = translateCommandList(parse('echo hi >f'))[0];
     expect(single.outputRedirects).toEqual([{ op: '>', target: 'f' }]);
     const disc = translateCommandList(parse('echo hi >/dev/null'))[0];
     expect(disc.outputRedirects).toEqual([{ op: '>', target: '/dev/null' }]);
     const last = translateCommandList(parse('echo hi | cat >f'))[0];
     expect(last.outputRedirects).toEqual([{ op: '>', target: 'f' }]);
-    expect(() => translateCommandList(parse('echo hi 2>e | cat'))).not.toThrow();
+    for (const command of [
+      'echo hi | cat missing.txt 2>e',
+      'echo hi | cat missing.txt 2>>e',
+      'echo hi | cat missing.txt 2>&1',
+      'echo hi | echo last 1>&2',
+    ]) {
+      expect(() => translateCommandList(parse(command)), command).not.toThrow();
+    }
+  });
+
+  it('translates attached word digits as argv plus stdout append', () => {
+    const attached = translateCommandList(parse('echo file2>>out.txt'))[0];
+    expect(attached.outputRedirects).toEqual([{ op: '>>', target: 'out.txt' }]);
+    expect(attached.body).toContain("@('file2')");
+
+    const stderrAppend = translateCommandList(parse('echo x 2>>err.txt'))[0];
+    expect(stderrAppend.outputRedirects).toEqual([{ op: '2>>', target: 'err.txt' }]);
   });
 
   it('uses functions for multi-stage pipelines (PS 5.1 rule)', () => {


### PR DESCRIPTION
## Problem

The first #157 slice rejects non-last-stage stdout redirects, but the remaining fd forms still appear to succeed while Node applies them only to the last stage. Examples such as `cmd 2>&1 | next` therefore produce the wrong pipeline.

## Fix

Reject these forms on every non-last stage with an operation-specific alternative:

- `2>` / `2>>`
- `2>&1`
- `1>&2`

Last-stage forms and per-stage input `<` continue to work. This is the fail-loud completion of the current model; it does **not** claim routed per-stage stdout/stderr or close #157.

The patch also completes the parser's `2>>` handling without changing adjacent-word or multi-digit-fd semantics:

- `x 2>>err` -> stderr append
- `echo file2>>out` -> argv `file2`, stdout append
- `12>>out` -> existing explicit rejection

## Verification

- focused parser/translator/real-PowerShell checks: 8 passed
- npm run typecheck
- npm run build
- npm test: 330 passed, 1 opt-in oracle skipped
- npm run test:package
- Git Bash oracle: 130/131 identical (99.2%); all new cases identical
- git diff --check

Follow-up to #157 and the first slice in #175; roadmap C-6 remains open for routed stage fds.