### PR TITLE
fix: derive wget output from the final URL component

### DIFF
--- a/src/commands/net.ts
+++ b/src/commands/net.ts
@@ -114,17 +114,59 @@ const curl: Handler = (args) => {
 /* wget                                                                */
 /* ------------------------------------------------------------------ */
 
-/** GNU wget default output filename derived from a literal URL (index.html when bare). */
-function urlFileName(u: string): string {
-  // keep only the path component (drop scheme, host, query, fragment)
-  let p = u.split('#')[0].split('?')[0];
-  const sm = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.exec(p);
-  if (sm) p = p.slice(sm[0].length);
-  const slash = p.indexOf('/');
-  if (slash >= 0) p = p.slice(slash + 1);
-  else p = '';
-  if (p === '') return 'index.html'; // no path (or trailing /) → GNU default
-  return p;
+const WINDOWS_DEVICE_NAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i;
+
+function percentEncodeChar(char: string): string {
+  return Array.from(Buffer.from(char, 'utf8'), (byte) => '%' + byte.toString(16).toUpperCase()).join('');
+}
+
+/**
+ * GNU wget-style default output basename for the curl fallback.
+ *
+ * A valid UTF-8 percent sequence is decoded exactly once. Malformed sequences
+ * remain literal, while characters Windows cannot put in a filename are
+ * percent-encoded again. This keeps encoded separators inside one basename
+ * instead of accidentally turning them into local path components.
+ */
+export function urlFileName(u: string): string {
+  let pathname: string;
+  try {
+    pathname = new URL(u).pathname;
+  } catch {
+    return 'index.html';
+  }
+
+  // URL normalisation handles dot segments. A bare path or trailing slash uses
+  // wget's conventional index filename.
+  if (pathname === '' || pathname.endsWith('/')) return 'index.html';
+  const rawName = pathname.slice(pathname.lastIndexOf('/') + 1);
+
+  let decoded = rawName;
+  try {
+    decoded = decodeURIComponent(rawName);
+  } catch {
+    // Keep malformed percent escapes literal so naming remains deterministic.
+  }
+
+  let safe = '';
+  for (const char of decoded) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code <= 0x1f || code === 0x7f || /[<>:"/\\|?*]/.test(char)) {
+      safe += percentEncodeChar(char);
+    } else {
+      safe += char;
+    }
+  }
+
+  // Windows strips trailing dots/spaces and treats DOS device basenames as
+  // special even when an extension is present. Preserve the intended text in
+  // a stable, ordinary filename instead.
+  safe = safe.replace(/[. ]+$/, (suffix) =>
+    Array.from(suffix, (char) => percentEncodeChar(char)).join(''),
+  );
+  if (safe === '' || safe === '.' || safe === '..') return 'index.html';
+  if (WINDOWS_DEVICE_NAME.test(safe)) safe = '_' + safe;
+  return safe;
 }
 
 interface WgetMap {

--- a/test/wget-fallback.windows.test.ts
+++ b/test/wget-fallback.windows.test.ts
@@ -1,0 +1,74 @@
+/** Offline integration coverage for wget's curl.exe fallback on real PowerShell. */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { hostname, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { FauxnixSession } from '../src/executor.js';
+import { parseCommand } from '../src/parser.js';
+import { translateCommandList } from '../src/translator.js';
+import '../src/commands/install-all.js';
+
+const systemRoot = process.env.SystemRoot ?? 'C:\\Windows';
+const systemCurl = join(systemRoot, 'System32', 'curl.exe');
+const hasPs =
+  process.platform === 'win32' &&
+  spawnSync('powershell.exe', ['-NoProfile', '-Command', 'exit 0'], { shell: false }).status === 0;
+
+describe.skipIf(!hasPs || !existsSync(systemCurl))(
+  'wget curl fallback (real PowerShell, local fixture)',
+  { timeout: 30000 },
+  () => {
+    let dir: string;
+    let session: FauxnixSession;
+    let server: Server;
+    let port: number;
+
+    beforeAll(async () => {
+      dir = mkdtempSync(join(tmpdir(), 'fauxnix-wget-'));
+      copyFileSync(systemCurl, join(dir, 'curl.exe'));
+
+      server = createServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'text/plain' });
+        response.end('local wget fixture\n');
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '0.0.0.0', () => resolve());
+      });
+      const address = server.address();
+      if (address === null || typeof address === 'string') throw new Error('fixture server has no TCP port');
+      port = address.port;
+
+      session = new FauxnixSession();
+      await run(`cd '${dir.replaceAll("'", "'\\''")}'`);
+      // An isolated PATH makes the branch choice deterministic: curl.exe is
+      // available, while a separately installed wget.exe cannot intercept it.
+      await run(`export PATH='${dir.replaceAll("'", "'\\''")}'`);
+    }, 60000);
+
+    afterAll(async () => {
+      if (session) await session.dispose();
+      if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    });
+
+    async function run(command: string) {
+      return session.run(translateCommandList(parseCommand(command)));
+    }
+
+    it('writes the response to the decoded final basename, not the URL path', async () => {
+      const localHost = hostname();
+      const result = await run(
+        `wget -q 'http://${localHost}:${port}/nested/report%20one.txt?download=1#part'`,
+      );
+
+      expect(result.exitCode).toBe(0);
+      const output = join(dir, 'report one.txt');
+      expect(existsSync(output)).toBe(true);
+      expect(readFileSync(output, 'utf8')).toBe('local wget fixture\n');
+      expect(existsSync(join(dir, 'nested'))).toBe(false);
+    });
+  },
+);

