### PR TITLE
feat: add an opt-in PowerShell 7 tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: windows-x64
+          - name: windows-x64-desktop
             runner: windows-2025
             node_arch: x64
-          - name: windows-arm64
+            fauxnix_ps: ''
+            edition: Desktop
+          - name: windows-x64-core
+            runner: windows-2025
+            node_arch: x64
+            fauxnix_ps: pwsh
+            edition: Core
+          - name: windows-arm64-desktop
             runner: windows-11-arm
             node_arch: arm64
+            fauxnix_ps: ''
+            edition: Desktop
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
+    env:
+      FAUXNIX_PS: ${{ matrix.fauxnix_ps }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -38,6 +49,15 @@ jobs:
           }
       - run: npm ci
       - run: npm run release:check
+      - name: Verify fauxnix selected the matrix host
+        shell: pwsh
+        run: |
+          $check = npm run dev -- check 2>&1 | Out-String
+          $check
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if ($check -notmatch 'edition\s+:\s+${{ matrix.edition }}') {
+            throw 'fauxnix check did not report the expected ${{ matrix.edition }} edition'
+          }
       - run: npm run typecheck
       - run: npm run build
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ npm install -g .
 
 Requires: Windows with PowerShell 5.1+ (built-in) and Node.js ≥ 18.
 
+PowerShell 7 is an opt-in, CI-tested tier:
+
+```powershell
+$env:FAUXNIX_PS = 'pwsh'
+fauxnix check                 # edition: Core
+```
+
+Set the variable before starting `fauxnix` or its MCP harness; restart the
+harness after changing it. Windows PowerShell 5.1 remains the default. Invalid
+values and a missing selected executable fail loudly rather than falling back.
+The default is pinned below `SystemRoot`; `pwsh.exe` is resolved once from
+absolute `PATH` directories, excluding the current working directory.
+See [PowerShell 7 support](docs/powershell-7.md).
+
 ## Quick start
 
 ```bash
@@ -209,7 +223,7 @@ Exit codes follow bash conventions: 0 ok, 1 fail, 2 usage/serious, 127 command n
 ## How it works
 
 ```
-bash command ──parser──▶ AST ──translator──▶ PowerShell script ──executor──▶ powershell.exe
+bash command ──parser──▶ AST ──translator──▶ PowerShell script ──executor──▶ selected PowerShell
                                                                               │
 agent ◀── GNU-style output, bash-style errors ◀── UTF-8 framed host protocol ◀┘
 ```
@@ -269,9 +283,10 @@ fauxnix optimizes for the commands agents actually run. Documented deviations:
 
 ## Development
 
-```bash
+```powershell
 npm install
 npm test          # unit + real-PowerShell integration suite (Windows only, auto-skipped elsewhere)
+$env:FAUXNIX_PS = 'pwsh'; npm test   # same suite through PowerShell 7
 npm run build
 npx tsx scratch/run.mjs "any bash command"   # quick live check
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,11 @@ lists sandboxing policy as a non-goal.
 ## Trust model
 
 - **Same user, same privileges.** `fauxnix` and `fauxnix mcp` spawn
-  `powershell.exe` as the logged-in user. Translated commands (`rm`,
+  the selected PowerShell host as the logged-in user. The default is
+  `%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe`;
+  process-level `FAUXNIX_PS=pwsh` selects an absolute `pwsh.exe` resolved from
+  eligible `PATH` entries.
+  Translated commands (`rm`,
   `chmod`, `kill`, …) and native passthrough (`git`, `node`, `npm`,
   `python`, `cargo`, … via `fx-native`) inherit that identity.
 - **No isolation.** There is no container, AppContainer, filesystem jail,
@@ -26,14 +30,24 @@ lists sandboxing policy as a non-goal.
 
 ## Host-protocol surface
 
-One `FauxnixSession` owns one resident `powershell.exe` 5.1 process
+One `FauxnixSession` owns one resident PowerShell process
 (`src/ps-host.ts`; RFC
 [`docs/rfc-persistent-powershell-host.md`](docs/rfc-persistent-powershell-host.md)).
+The selection is fixed when the session is constructed. Only the documented
+`powershell[.exe]` and `pwsh[.exe]` values are accepted; the variable is not a
+free-form command line or executable path. The 5.1 host uses its fixed
+`SystemRoot` path. PowerShell 7 resolution ignores empty and relative `PATH`
+entries and an entry equal to the process current directory, then fixes the
+first matching absolute path for the lifetime of the session. `PATH` remains
+process-startup configuration and its other absolute entries are honored in
+order. Host restarts do not search again. This prevents a checkout-local
+`powershell.exe` or `pwsh.exe` from winning normal Windows current-directory
+executable search.
 
 The host is started as:
 
 ```
-powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File <temp>/fauxnix-<id>-host.ps1
+<fixed/absolute-selected powershell.exe|pwsh.exe> -NoProfile -NonInteractive -ExecutionPolicy Bypass -File <temp>/fauxnix-<id>-host.ps1
 ```
 
 Frames are UTF-8 JSON lines on the process stdin/stdout pipes (raw
@@ -67,12 +81,12 @@ a host. Session sidecars live under `%TEMP%`
 ## Kill semantics
 
 Cancel and timeout **kill the host process**. The next `run()`
-cold-starts a new `powershell.exe`. This is the RFC #129 leftover:
+cold-starts a new process of the same selected edition. This is the RFC #129 leftover:
 per-frame runspace `Stop()` (roadmap B3) is not implemented.
 
 | Event | What happens |
 |---|---|
-| MCP `extra.signal` abort | `ChildProcess.kill()` on `powershell.exe`. Result: `cancelled: true`, exit **130**. Later list segments do not run. |
+| MCP `extra.signal` abort | `ChildProcess.kill()` on the selected PowerShell host. Result: `cancelled: true`, exit **130**. Later list segments do not run. |
 | `timeout_ms` / `ExecOptions.timeoutMs` (default 120s) | Same kill. Result: `timedOut: true`, exit **124**. |
 | `fauxnix_session reset` / `dispose()` | Kill host, unlink temp files. Reset re-prewarms the same session object. |
 | Stdio EOF / SIGINT / SIGTERM | Idempotent dispose. |

--- a/docs/powershell-7.md
+++ b/docs/powershell-7.md
@@ -1,0 +1,68 @@
+# PowerShell 7 support
+
+Windows PowerShell 5.1 remains fauxnix's built-in default. PowerShell 7 is an
+opt-in compatibility tier that runs the same unit, integration, package, and
+performance checks in CI.
+
+## Select PowerShell 7
+
+Install PowerShell 7 so `pwsh.exe` is in a non-empty, absolute `PATH` directory,
+then set the variable **before** starting fauxnix:
+
+```powershell
+$env:FAUXNIX_PS = 'pwsh'
+fauxnix check
+```
+
+`check` must report the resolved absolute `pwsh.exe` path and `edition : Core`.
+For an MCP integration,
+set `FAUXNIX_PS=pwsh` in the environment that launches the harness and restart
+the harness. Changing the variable inside a running fauxnix shell does not
+replace its resident host.
+
+Accepted values are case-insensitive:
+
+| `FAUXNIX_PS` | Selected host |
+|---|---|
+| unset or empty | fixed `%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe` (`Desktop`, default) |
+| `powershell` or `powershell.exe` | same fixed system executable (`Desktop`) |
+| `pwsh` or `pwsh.exe` | first eligible absolute `PATH` match (`Core`) |
+
+Any other value is a configuration error. If the requested executable is
+missing, `check`/`doctor` return nonzero and command execution exits 127 with
+recovery guidance; fauxnix never silently switches editions.
+
+The Desktop entries resolve only to
+`%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe`. The Core entry is
+resolved once from `PATH`, ignoring empty entries, relative entries, and an
+absolute entry equal to the current working directory. The resulting absolute
+path is fixed for the session, including host restarts. This deliberately avoids
+normal Windows current-directory executable search: placing a same-named EXE in
+the active checkout does not select it. Arbitrary executable paths remain
+unsupported. Other absolute `PATH` entries are still process-startup
+configuration and are honored in their declared order.
+
+## Compatibility contract
+
+- The bash surface, output framing, exit codes, timeout behavior, and native
+  argv path are the same on both editions. A difference is a bug unless it is
+  documented here.
+- PowerShell 7 is installed separately; Windows PowerShell 5.1 ships with
+  supported Windows versions.
+- Startup latency can differ by host version. The warm-host performance budgets
+  are identical and run against both editions in CI.
+- `FAUXNIX_NATIVE_ENCODING` remains an independent setting. Selecting `pwsh`
+  does not change its value or the documented native-tool encoding policy.
+- fauxnix supplies its fixed `-NoProfile -NonInteractive -ExecutionPolicy
+  Bypass` arguments. `FAUXNIX_PS` is an edition selector, not a place for extra
+  PowerShell arguments or an arbitrary executable path.
+
+Run the local matrix manually:
+
+```powershell
+Remove-Item Env:FAUXNIX_PS -ErrorAction SilentlyContinue
+npm test
+
+$env:FAUXNIX_PS = 'pwsh'
+npm test
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,12 @@ import { startMcpServer } from './mcp.js';
 import { collectDoctorReport } from './doctor.js';
 import { runInstall } from './install.js';
 import { packageVersion } from './version.js';
