### PR TITLE
fix: keep zip input paths literal

### DIFF
--- a/src/commands/archive.ts
+++ b/src/commands/archive.ts
@@ -319,7 +319,7 @@ const zip: Handler = (args) => {
     "    $fx_dst = $fx_arc",
     '    $fx_rename = $false',
     "    if (-not $fx_arc.ToLower().EndsWith('.zip')) { $fx_dst = $fx_arc + '.zip'; $fx_rename = $true }",
-    '    Compress-Archive -Path $fx_valid -DestinationPath $fx_dst -Force -ErrorAction Stop',
+    '    Compress-Archive -LiteralPath $fx_valid -DestinationPath $fx_dst -Force -ErrorAction Stop',
     // PS 5.1 Compress-Archive writes `\` entry separators; rewrite them to `/`
     // so GNU unzip/bsdtar see proper directory entries.
     '    Add-Type -AssemblyName System.IO.Compression.FileSystem',

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -977,6 +977,62 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(z.stdout).toBe('');
   });
 
+  it('zip archives wildcard-looking names literally', async () => {
+    writeFileSync(join(dir, '[.]env'), 'bracket-dot\n', 'utf8');
+    writeFileSync(join(dir, '.env'), 'plain-dot\n', 'utf8');
+    writeFileSync(join(dir, '[wild].txt'), 'bracket-name\n', 'utf8');
+    writeFileSync(join(dir, 'w.txt'), 'wildcard-match\n', 'utf8');
+
+    const zipped = await run("zip literal-paths.zip '[.]env' '.env' '[wild].txt'");
+    expect(zipped.exitCode).toBe(0);
+    expect(zipped.stderr).toBe('');
+
+    const listed = await run('unzip -l literal-paths.zip');
+    expect(listed.exitCode).toBe(0);
+    expect(listed.stdout).toContain('[.]env');
+    expect(listed.stdout).toContain('.env');
+    expect(listed.stdout).toContain('[wild].txt');
+    expect(listed.stdout).not.toContain('w.txt');
+
+    const extracted = await run('unzip -o -d literal-out literal-paths.zip');
+    expect(extracted.exitCode).toBe(0);
+    expect(readFileSync(join(dir, 'literal-out', '[.]env'), 'utf8')).toBe('bracket-dot\n');
+    expect(readFileSync(join(dir, 'literal-out', '.env'), 'utf8')).toBe('plain-dot\n');
+    expect(readFileSync(join(dir, 'literal-out', '[wild].txt'), 'utf8')).toBe(
+      'bracket-name\n',
+    );
+    expect(existsSync(join(dir, 'literal-out', 'w.txt'))).toBe(false);
+
+    for (const [operand, archive] of [
+      ['*', 'literal-star.zip'],
+      ['?', 'literal-question.zip'],
+    ] as const) {
+      const missing = await run(`zip ${archive} '${operand}'`);
+      expect(missing.exitCode).toBe(12);
+      expect(missing.stderr).toContain('name not matched');
+      expect(existsSync(join(dir, archive))).toBe(false);
+    }
+  });
+
+  it('zip literal paths retain multi-input recursion and force-overwrite behavior', async () => {
+    mkdirSync(join(dir, 'zip-tree', 'nested'), { recursive: true });
+    writeFileSync(join(dir, 'zip-tree', 'nested', 'inside.txt'), 'inside\n', 'utf8');
+
+    const initial = await run('zip -r zip-shape.zip zip-tree fruits.txt');
+    expect(initial.exitCode).toBe(0);
+    const initialList = (await run('unzip -l zip-shape.zip')).stdout.replaceAll('\\', '/');
+    expect(initialList).toContain('zip-tree/nested/inside.txt');
+    expect(initialList).toContain('fruits.txt');
+
+    writeFileSync(join(dir, '[replacement].txt'), 'replacement\n', 'utf8');
+    const replaced = await run("zip zip-shape.zip '[replacement].txt'");
+    expect(replaced.exitCode).toBe(0);
+    const replacedList = (await run('unzip -l zip-shape.zip')).stdout.replaceAll('\\', '/');
+    expect(replacedList).toContain('[replacement].txt');
+    expect(replacedList).not.toContain('zip-tree/');
+    expect(replacedList).not.toContain('fruits.txt');
+  });
+
   it('printf CRLF without a trailing LF is preserved on redirect', async () => {
     const r = await run("printf 'a\\r\\nb' > cr.txt; wc -c cr.txt");
     expect(r.exitCode).toBe(0);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1574,6 +1574,13 @@ describe('CommandSpec archive leftovers (#143)', () => {
     expect(bodyOf('zip -Z a.zip f')).toContain("invalid option -- ''Z''");
   });
 
+  it('zip passes validated wildcard-looking operands as literal paths', () => {
+    const body = bodyOf("zip a.zip '*' '?' '[.]env'");
+    expect(body).toContain('Test-Path -LiteralPath $fx_p');
+    expect(body).toContain('Compress-Archive -LiteralPath $fx_valid');
+    expect(body).not.toContain('Compress-Archive -Path $fx_valid');
+  });
+
   it('unzip -l/-o/-d still translate; unknown flags fail', () => {
     expect(bodyOf('unzip -l a.zip')).toContain('OpenRead');
     expect(bodyOf('unzip -o a.zip')).toContain('-Force:$true');


### PR DESCRIPTION
## Problem

`zip` checks each input with `Test-Path -LiteralPath`, but then sends the accepted strings to `Compress-Archive -Path`. The second command treats wildcard-looking filenames differently from the validation step. For example, `[.]env` can select `.env`, and names containing `*`, `?`, or brackets are not stable end to end.

## Fix

Pass the already validated array through `Compress-Archive -LiteralPath` as well. This keeps the object checked by the handler identical to the object archived.

## Verification

- `[.]env` and `.env` with different contents are both archived and extracted exactly
- `[wild].txt` does not select `w.txt`
- literal `*` and `?` report name-not-matched and create no archive
- multi-input recursive archives retain their existing shape
- force-overwrite behavior remains unchanged
- npm ci
- npm run typecheck / build
- full suite: 321 passed, 1 opt-in oracle skipped
- npm run test:package
- Git Bash oracle: 125/126 identical (99.2%)
- git diff --check