--- a/test/wget-filename.test.ts
+++ b/test/wget-filename.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { urlFileName } from '../src/commands/net.js';
+import { parseCommand } from '../src/parser.js';
+import { translateCommandList } from '../src/translator.js';
+import '../src/commands/install-all.js';
+
+describe('wget fallback default output filename', () => {
+  it('uses only the final URL path component', () => {
+    expect(urlFileName('https://host.example/a/b')).toBe('b');
+    expect(urlFileName('https://host.example/a/report.txt?download=1#top')).toBe('report.txt');
+  });
+
+  it('uses index.html for a bare URL or trailing slash', () => {
+    expect(urlFileName('https://host.example')).toBe('index.html');
+    expect(urlFileName('https://host.example/')).toBe('index.html');
+    expect(urlFileName('https://host.example/a/../')).toBe('index.html');
+  });
+
+  it('normalises dot segments before selecting the basename', () => {
+    expect(urlFileName('https://host.example/a/../b/file.txt')).toBe('file.txt');
+    expect(urlFileName('https://host.example/a/%2e%2e/final')).toBe('final');
+  });
+
+  it('decodes valid percent escapes once and preserves malformed escapes', () => {
+    expect(urlFileName('https://host.example/a/hello%20world.txt')).toBe('hello world.txt');
+    expect(urlFileName('https://host.example/a/%252F.txt')).toBe('%2F.txt');
+    expect(urlFileName('https://host.example/a/bad%ZZname')).toBe('bad%ZZname');
+  });
+
+  it('keeps decoded separators and invalid Windows characters inside one filename', () => {
+    expect(urlFileName('https://host.example/a%2Fb')).toBe('a%2Fb');
+    expect(urlFileName('https://host.example/a%5Cb')).toBe('a%5Cb');
+    expect(urlFileName('https://host.example/%3Cbad%3E%3Aname')).toBe('%3Cbad%3E%3Aname');
+    expect(urlFileName('https://host.example/C%3A')).toBe('C%3A');
+  });
+
+  it('stabilises Windows device names and trailing dots or spaces', () => {
+    expect(urlFileName('https://host.example/CON')).toBe('_CON');
+    expect(urlFileName('https://host.example/aux.txt')).toBe('_aux.txt');
+    expect(urlFileName('https://host.example/report.')).toBe('report%2E');
+    expect(urlFileName('https://host.example/report%20')).toBe('report%20');
+  });
+
+  it('keeps explicit output mapping and the native wget branch unchanged', () => {
+    const body = translateCommandList(
+      parseCommand('wget -O custom.bin https://host.example/a/report.txt'),
+    )[0].body;
+    expect(body).toContain("$fx_args = (@('-O') + @('custom.bin') + @('https://host.example/a/report.txt'))");
+    expect(body).toContain("Get-Command 'wget.exe'");
+    expect(body).toContain("fx-native 'wget.exe' ([object[]]@($fx_args))");
+    expect(body).toContain("$fx_margs = @('-o', 'custom.bin', 'https://host.example/a/report.txt')");
+    expect(body).not.toContain("'report.txt'");
+  });
+});


### PR DESCRIPTION
## Problem

When `wget` falls back to `curl.exe` and `-O` is absent, the compatibility mapper uses the entire URL path as curl's local `-o` value. For example, `/a/b/report.txt` tries to write `a/b/report.txt` instead of wget's default basename `report.txt`. Dot segments, encoded separators, device names, and Windows-invalid filename characters also make the result inconsistent.

## Fix

- parse the URL with the platform URL implementation
- use only the final path component
- keep bare and trailing-slash URLs on `index.html`
- decode valid UTF-8 escapes exactly once
- keep decoded separators/invalid characters inside one filename via stable percent encoding
- stabilize DOS device names and trailing dots/spaces

Explicit `-O` mapping and the native `wget.exe` branch are unchanged.

## Verification

- 7 focused naming/mapping tests
- real PowerShell offline integration test with a local HTTP fixture and isolated curl-only PATH
- nested URL saves `report one.txt` and does not create a `nested` directory
- npm run typecheck
- full suite: 326 passed, 1 opt-in oracle skipped
- npm run test:package
- Git Bash oracle: 125/126 identical (99.2%)
- git diff --check