### PR TITLE
fix: preserve unset variables across host restarts

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -243,6 +243,8 @@ export class FauxnixSession {
   private hostFile!: string;
   private host: PowerShellHost | null = null;
   private lifecycleLock: Promise<unknown> = Promise.resolve();
+  /** True once `env` was loaded from the host's complete environment snapshot. */
+  private hasEnvSnapshot = false;
 
   constructor() {
     this.id = randomUUID().slice(0, 8);
@@ -278,7 +280,10 @@ export class FauxnixSession {
     try {
       if (existsSync(this.envFile)) {
         const raw = readFileSync(this.envFile, 'utf8');
-        if (raw.trim()) this.env = JSON.parse(raw) as Record<string, string>;
+        if (raw.trim()) {
+          this.env = JSON.parse(raw) as Record<string, string>;
+          this.hasEnvSnapshot = true;
+        }
       }
     } catch {
       /* ignore */
@@ -318,6 +323,7 @@ export class FauxnixSession {
     }
     this.cwd = null;
     this.env = {};
+    this.hasEnvSnapshot = false;
     this.prevExit = null;
     await Promise.allSettled([
       fs.rm(this.cwdFile, { force: true }),
@@ -330,10 +336,17 @@ export class FauxnixSession {
 
   /** env for the child powershell process. */
   childEnv(cwdOverride?: string, stdinFile?: string | null): NodeJS.ProcessEnv {
-    const env: NodeJS.ProcessEnv = { ...process.env };
-    for (const [k, v] of Object.entries(this.env)) {
-      if (v === undefined) delete env[k];
-      else env[k] = v;
+    // Before the first completed request, `env` contains optional caller
+    // overrides and is layered over the process baseline. Afterwards it is a
+    // complete snapshot written by the resident host. Restore that snapshot
+    // verbatim on transparent host restarts: merging it with process.env would
+    // resurrect inherited variables that the shell successfully unset.
+    const env: NodeJS.ProcessEnv = this.hasEnvSnapshot ? { ...this.env } : { ...process.env };
+    if (!this.hasEnvSnapshot) {
+      for (const [k, v] of Object.entries(this.env)) {
+        if (v === undefined) delete env[k];
+        else env[k] = v;
+      }
     }
     // The MCP SDK's safe Windows stdio environment omits PATHEXT. Without it,
     // PowerShell cannot resolve extensionless native commands such as `node`.

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1437,6 +1437,81 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     }
   }, 30000);
 
+  it('unset inherited env stays absent after a timeout restart, including native children', async () => {
+    const key = 'FAUXNIX_RESTART_TIMEOUT_CASE';
+    const unsetSpelling = 'fauxnix_restart_timeout_case';
+    const old = process.env[key];
+    process.env[key] = 'parent-baseline';
+    const extra = new FauxnixSession();
+    try {
+      expect((await extra.run(translateCommandList(parseCommand('printenv ' + key)))).stdout.trim()).toBe(
+        'parent-baseline',
+      );
+      expect((await extra.run(translateCommandList(parseCommand('unset ' + unsetSpelling)))).exitCode).toBe(0);
+
+      const timedOut = await extra.run(translateCommandList(parseCommand('sleep 5')), {
+        timeoutMs: 800,
+      });
+      expect(timedOut.timedOut).toBe(true);
+      expect(timedOut.exitCode).toBe(124);
+
+      const printenv = await extra.run(translateCommandList(parseCommand('printenv ' + key)));
+      expect(printenv.exitCode).toBe(1);
+      expect(printenv.stdout).toBe('');
+      const native = await extra.run(
+        translateCommandList(
+          parseCommand(`node -e "process.stdout.write(process.env.${key} ?? 'missing')"`),
+        ),
+      );
+      expect(native.exitCode).toBe(0);
+      expect(native.stdout.trim()).toBe('missing');
+
+      await extra.reset();
+      expect((await extra.run(translateCommandList(parseCommand('printenv ' + key)))).stdout.trim()).toBe(
+        'parent-baseline',
+      );
+    } finally {
+      await extra.dispose();
+      if (old === undefined) delete process.env[key];
+      else process.env[key] = old;
+    }
+  }, 30000);
+
+  it('unset inherited env stays absent after an aborted request', async () => {
+    const key = 'FAUXNIX_RESTART_ABORT_CASE';
+    const old = process.env[key];
+    process.env[key] = 'parent-baseline';
+    const extra = new FauxnixSession();
+    try {
+      expect((await extra.run(translateCommandList(parseCommand('unset ' + key)))).exitCode).toBe(0);
+      const ac = new AbortController();
+      const pending = extra.run(translateCommandList(parseCommand('sleep 5')), {
+        timeoutMs: 30_000,
+        signal: ac.signal,
+      });
+      await new Promise((r) => setTimeout(r, 250));
+      ac.abort();
+      const cancelled = await pending;
+      expect(cancelled.cancelled).toBe(true);
+      expect(cancelled.exitCode).toBe(130);
+
+      const printenv = await extra.run(translateCommandList(parseCommand('printenv ' + key)));
+      expect(printenv.exitCode).toBe(1);
+      expect(printenv.stdout).toBe('');
+      const native = await extra.run(
+        translateCommandList(
+          parseCommand(`node -e "process.stdout.write(process.env.${key} ?? 'missing')"`),
+        ),
+      );
+      expect(native.exitCode).toBe(0);
+      expect(native.stdout.trim()).toBe('missing');
+    } finally {
+      await extra.dispose();
+      if (old === undefined) delete process.env[key];
+      else process.env[key] = old;
+    }
+  }, 30000);
+
   it('adds a default PATHEXT only when no case variant is present', async () => {
     const extra = new FauxnixSession();
     const overrides = extra.env as Record<string, string | undefined>;


### PR DESCRIPTION
## Problem

`unset` persists correctly while the resident PowerShell host stays alive, but a timeout, cancellation, or host exit starts the replacement process from `process.env` again. Keys missing from the saved session snapshot are then restored accidentally.

Reproduction with an inherited variable:

1. `unset NAME`
2. `printenv NAME` -> missing
3. force a timeout/restart
4. `printenv NAME` -> original parent value returns

## Fix

After the first completed host snapshot, treat `session.env` as the complete environment rather than an overlay. Transparent host restarts restore it verbatim. An explicit `fauxnix_session reset` still clears the snapshot and intentionally returns to the process baseline.

## Verification

- inherited key unset with different casing stays absent after timeout recovery
- the key is absent from both `printenv` and a native Node child
- AbortSignal recovery has the same behavior
- explicit reset restores the parent baseline
- npm run typecheck / build
- full suite: 320 passed, 1 opt-in oracle skipped
- npm run test:package
- Git Bash oracle: 125/126 identical (99.2%)
- git diff --check