### PR TITLE
fix: validate tail counts and awk assignments

### DIFF
--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -1903,17 +1903,38 @@ const awk: Handler = (args) => {
 
   // -v may repeat; collect all of them
   const vvars: Array<[string, string]> = [];
+  const addVVar = (nv: string): void => {
+    const eq = nv.indexOf('=');
+    if (eq < 1) {
+      throw new FauxnixParseError("fauxnix: awk invalid -v assignment '" + nv + "'");
+    }
+    const name = nv.slice(0, eq);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw new FauxnixParseError("fauxnix: awk invalid variable name '" + name + "'");
+    }
+    vvars.push([name, nv.slice(eq + 1)]);
+  };
+  let onlyOperands = false;
   for (let i = 0; i < args.length; i++) {
     const t = wordToString(args[i]);
-    if (t === '-v' && i + 1 < args.length) {
-      const nv = wordToString(args[i + 1]);
-      const eq = nv.indexOf('=');
-      if (eq > 0) vvars.push([nv.slice(0, eq), nv.slice(eq + 1)]);
+    if (t === '--') {
+      onlyOperands = true;
+      continue;
+    }
+    if (onlyOperands) continue;
+    if (t === '-F') {
+      if (i + 1 < args.length) i++;
+      continue;
+    }
+    if (t.startsWith('-F') && t.length > 2) continue;
+    if (t === '-v') {
+      if (i + 1 >= args.length) {
+        throw new FauxnixParseError('fauxnix: awk -v requires an argument');
+      }
+      addVVar(wordToString(args[i + 1]));
       i++;
     } else if (t.startsWith('-v') && t.length > 2) {
-      const nv = t.slice(2);
-      const eq = nv.indexOf('=');
-      if (eq > 0) vvars.push([nv.slice(0, eq), nv.slice(eq + 1)]);
+      addVVar(t.slice(2));
     }
   }
 

--- a/src/commands/text-io.ts
+++ b/src/commands/text-io.ts
@@ -592,6 +592,18 @@ const head: Handler = (args, ctx) => {
 /* tail                                                                */
 /* ------------------------------------------------------------------ */
 
+/** A count embedded in generated PS must be a canonical Int32 literal. */
+function tailCountLiteral(raw: string): string | null {
+  if (!/^[+-]?\d+$/.test(raw)) return null;
+  try {
+    const n = BigInt(raw.replace(/^[+-]/, ''));
+    if (n > 2147483647n) return null;
+    return n.toString();
+  } catch {
+    return null;
+  }
+}
+
 const tail: Handler = (args, ctx) => {
   const pre = parseWords(args);
   if (pre.flags.has('f') || pre.flags.has('F')) {
@@ -602,9 +614,33 @@ const tail: Handler = (args, ctx) => {
   let nLines: string | null = null;
   let fromLine: string | null = null;
   let nBytes: string | null = null;
+  let fromByte = false;
   const operandWords: Word[] = [];
   let quiet = false;
   let verbose = false;
+  const setCount = (kind: 'lines' | 'bytes', raw: string): string | null => {
+    const literal = tailCountLiteral(raw);
+    if (literal === null) {
+      return psErrExpr(psStr("tail: invalid number of " + kind + ": '" + raw + "'"));
+    }
+    if (kind === 'bytes') {
+      nBytes = literal;
+      fromByte = raw.startsWith('+');
+      nLines = null;
+      fromLine = null;
+    } else {
+      nBytes = null;
+      fromByte = false;
+      if (raw.startsWith('+')) {
+        fromLine = literal;
+        nLines = null;
+      } else {
+        nLines = literal;
+        fromLine = null;
+      }
+    }
+    return null;
+  };
   {
     let i = 0;
     let onlyOps = false;
@@ -635,9 +671,8 @@ const tail: Handler = (args, ctx) => {
           } else {
             i++;
           }
-          if (name === '--bytes') nBytes = val;
-          else if (val.startsWith('+')) fromLine = val.slice(1);
-          else nLines = val.replace(/^-/, '');
+          const err = setCount(name === '--bytes' ? 'bytes' : 'lines', val);
+          if (err !== null) return err;
           continue;
         }
         if (name === '--quiet' || name === '--silent') {
@@ -654,41 +689,40 @@ const tail: Handler = (args, ctx) => {
         continue;
       }
       let m: RegExpMatchArray | null;
-      if (t === '-n' || t === '-c') {
-        const val = i + 1 < args.length ? wordToString(args[i + 1]) : null;
-        if (val === null) {
-          return psErrExpr(psStr('tail: option requires an argument -- ' + t.slice(1)));
-        }
-        if (t === '-c') nBytes = val;
-        else if (val.startsWith('+')) fromLine = val.slice(1);
-        else nLines = val.replace(/^-/, ''); // -n -N ≡ -n N (last N)
-        i += 2;
-        continue;
-      }
-      if ((m = t.match(/^-[nc](.*)$/)) !== null) {
-        const val = m[1];
-        if (t[1] === 'c') nBytes = val;
-        else if (val.startsWith('+')) fromLine = val.slice(1);
-        else nLines = val.replace(/^-/, '');
-        i++;
-        continue;
-      }
       if ((m = t.match(/^-(\d+)$/)) !== null) {
-        nLines = m[1];
+        const err = setCount('lines', t);
+        if (err !== null) return err;
         i++;
         continue;
       }
       if ((m = t.match(/^\+(\d+)$/)) !== null) {
-        fromLine = m[1];
+        const err = setCount('lines', t);
+        if (err !== null) return err;
         i++;
         continue;
       }
       if (t.startsWith('-') && t.length > 1) {
-        for (const ch of t.slice(1)) {
+        const body = t.slice(1);
+        let usedNext = false;
+        for (let c = 0; c < body.length; c++) {
+          const ch = body[c];
           if (ch === 'q') quiet = true;
           else if (ch === 'v') verbose = true;
+          else if (ch === 'n' || ch === 'c') {
+            let val = body.slice(c + 1);
+            if (val === '') {
+              if (i + 1 >= args.length) {
+                return psErrExpr(psStr('tail: option requires an argument -- ' + ch));
+              }
+              val = wordToString(args[i + 1]);
+              usedNext = true;
+            }
+            const err = setCount(ch === 'c' ? 'bytes' : 'lines', val);
+            if (err !== null) return err;
+            break;
+          }
         }
-        i++;
+        i += usedNext ? 2 : 1;
         continue;
       }
       operandWords.push(args[i]);
@@ -696,13 +730,7 @@ const tail: Handler = (args, ctx) => {
     }
   }
   const bytesMode = nBytes !== null;
-  const countLit = bytesMode
-    ? nBytes!
-    : fromLine !== null
-      ? fromLine
-      : nLines !== null
-        ? nLines
-        : '10';
+  const countLit = bytesMode ? nBytes! : fromLine ?? nLines ?? '10';
 
   const lines: string[] = [
     PS_GLOB_FN,
@@ -736,7 +764,9 @@ const tail: Handler = (args, ctx) => {
       "    [void]$fx_out.Append('==> ' + $fx_disp + ' <==' + [string][char]10)",
       '  }',
       '  $fx_first = $false',
-      '  $fx_st = $fx_txt.Length - $fx_count',
+      fromByte
+        ? '  $fx_st = $fx_count - 1'
+        : '  $fx_st = $fx_txt.Length - $fx_count',
       '  if ($fx_st -lt 0) { $fx_st = 0 }',
       '  if ($fx_st -lt $fx_txt.Length) { [void]$fx_out.Append($fx_txt.Substring($fx_st)) }',
       '}',

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -210,6 +210,14 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
   it('awk field printing and sum', async () => {
     expect((await run("awk '{print $1}' fruits.txt")).stdout).toContain('apple');
     expect((await run("awk '{sum += $1} END {print sum}' nums.txt")).stdout.trim()).toBe('9');
+    expect((await run("awk -v answer=42 'BEGIN { print answer }'")).stdout.trim()).toBe('42');
+    expect((await run("awk -F -- -v answer=42 'BEGIN { print answer }'")).stdout.trim()).toBe(
+      '42',
+    );
+    expect((await run("awk -F '-vbad-name=1' 'BEGIN { print 1 }'")).stdout.trim()).toBe('1');
+    await expect(
+      run("awk -v 'x; Write-Output UNEXPECTED_AWK; $z=1' 'BEGIN { print 1 }'"),
+    ).rejects.toThrow(/awk invalid variable name/);
   });
 
   it('sort -n and uniq -c', async () => {
@@ -246,6 +254,23 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect((await run('tail --lines=1 fruits.txt')).stdout.trim()).toBe('cherry');
     expect((await run('wc -l fruits.txt')).stdout.trim()).toMatch(/4/);
     expect((await run('wc -l < fruits.txt')).stdout.trim()).toBe('4');
+  });
+
+  it('tail count data cannot become generated PowerShell', async () => {
+    const injected = await run(
+      "tail --lines='1); Write-Output UNEXPECTED_TAIL; [int](1' fruits.txt",
+    );
+    expect(injected.exitCode).toBe(1);
+    expect(injected.stderr).toContain('tail: invalid number of lines');
+    expect(injected.stdout).not.toContain('UNEXPECTED_TAIL');
+
+    const overflow = await run('tail --bytes=2147483648 fruits.txt');
+    expect(overflow.exitCode).toBe(1);
+    expect(overflow.stderr).toContain('tail: invalid number of bytes');
+    expect(overflow.stdout).toBe('');
+
+    expect((await run('printf abc | tail -c -1')).stdout).toBe('c');
+    expect((await run('printf abcde | tail -c +2')).stdout).toBe('bcde');
   });
 
   it('head --lines=-N / --bytes=-N print all but last N (GNU)', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1438,6 +1438,67 @@ describe('CommandSpec text-io leftovers (#143)', () => {
     expect(follow).not.toContain('fx-read');
   });
 
+  it('tail rejects code syntax in separate, attached, long, and bundled count forms', () => {
+    const bad = [
+      "tail -n '1); Write-Output UNEXPECTED_TAIL_N; [int](1' f",
+      "tail -c '1); Write-Output UNEXPECTED_TAIL_C; [int](1' f",
+      "tail -n'1); Write-Output UNEXPECTED_TAIL_N_ATTACHED; [int](1' f",
+      "tail -c'1); Write-Output UNEXPECTED_TAIL_C_ATTACHED; [int](1' f",
+      "tail -qn'1); Write-Output UNEXPECTED_TAIL_N_BUNDLED; [int](1' f",
+      "tail --lines='1); Write-Output UNEXPECTED_TAIL_LINES; [int](1' f",
+      "tail --bytes='1); Write-Output UNEXPECTED_TAIL_BYTES; [int](1' f",
+      "tail --lines '1); Write-Output UNEXPECTED_TAIL_LINES_SEPARATE; [int](1' f",
+      "tail --bytes '1); Write-Output UNEXPECTED_TAIL_BYTES_SEPARATE; [int](1' f",
+    ];
+    for (const cmd of bad) {
+      const body = bodyOf(cmd);
+      expect(body, cmd).toContain('tail: invalid number of');
+      expect(body, cmd).toContain('$script:fx_exit = 1');
+      expect(body, cmd).not.toContain('$fx_count = [int](');
+    }
+  });
+
+  it('tail emits canonical Int32 counts and fails loud on syntax or overflow', () => {
+    expect(bodyOf('tail -n 0002 f')).toContain('$fx_count = [int](2)');
+    expect(bodyOf('tail -n2 f')).toContain('$fx_count = [int](2)');
+    expect(bodyOf('tail -qn2 f')).toContain('$fx_count = [int](2)');
+    expect(bodyOf('tail -vc2 f')).toContain('$fx_count = [int](2)');
+    expect(bodyOf('tail --lines 2 f')).toContain('$fx_count = [int](2)');
+    expect(bodyOf('tail --bytes 2 f')).toContain('$fx_count = [int](2)');
+    expect(bodyOf('tail --lines=+0002 f')).toContain('$fx_count = [int](2)');
+    expect(bodyOf('tail --lines=2147483647 f')).toContain(
+      '$fx_count = [int](2147483647)',
+    );
+    expect(bodyOf('tail --bytes=2147483647 f')).toContain(
+      '$fx_count = [int](2147483647)',
+    );
+    expect(bodyOf('tail -c -2 f')).toContain('$fx_txt.Length - $fx_count');
+    expect(bodyOf('tail -c +2 f')).toContain('$fx_st = $fx_count - 1');
+
+    const mixed = bodyOf('tail --bytes=1 --lines=2 f');
+    expect(mixed).toContain('$fx_count = [int](2)');
+    expect(mixed).toContain('$fx_ls.Count - $fx_count');
+    const repeated = bodyOf('tail --lines=+2 --lines=1 f');
+    expect(repeated).toContain('$fx_from = $false');
+
+    const bad = [
+      'tail -n --1 f',
+      'tail --lines=+-1 f',
+      'tail -c 1KB f',
+      'tail --bytes=0x10 f',
+      'tail --lines=2147483648 f',
+      'tail -n -2147483648 f',
+      'tail -c -2147483648 f',
+      'tail --lines=bogus --lines=1 f',
+      'tail --lines=+2 --lines=bogus f',
+    ];
+    for (const cmd of bad) {
+      const body = bodyOf(cmd);
+      expect(body, cmd).toContain('tail: invalid number of');
+      expect(body, cmd).not.toContain('$fx_count = [int](');
+    }
+  });
+
   it('wc -l/-w/-c/-m are spec\'d; find/xargs/nl stay unspec\'d', () => {
     expect(lookupSpec('wc')).toBeTruthy();
     expect(bodyOf('wc -lwm f')).not.toContain('invalid option');
@@ -1451,6 +1512,45 @@ describe('CommandSpec text-io leftovers (#143)', () => {
 
 describe('CommandSpec text-filters leftovers (#143)', () => {
   const bodyOf = (cmd: string): string => translateCommandList(parse(cmd))[0].body;
+
+  it('awk -v only generates PowerShell names from strict awk identifiers', () => {
+    const body = bodyOf(
+      "awk -v _=0 -v answer=42 -v empty= -v 'pair=a=b' -v 'message=hello world' 'BEGIN { print answer }'",
+    );
+    expect(body).toContain('$fxv__ = [double]0');
+    expect(body).toContain('$fxv_answer = [double]42');
+    expect(body).toContain("$fxv_empty = ''");
+    expect(body).toContain("$fxv_pair = 'a=b'");
+    expect(body).toContain("$fxv_message = 'hello world'");
+    expect(bodyOf("awk -vname_2=7 'BEGIN { print name_2 }'")).toContain(
+      '$fxv_name_2 = [double]7',
+    );
+    expect(() => bodyOf("awk -- 'BEGIN { print 1 }' '-vbad-name=1'")).not.toThrow();
+    expect(bodyOf("awk -F -- -v answer=42 'BEGIN { print answer }'")).toContain(
+      '$fxv_answer = [double]42',
+    );
+    expect(() => bodyOf("awk -F '-vbad-name=1' 'BEGIN { print 1 }'")).not.toThrow();
+  });
+
+  it('awk -v rejects malformed and code-bearing names before generation', () => {
+    const invalidNames = [
+      "awk -v '9name=1' 'BEGIN { print 1 }'",
+      "awk -v 'bad-name=1' 'BEGIN { print 1 }'",
+      "awk -v '名字=1' 'BEGIN { print 1 }'",
+      "awk -v 'x; Write-Output UNEXPECTED_AWK; $z=1' 'BEGIN { print 1 }'",
+      "awk '-vx; Write-Output UNEXPECTED_AWK_ATTACHED; $z=1' 'BEGIN { print 1 }'",
+    ];
+    for (const cmd of invalidNames) {
+      expect(() => bodyOf(cmd)).toThrow(/awk invalid variable name/);
+    }
+    expect(() => bodyOf("awk -v name 'BEGIN { print 1 }'")).toThrow(
+      /awk invalid -v assignment/,
+    );
+    expect(() => bodyOf("awk -v '=1' 'BEGIN { print 1 }'")).toThrow(
+      /awk invalid -v assignment/,
+    );
+    expect(() => bodyOf("awk 'BEGIN { print 1 }' -v")).toThrow(/awk -v requires an argument/);
+  });
 
   it('sort/uniq/cut/tr are spec\'d; sed/awk/egrep stay unspec\'d', () => {
     expect(lookupSpec('sort')).toBeTruthy();


### PR DESCRIPTION
## Problem

Two option parsers accept values outside the grammar their handlers can represent:

- `tail -n/-c/--lines/--bytes` inserts the flattened count text into an `[int](...)` PowerShell expression instead of validating a number
- `awk -v` accepts any non-empty text before `=` and uses it to form a PowerShell variable name, even though normal awk identifiers are already restricted

Malformed values can therefore change the generated script or fail far away from the option that caused it.

## Fix

- require signed decimal tail counts, normalize them to a canonical Int32 literal, and fail immediately on syntax/overflow
- preserve last-option-wins behavior and the distinct `+N` byte/line origins
- require awk identifiers for every attached/separate `-v NAME=VALUE`
- preserve empty values and additional `=` characters
- correctly handle genuine `--`, separate/attached `-F`, and a missing terminal `-v`

## Verification

- punctuation/newline/variable-shaped values fail before generated code is produced
- valid zero, sign, bundle, repeat, byte, line, empty-value, and Int32 boundary cases are pinned
- real PowerShell regression tests cover both handlers
- npm run typecheck / build
- full suite: 323 passed, 1 opt-in oracle skipped
- npm run test:package
- Git Bash oracle: 125/126 identical (99.2%)
- independent patch review: pass
- git diff --check