+import {
+  POWERSHELL_ARGS,
+  powerShellDisplay,
+  powerShellMissingMessage,
+  resolvePowerShell,
+} from './powershell.js';
 import './commands/install-all.js';
 
 export const USAGE = `fauxnix — run Linux-style commands on Windows via PowerShell translation
@@ -26,6 +32,7 @@ Usage:
   fauxnix --version
 
 Notes:
+  FAUXNIX_PS=pwsh selects the opt-in PowerShell 7 host (5.1 is the default).
   Unknown commands (git, node, npm, python, cargo, ...) pass through and run natively.`;
 
 export async function runCli(argv: string[]): Promise<void> {
@@ -103,35 +110,79 @@ export async function runCli(argv: string[]): Promise<void> {
   process.exit(result.exitCode);
 }
 
-const PS_ARGS = ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass'];
-
 async function runDoctor(): Promise<void> {
-  await runCheck();
+  const checkOk = await runCheck();
   const report = await collectDoctorReport();
   for (const line of report.lines) console.log(line);
-  if (!report.ok) process.exitCode = 1;
+  if (!checkOk || !report.ok) process.exitCode = 1;
 }
 
-async function runCheck(): Promise<void> {
-  console.log('powershell : powershell.exe (Windows built-in)');
-  const probeCmd = '$PSVersionTable.PSVersion.ToString()';
-  const probe = spawn('powershell.exe', [...PS_ARGS, '-EncodedCommand', encodeCommand(probeCmd)], {
-    stdio: ['ignore', 'pipe', 'pipe'],
-    windowsHide: true,
-  });
-  probe.on('error', (e) => {
-    console.error('status     : FAILED to run powershell.exe: ' + e.message);
-    process.exit(1);
-  });
-  let out = '';
-  probe.stdout.on('data', (d) => (out += d.toString('utf8')));
-  const code = await new Promise<number>((resolve) => probe.on('close', (c) => resolve(c ?? 1)));
-  if (code === 0) {
-    console.log('version    : ' + out.trim());
-    console.log('commands   : ' + registeredNames().length + ' translated, others pass through');
-    console.log('status     : OK');
-  } else {
-    console.error('status     : FAILED to run powershell.exe');
+export async function runCheck(): Promise<boolean> {
+  const selection = resolvePowerShell();
+  console.log('powershell : ' + powerShellDisplay(selection));
+  if (selection.error) {
+    console.error('status     : FAILED');
+    console.error(selection.error);
     process.exitCode = 1;
+    return false;
   }
+
+  const probeCmd =
+    '[Console]::Out.WriteLine($PSVersionTable.PSVersion.ToString()); ' +
+    '[Console]::Out.WriteLine([string]$PSVersionTable.PSEdition)';
+  const probe = spawn(
+    selection.executable,
+    [...POWERSHELL_ARGS, '-EncodedCommand', encodeCommand(probeCmd)],
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    },
+  );
+  let out = '';
+  let err = '';
+  probe.stdout.on('data', (d) => (out += d.toString('utf8')));
+  probe.stderr.on('data', (d) => (err += d.toString('utf8')));
+  const outcome = await new Promise<{ code: number; error?: NodeJS.ErrnoException }>((resolve) => {
+    let settled = false;
+    const done = (value: { code: number; error?: NodeJS.ErrnoException }) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    probe.once('error', (error: NodeJS.ErrnoException) => done({ code: 127, error }));
+    probe.once('close', (code) => done({ code: code ?? 1 }));
+  });
+  if (outcome.error) {
+    console.error('status     : FAILED');
+    if (outcome.error.code === 'ENOENT') {
+      console.error(powerShellMissingMessage(selection).trimEnd());
+    } else {
+      console.error(`fauxnix: failed to start ${selection.executable}: ${outcome.error.message}`);
+    }
+    process.exitCode = 1;
+    return false;
+  }
+  if (outcome.code !== 0) {
+    console.error(`status     : FAILED to run ${selection.executable}`);
+    if (err.trim()) console.error(err.trim());
+    process.exitCode = 1;
+    return false;
+  }
+
+  const lines = out.trim().split(/\r?\n/);
+  const version = lines[0] ?? '';
+  const edition = lines[1] ?? '';
+  console.log('version    : ' + version);
+  console.log('edition    : ' + edition);
+  if (edition !== selection.expectedEdition) {
+    console.error(
+      `status     : FAILED: ${selection.executable} reported ${edition || 'no edition'}; ` +
+        `expected ${selection.expectedEdition}`,
+    );
+    process.exitCode = 1;
+    return false;
+  }
+  console.log('commands   : ' + registeredNames().length + ' translated, others pass through');
+  console.log('status     : OK');
+  return true;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -48,7 +48,7 @@ function unescapeClixml(t: string): string {
 }
 
 /**
- * When stderr is redirected, powershell.exe serializes error records as
+ * When stderr is redirected, PowerShell can serialize error records as
  * CLIXML (`#< CLIXML` + XML). Unwrap the real message lines and drop
  * progress records, so agents see plain bash-style text.
  */

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -10,8 +10,8 @@ import {
   DEFAULT_STDERR_LIMIT,
   DEFAULT_STDOUT_LIMIT,
   PowerShellHost,
-  PS_MISSING_MESSAGE,
 } from './ps-host.js';
+import { PowerShellSelection, resolvePowerShell } from './powershell.js';
 
 export interface ExecResult {
   stdout: string;
@@ -245,9 +245,11 @@ export class FauxnixSession {
   private lifecycleLock: Promise<unknown> = Promise.resolve();
   /** True once `env` was loaded from the host's complete environment snapshot. */
   private hasEnvSnapshot = false;
+  private readonly powerShell: PowerShellSelection;
 
   constructor() {
     this.id = randomUUID().slice(0, 8);
+    this.powerShell = resolvePowerShell();
     this.bindFiles(this.id);
   }
 
@@ -292,12 +294,12 @@ export class FauxnixSession {
 
   private ensureHost(): PowerShellHost {
     if (!this.host) {
-      this.host = new PowerShellHost(this.hostFile, () => this.childEnv());
+      this.host = new PowerShellHost(this.hostFile, () => this.childEnv(), this.powerShell);
     }
     return this.host;
   }
 
-  /** Boot powershell.exe now so the first run() is not the 1.1s cold start. */
+  /** Boot the selected PowerShell now so the first run() is not a cold start. */
   prewarm(): Promise<void> {
     return this.withLock(async () => {
       await this.ensureHost().ready();
@@ -536,7 +538,7 @@ async function runPlans(
     );
 
     if (inv.spawnError === 'ENOENT' || inv.spawnError === 'START') {
-      stderr += inv.stderr.toString('utf8') || PS_MISSING_MESSAGE;
+      stderr += inv.stderr.toString('utf8') || 'fauxnix: failed to start the selected PowerShell host\n';
       exitCode = 127;
       spawnError = inv.spawnError;
       session.prevExit = exitCode;

--- a/src/powershell.ts
+++ b/src/powershell.ts
@@ -1,0 +1,178 @@
+import { existsSync } from 'node:fs';
+import { win32 } from 'node:path';
+
+export const POWERSHELL_ARGS = [
+  '-NoProfile',
+  '-NonInteractive',
+  '-ExecutionPolicy',
+  'Bypass',
+] as const;
+
+export type PowerShellEdition = 'Desktop' | 'Core';
+
+export interface PowerShellSelection {
+  /** Absolute executable path resolved once for this check/session. */
+  readonly executable: string;
+  readonly expectedEdition: PowerShellEdition;
+  readonly configured: boolean;
+  readonly requested?: string;
+  readonly error?: string;
+}
+
+export interface PowerShellResolveOptions {
+  cwd?: string;
+  exists?: (candidate: string) => boolean;
+}
+
+function envValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === name.toLowerCase());
+  return key === undefined ? undefined : env[key];
+}
+
+function comparableWindowsPath(value: string): string {
+  return win32.normalize(value).replace(/[\\/]+$/, '').toLowerCase();
+}
+
+function isFullyQualifiedWindowsPath(value: string): boolean {
+  return /^[a-z]:[\\/]/i.test(value) || /^\\\\[^\\/]+[\\/][^\\/]+/.test(value);
+}
+
+function unquotePathEntry(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function desktopSelection(
+  env: NodeJS.ProcessEnv,
+  configured: boolean,
+  requested: string | undefined,
+  exists: (candidate: string) => boolean,
+): PowerShellSelection {
+  const systemRoot = envValue(env, 'SystemRoot')?.trim();
+  if (!systemRoot || !/^[a-z]:[\\/]/i.test(systemRoot)) {
+    return {
+      executable: '',
+      expectedEdition: 'Desktop',
+      configured,
+      requested,
+      error:
+        'fauxnix: cannot resolve Windows PowerShell safely because SystemRoot is missing or not drive-absolute.',
+    };
+  }
+  const executable = win32.join(
+    systemRoot,
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe',
+  );
+  if (!exists(executable)) {
+    return {
+      executable,
+      expectedEdition: 'Desktop',
+      configured,
+      requested,
+      error: `fauxnix: Windows PowerShell not found at trusted system path ${executable}.`,
+    };
+  }
+  return { executable, expectedEdition: 'Desktop', configured, requested };
+}
+
+function coreSelection(
+  env: NodeJS.ProcessEnv,
+  requested: string,
+  cwd: string,
+  exists: (candidate: string) => boolean,
+): PowerShellSelection {
+  const cwdKey = win32.isAbsolute(cwd) ? comparableWindowsPath(cwd) : '';
+  const rawPath = envValue(env, 'PATH') ?? '';
+  const seen = new Set<string>();
+  for (const rawEntry of rawPath.split(';')) {
+    const directory = unquotePathEntry(rawEntry);
+    if (!directory || !isFullyQualifiedWindowsPath(directory)) continue;
+    const directoryKey = comparableWindowsPath(directory);
+    if (!directoryKey || directoryKey === cwdKey || seen.has(directoryKey)) continue;
+    seen.add(directoryKey);
+    const candidate = win32.join(directory, 'pwsh.exe');
+    if (exists(candidate)) {
+      return {
+        executable: candidate,
+        expectedEdition: 'Core',
+        configured: true,
+        requested,
+      };
+    }
+  }
+  return {
+    executable: '',
+    expectedEdition: 'Core',
+    configured: true,
+    requested,
+    error:
+      'fauxnix: pwsh.exe not found in eligible PATH entries ' +
+      '(absolute directories only; the current directory is excluded).',
+  };
+}
+
+/**
+ * Select the process-wide PowerShell host. FAUXNIX_PS is intentionally a
+ * small enum, not a command line: spawn() receives one executable and the
+ * fixed fauxnix arguments separately.
+ */
+export function resolvePowerShell(
+  env: NodeJS.ProcessEnv = process.env,
+  options: PowerShellResolveOptions = {},
+): PowerShellSelection {
+  const requested = envValue(env, 'FAUXNIX_PS')?.trim();
+  const exists = options.exists ?? existsSync;
+  const cwd = options.cwd ?? process.cwd();
+  if (!requested) {
+    return desktopSelection(env, false, undefined, exists);
+  }
+
+  switch (requested.toLowerCase()) {
+    case 'powershell':
+    case 'powershell.exe':
+      return desktopSelection(env, true, requested, exists);
+    case 'pwsh':
+    case 'pwsh.exe':
+      return coreSelection(env, requested, cwd, exists);
+    default:
+      return {
+        executable: '',
+        expectedEdition: 'Desktop',
+        configured: true,
+        requested,
+        error:
+          `fauxnix: invalid FAUXNIX_PS=${JSON.stringify(requested)}; ` +
+          'expected "powershell" or "pwsh". Unset it to use Windows PowerShell 5.1.',
+      };
+  }
+}
+
+export function powerShellDisplay(selection: PowerShellSelection): string {
+  if (selection.error) {
+    if (selection.requested === undefined) return 'unresolved default Windows PowerShell';
+    return `unresolved selection (FAUXNIX_PS=${JSON.stringify(selection.requested)})`;
+  }
+  if (!selection.configured) return `${selection.executable} (default, trusted system path)`;
+  return `${selection.executable} (FAUXNIX_PS=${selection.requested}, resolved once)`;
+}
+
+export function powerShellMissingMessage(selection: PowerShellSelection): string {
+  if (selection.expectedEdition === 'Core') {
+    return (
+      'fauxnix: pwsh.exe not found in eligible absolute PATH entries — FAUXNIX_PS=pwsh selects PowerShell 7.\n' +
+      'Install PowerShell 7 in an absolute PATH directory outside the current working directory, ' +
+      'or unset FAUXNIX_PS ' +
+      'to use Windows PowerShell 5.1.\n'
+    );
+  }
+  return (
+    `fauxnix: Windows PowerShell not found at ${selection.executable || 'the trusted SystemRoot path'}.\n` +
+    'Run fauxnix on Windows, or set FAUXNIX_PS=pwsh after installing PowerShell 7 in an eligible absolute PATH directory.\n'
+  );
+}

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -1,14 +1,14 @@
 import { spawn, ChildProcess } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { hostBootstrapScript } from './translator.js';
+import {
+  POWERSHELL_ARGS,
+  PowerShellSelection,
+  powerShellMissingMessage,
+  resolvePowerShell,
+} from './powershell.js';
 
-const PS_ARGS = ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass'];
 const READY_TIMEOUT_MS = 30_000;
-
-export const PS_MISSING_MESSAGE =
-  'fauxnix: powershell.exe not found — fauxnix executes bash via native Windows PowerShell 5.1+.\n' +
-  'This host has no PowerShell on PATH (typical for Linux containers/sandboxes).\n' +
-  'Run fauxnix on Windows, or install PowerShell and make powershell.exe reachable on PATH.\n';
 
 export const DEFAULT_STDOUT_LIMIT = 8_388_608;
 export const DEFAULT_STDERR_LIMIT = 1_048_576;
@@ -100,9 +100,9 @@ export function decodeHostResponse(line: string): {
 }
 
 /**
- * One resident powershell.exe 5.1 process. Frames are UTF-8 JSON lines;
- * command stdout/stderr come back as base64 so PS 5.1's UTF-16LE pipe
- * encoding cannot scramble the payload.
+ * One resident selected PowerShell process. Frames are UTF-8 JSON lines;
+ * command stdout/stderr come back as base64 so Windows PowerShell 5.1's
+ * UTF-16LE pipe encoding cannot scramble the payload.
  */
 export class PowerShellHost {
   private proc: ChildProcess | null = null;
@@ -123,6 +123,7 @@ export class PowerShellHost {
   constructor(
     private readonly hostFile: string,
     private readonly envFn: () => NodeJS.ProcessEnv,
+    private readonly powerShell: PowerShellSelection = resolvePowerShell(),
   ) {}
 
   /** Start the resident process and wait for the ready handshake (B1 prewarm). */
@@ -158,7 +159,7 @@ export class PowerShellHost {
     const proc = this.proc;
     this.proc = null;
     this.closed = true;
-    this.failWaiters(new Error('fauxnix: powershell host stopped'));
+    this.failWaiters(new Error('fauxnix: PowerShell host stopped'));
     if (!proc) return;
     try {
       proc.stdin?.end();
@@ -269,7 +270,7 @@ export class PowerShellHost {
       if (this.closeErr && (this.closeErr as NodeJS.ErrnoException).code === 'ENOENT') {
         return {
           stdout: Buffer.alloc(0),
-          stderr: Buffer.from(PS_MISSING_MESSAGE, 'utf8'),
+          stderr: Buffer.from(powerShellMissingMessage(this.powerShell), 'utf8'),
           exitCode: 127,
           timedOut: false,
           cancelled: false,
@@ -297,6 +298,18 @@ export class PowerShellHost {
   }
 
   private async ensureStarted(): Promise<HostInvokeResult | null> {
+    if (this.powerShell.error) {
+      return {
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.from(this.powerShell.error + '\n', 'utf8'),
+        exitCode: 127,
+        timedOut: false,
+        cancelled: false,
+        truncated: false,
+        spawnError: 'START',
+        spawnMessage: this.powerShell.error,
+      };
+    }
     if (this.proc && !this.closed) return null;
     if (!this.startLock) this.startLock = this.start();
     try {
@@ -307,7 +320,7 @@ export class PowerShellHost {
       if (err.code === 'ENOENT') {
         return {
           stdout: Buffer.alloc(0),
-          stderr: Buffer.from(PS_MISSING_MESSAGE, 'utf8'),
+          stderr: Buffer.from(powerShellMissingMessage(this.powerShell), 'utf8'),
           exitCode: 127,
           timedOut: false,
           cancelled: false,
@@ -318,7 +331,7 @@ export class PowerShellHost {
       return {
         stdout: Buffer.alloc(0),
         stderr: Buffer.from(
-          'fauxnix: failed to start powershell.exe: ' + err.message + '\n',
+          'fauxnix: failed to start ' + this.powerShell.executable + ': ' + err.message + '\n',
           'utf8',
         ),
         exitCode: 127,
@@ -347,7 +360,7 @@ export class PowerShellHost {
     await this.deadRestart();
     this.closed = false;
     writeFileSync(this.hostFile, '\ufeff' + hostBootstrapScript(), 'utf8');
-    const child = spawn('powershell.exe', [...PS_ARGS, '-File', this.hostFile], {
+    const child = spawn(this.powerShell.executable, [...POWERSHELL_ARGS, '-File', this.hostFile], {
       env: this.envFn(),
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1151,7 +1151,7 @@ export function translatePipelineBody(p: {
 
 export interface SegmentPlan {
   op: ';' | '&&' | '||';
-  /** Spawn-mode wrapScript (CLI/MCP `translate`, one-shot powershell.exe). */
+  /** Spawn-mode wrapScript (`translate` output for a one-shot PowerShell process). */
   script: string;
   /** Pipeline body before wrapScript — executor host mode re-wraps this. */
   body: string;
@@ -1822,7 +1822,7 @@ function wrapHelperCatalog(): Record<WrapHelper, string[]> {
 
 /**
  * Resident-host bootstrap: encoding + full fx-* catalog + JSON-line RPC loop.
- * Loaded once via `powershell.exe -File`. Must never `exit` a successful frame.
+ * Loaded once via the selected PowerShell's `-File`. Must never `exit` a successful frame.
  */
 export function hostBootstrapScript(): string {
   const helpers = wrapHelperCatalog();

--- a/test/differential/run.ts
+++ b/test/differential/run.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { parseCommand } from '../../src/parser.js';
 import { translateCommandList } from '../../src/translator.js';
 import { FauxnixSession } from '../../src/executor.js';
+import { resolvePowerShell } from '../../src/powershell.js';
 import '../../src/commands/install-all.js';
 
 export interface CorpusCase {
@@ -90,14 +91,18 @@ export function resolveGitBash(env: NodeJS.ProcessEnv = process.env): string | n
   return null;
 }
 
-export function hasPowerShell(): boolean {
+export function hasPowerShell(env: NodeJS.ProcessEnv = process.env): boolean {
   if (process.platform !== 'win32') return false;
-  return spawnSync('powershell.exe', ['-NoProfile', '-Command', 'exit 0'], { shell: false }).status === 0;
+  const selection = resolvePowerShell(env);
+  if (selection.error) return false;
+  return (
+    spawnSync(selection.executable, ['-NoProfile', '-Command', 'exit 0'], { shell: false }).status === 0
+  );
 }
 
 /** Oracle runs only when requested *and* git-bash bash.exe is present (and we can execute). */
 export function canRunOracle(env: NodeJS.ProcessEnv = process.env): boolean {
-  return isOracleRequested(env) && resolveGitBash(env) !== null && hasPowerShell();
+  return isOracleRequested(env) && resolveGitBash(env) !== null && hasPowerShell(env);
 }
 
 export function oracleSkipReason(env: NodeJS.ProcessEnv = process.env): string | null {
@@ -107,8 +112,10 @@ export function oracleSkipReason(env: NodeJS.ProcessEnv = process.env): string |
   if (resolveGitBash(env) === null) {
     return 'FAUXNIX_DIFF_ORACLE is set but git-bash bash.exe was not found';
   }
-  if (!hasPowerShell()) {
-    return 'PowerShell is unavailable; fauxnix execution is Windows-only';
+  const selection = resolvePowerShell(env);
+  if (selection.error) return selection.error;
+  if (!hasPowerShell(env)) {
+    return `${selection.executable} is unavailable; check FAUXNIX_PS or install the selected host`;
   }
   return null;
 }

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -1,6 +1,6 @@
 /**
- * Integration tests — execute translated commands through real Windows
- * PowerShell 5.1. Skipped automatically on non-Windows platforms.
+ * Integration tests — execute translated commands through the selected real
+ * Windows PowerShell host. Skipped automatically on non-Windows platforms.
  */
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
 import { getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -11,14 +11,18 @@ import { join } from 'node:path';
 import { parseCommand } from '../src/parser.js';
 import { translateCommandList } from '../src/translator.js';
 import { FauxnixSession } from '../src/executor.js';
+import { resolvePowerShell } from '../src/powershell.js';
 import '../src/commands/install-all.js';
 
 const onWindows = process.platform === 'win32';
+const selectedPowerShell = resolvePowerShell();
 const hasPs =
   onWindows &&
-  spawnSync('powershell.exe', ['-NoProfile', '-Command', 'exit 0'], { shell: false }).status === 0;
+  !selectedPowerShell.error &&
+  spawnSync(selectedPowerShell.executable, ['-NoProfile', '-Command', 'exit 0'], { shell: false })
+    .status === 0;
 
-describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () => {
+describe.skipIf(!hasPs)(`integration (real ${selectedPowerShell.executable})`, { timeout: 30000 }, () => {
   let dir: string;
   let session: FauxnixSession;
 

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -35,7 +35,17 @@ import {
   PYTHON3_WINDOWS_HINT,
   SH_SCRIPT_WINDOWS_HINT,
 } from '../src/errors.js';
-import { decodeHostResponse, encodeHostRequest, parseHostLine } from '../src/ps-host.js';
+import {
+  decodeHostResponse,
+  encodeHostRequest,
+  parseHostLine,
+  PowerShellHost,
+} from '../src/ps-host.js';
+import {
+  powerShellDisplay,
+  powerShellMissingMessage,
+  resolvePowerShell,
+} from '../src/powershell.js';
 import { packageVersion } from '../src/version.js';
 import {
   bashToolResult,
@@ -2050,13 +2060,108 @@ describe('MCP structured results (#129)', () => {
   });
 });
 
-describe('cli check spawn error', () => {
-  it('runCheck attaches an error listener so missing powershell.exe prints FAILED', () => {
+describe('PowerShell host selection', () => {
+  const desktopPath = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+  const corePath = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe';
+  const found = (candidate: string) => candidate === desktopPath || candidate === corePath;
+
+  it('defaults empty and unset FAUXNIX_PS to Windows PowerShell 5.1', () => {
+    const env = { SystemRoot: 'C:\\Windows' };
+    expect(resolvePowerShell(env, { exists: found })).toEqual({
+      executable: desktopPath,
+      expectedEdition: 'Desktop',
+      configured: false,
+    });
+    expect(resolvePowerShell({ ...env, FAUXNIX_PS: '  ' }, { exists: found }).executable).toBe(
+      desktopPath,
+    );
+    expect(powerShellDisplay(resolvePowerShell(env, { exists: found }))).toContain(
+      'default, trusted system path',
+    );
+  });
+
+  it('accepts only the documented powershell and pwsh aliases', () => {
+    const desktop = resolvePowerShell(
+      { SystemRoot: 'C:\\Windows', FAUXNIX_PS: ' PowerShell ' },
+      { exists: found },
+    );
+    expect(desktop).toMatchObject({
+      executable: desktopPath,
+      expectedEdition: 'Desktop',
+    });
+    expect(desktop.error).toBeUndefined();
+    const core = resolvePowerShell(
+      { FAUXNIX_PS: ' PwSh.ExE ', PATH: 'C:\\Program Files\\PowerShell\\7' },
+      { cwd: 'D:\\repo', exists: found },
+    );
+    expect(core).toMatchObject({
+      executable: corePath,
+      expectedEdition: 'Core',
+    });
+    expect(core.error).toBeUndefined();
+    const bad = resolvePowerShell({ FAUXNIX_PS: 'pwsh -NoLogo' });
+    expect(bad.error).toMatch(/invalid FAUXNIX_PS/);
+    expect(bad.error).toMatch(/expected "powershell" or "pwsh"/);
+    expect(resolvePowerShell({ FAUXNIX_PS: corePath }).error).toMatch(/invalid FAUXNIX_PS/);
+  });
+
+  it('never resolves pwsh from empty, relative, or current-directory PATH entries', () => {
+    const malicious = 'D:\\repo\\pwsh.exe';
+    const rooted = '\\repo-bin\\pwsh.exe';
+    const existing = new Set([malicious, rooted, corePath].map((candidate) => candidate.toLowerCase()));
+    const core = resolvePowerShell(
+      {
+        FAUXNIX_PS: 'pwsh',
+        Path: ';.;relative-bin;\\repo-bin;D:\\repo\\.;"C:\\Program Files\\PowerShell\\7"',
+      },
+      {
+        cwd: 'D:\\repo',
+        exists: (candidate) => existing.has(candidate.toLowerCase()),
+      },
+    );
+    expect(core.error).toBeUndefined();
+    expect(core.executable).toBe(corePath);
+    expect(core.executable).not.toBe(malicious);
+  });
+
+  it('fails loudly when trusted resolution cannot find the requested host', () => {
+    const desktop = resolvePowerShell(
+      { SystemRoot: 'relative-windows' },
+      { exists: () => false },
+    );
+    expect(desktop.error).toMatch(/SystemRoot is missing or not drive-absolute/);
+    const core = resolvePowerShell(
+      { FAUXNIX_PS: 'pwsh', PATH: ';.;D:\\repo' },
+      { cwd: 'D:\\repo', exists: () => true },
+    );
+    expect(core.executable).toBe('');
+    expect(core.error).toMatch(/pwsh\.exe not found in eligible PATH entries/);
+  });
+
+  it('gives selected-host recovery guidance without silent fallback', () => {
+    const pwsh = resolvePowerShell(
+      { FAUXNIX_PS: 'pwsh', PATH: '' },
+      { cwd: 'D:\\repo', exists: () => false },
+    );
+    expect(powerShellMissingMessage(pwsh)).toContain('pwsh.exe not found');
+    expect(powerShellMissingMessage(pwsh)).toContain('unset FAUXNIX_PS');
+  });
+
+  it('returns a loud host failure for an invalid FAUXNIX_PS without spawning', async () => {
+    const selection = resolvePowerShell({ FAUXNIX_PS: 'pwsh -NoLogo' });
+    const host = new PowerShellHost(join(tmpdir(), 'fauxnix-invalid-ps-host.ps1'), () => ({}), selection);
+    const result = await host.ready();
+    expect(result?.spawnError).toBe('START');
+    expect(result?.exitCode).toBe(127);
+    expect(result?.stderr.toString('utf8')).toMatch(/invalid FAUXNIX_PS/);
+  });
+
+  it('runCheck attaches an error listener so a missing selected host fails cleanly', () => {
     const src = readFileSync('src/cli.ts', 'utf8');
     const check = src.slice(src.indexOf('async function runCheck'));
-    expect(check).toContain("probe.on('error'");
-    expect(check).toMatch(/FAILED to run powershell\.exe:.*e\.message/);
-    expect(check).toContain('process.exit(1)');
+    expect(check).toContain("probe.once('error'");
+    expect(check).toContain('powerShellMissingMessage(selection)');
+    expect(check).toContain('process.exitCode = 1');
   });
 });
 
@@ -2767,6 +2872,8 @@ describe.skipIf(process.platform !== 'win32')('cli doctor spawn', () => {
     });
     expect(r.error).toBeUndefined();
     expect(r.stdout).toContain('powershell');
+    expect(r.stdout).toContain('edition');
+    expect(r.stdout).toContain(resolvePowerShell(process.env).expectedEdition);
     expect(r.stdout).toContain('encoding');
     expect(r.stdout).toContain('FAUXNIX_NATIVE_ENCODING');
     expect(r.stdout).toContain('start with: fauxnix mcp');


### PR DESCRIPTION
## Summary

Implements roadmap U-5 as an explicit, opt-in PowerShell 7 tier.

```powershell
$env:FAUXNIX_PS = 'pwsh'
fauxnix check   # edition: Core
```

Windows PowerShell 5.1 remains the default. The selection is fixed when a `FauxnixSession` is constructed; changing it requires restarting the CLI/MCP process.

## Host selection contract

- accept only `powershell[.exe]` and `pwsh[.exe]`, never a free-form command line or path
- resolve the 5.1 default at the fixed SystemRoot PowerShell location
- resolve `pwsh.exe` once from non-empty absolute PATH directories, excluding cwd/relative entries
- reuse the same absolute path across prewarm and transparent host restarts
- fail loudly on an invalid value or missing selected host; never silently fall back to a different edition
- `check` reports and verifies both version and PSEdition

## CI and verification

- two edition lanes: Windows PowerShell 5.1 / Desktop and PowerShell 7 / Core
- the job asserts the selected edition before running the suite
- PS 5.1: 325/325 tests; package smoke passed
- PowerShell 7.6.4: 325/325 tests; package smoke passed
- Git Bash oracle on both editions: 125/126 identical (99.2%)
- cwd/empty/relative PATH candidates, missing hosts, aliases, and free-form values covered
- typecheck/build/git diff --check passed

## Composition with U-6

#197 is independently green on x64 and ARM64. Whichever PR lands second must keep both dimensions: at minimum x64/Desktop, x64/Core, and ARM64/Desktop. The workflow comment makes that merge requirement explicit rather than silently dropping one matrix.

Roadmap: #118, U-5.