### PR TITLE
fix: pin the Qwen launcher to this installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ TOML config: `~/.kimi-code/mcp.json`
 ```
 
 **Qwen Code** (`~/.qwen/settings.json`)
-```json
-{
-  "mcpServers": {
-    "fauxnix": { "command": "fauxnix", "args": ["mcp"] }
-  }
-}
+```bash
+fauxnix install --qwen
 ```
+The installer preserves the rest of `settings.json` and writes an absolute
+Node + package-entry launcher so Qwen startup does not depend on its working
+directory or `PATH` order. See [the Qwen example](docs/examples/qwen.md) for
+the generated JSON shape.
 
 **Any MCP client** — stdio server: `fauxnix mcp`. The tool name is `bash` (override with
 `FAUXNIX_TOOL_NAME`). Tool description already teaches the model the supported subset, so no

--- a/docs/examples/qwen.md
+++ b/docs/examples/qwen.md
@@ -11,22 +11,32 @@ fauxnix is a bash→PowerShell translation layer for AI agents on Windows — no
 
 ## Install
 
-Preferred (idempotent; writes the same keys as the block below):
+Preferred (idempotent):
 
 ```bash
 fauxnix install --qwen
 ```
 
-If `install` is not in your build, paste the block by hand.
+The installer writes an absolute launcher for the Node executable and this
+fauxnix installation's `dist/index.js`. That keeps Qwen Code startup independent
+of its working directory and `PATH` order. Re-run the installer after moving or
+reinstalling Node.js or fauxnix-cli.
 
 **Path:** `%USERPROFILE%\.qwen\settings.json`
 
-Merge `mcpServers.fauxnix`; do not wipe other keys.
+The generated shape is shown below. Paths are examples; use the values written
+by `fauxnix install --qwen` rather than copying them from another machine.
 
 ```json
 {
   "mcpServers": {
-    "fauxnix": { "command": "fauxnix", "args": ["mcp"] }
+    "fauxnix": {
+      "command": "C:\\Program Files\\nodejs\\node.exe",
+      "args": [
+        "C:\\Users\\you\\AppData\\Roaming\\npm\\node_modules\\fauxnix-cli\\dist\\index.js",
+        "mcp"
+      ]
+    }
   }
 }
 ```
@@ -38,7 +48,9 @@ fauxnix check
 fauxnix doctor
 ```
 
-Encoding is UTF-8 by default (`FAUXNIX_NATIVE_ENCODING` unset). v0.10.0 `doctor` does not list a qwen row; it still confirms PowerShell, encoding, and `mcp : module loads`. Restart Qwen Code so it reloads MCP.
+Encoding is UTF-8 by default (`FAUXNIX_NATIVE_ENCODING` unset). `doctor` reports
+whether Qwen's fauxnix entry uses the generated absolute launcher. Restart Qwen
+Code so it reloads MCP.
 
 ## Smoke
 

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -7,6 +7,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, delimiter, dirname, join, resolve } from 'node:path';
@@ -63,7 +64,7 @@ const temporaryRoot = mkdtempSync(join(tmpdir(), 'fauxnix-package-smoke-'));
 const sourceDirectory = join(temporaryRoot, 'source');
 const sourceInstallDirectory = join(temporaryRoot, 'source-install');
 const packDirectory = join(temporaryRoot, 'pack');
-const installDirectory = join(temporaryRoot, 'install');
+const installDirectory = join(temporaryRoot, 'installed package with spaces');
 
 try {
   mkdirSync(sourceDirectory);
@@ -105,9 +106,10 @@ try {
     process.platform === 'win32'
       ? join(sourceInstallDirectory, 'fauxnix.cmd')
       : join(sourceInstallDirectory, 'bin', 'fauxnix');
+  const globalCliEntry = join(globalPackageRoot, 'dist', 'index.js');
   assert.ok(existsSync(sourceCliEntry), 'installing clean source should build dist/index.js');
   assert.ok(
-    existsSync(join(globalPackageRoot, 'dist', 'index.js')),
+    existsSync(globalCliEntry),
     'global source install should expose dist/index.js',
   );
   assert.ok(existsSync(globalCliShim), 'global source install should expose the fauxnix executable');
@@ -144,6 +146,73 @@ try {
   );
   assert.equal(version, `fauxnix ${metadata.version}`);
 
+  const qwenHome = join(temporaryRoot, 'qwen home');
+  const qwenWorkspace = join(temporaryRoot, 'qwen workspace');
+  mkdirSync(qwenHome);
+  mkdirSync(qwenWorkspace);
+  const wrongLauncherMarker = join(qwenWorkspace, 'wrong-launcher.txt');
+  writeFileSync(
+    join(qwenWorkspace, 'fauxnix.cmd'),
+    `@echo off\r\n>"${wrongLauncherMarker}" echo wrong\r\nexit /b 0\r\n`,
+  );
+  const qwenEnvironment = {
+    ...cleanEnvironment,
+    HOME: qwenHome,
+    USERPROFILE: qwenHome,
+  };
+  const qwenPathKey =
+    Object.keys(qwenEnvironment).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+  qwenEnvironment[qwenPathKey] =
+    qwenWorkspace + delimiter + (qwenEnvironment[qwenPathKey] ?? '');
+  const qwenInstall = run(process.execPath, [cliEntry, 'install', '--qwen'], {
+    cwd: qwenWorkspace,
+    env: qwenEnvironment,
+  });
+  assert.match(qwenInstall, /qwen: created/);
+  const qwenConfig = JSON.parse(
+    readFileSync(join(qwenHome, '.qwen', 'settings.json'), 'utf8'),
+  );
+  const qwenServer = qwenConfig.mcpServers.fauxnix;
+  assert.equal(qwenServer.command, process.execPath);
+  assert.deepEqual(qwenServer.args, [cliEntry, 'mcp']);
+  assert.match(qwenServer.args[0], /installed package with spaces/);
+  run(qwenServer.command, qwenServer.args, {
+    cwd: qwenWorkspace,
+    env: qwenEnvironment,
+  });
+  const qwenVersion = run(qwenServer.command, [qwenServer.args[0], '--version'], {
+    cwd: qwenWorkspace,
+    env: qwenEnvironment,
+  });
+  assert.equal(qwenVersion, `fauxnix ${metadata.version}`);
+  assert.equal(existsSync(wrongLauncherMarker), false);
+
+  const globalQwenHome = join(temporaryRoot, 'global qwen home');
+  mkdirSync(globalQwenHome);
+  const globalQwenEnvironment = {
+    ...qwenEnvironment,
+    HOME: globalQwenHome,
+    USERPROFILE: globalQwenHome,
+  };
+  run(process.execPath, [globalCliEntry, 'install', '--qwen'], {
+    cwd: qwenWorkspace,
+    env: globalQwenEnvironment,
+  });
+  const globalQwenConfig = JSON.parse(
+    readFileSync(join(globalQwenHome, '.qwen', 'settings.json'), 'utf8'),
+  );
+  assert.deepEqual(globalQwenConfig.mcpServers.fauxnix, {
+    command: process.execPath,
+    // `npm install -g <local-dir>` links the package, and Node resolves the
+    // module URL to the source tree's real path. Registry installs are copied.
+    args: [sourceCliEntry, 'mcp'],
+  });
+  run(
+    globalQwenConfig.mcpServers.fauxnix.command,
+    globalQwenConfig.mcpServers.fauxnix.args,
+    { cwd: qwenWorkspace, env: globalQwenEnvironment },
+  );
+
   const translation = runNpm(
     [
       'exec',
@@ -163,6 +232,7 @@ try {
   console.log(`clean source install passed: ${sourceVersion}`);
   console.log(`package smoke passed: ${basename(tarball)}`);
   console.log(`  ${version}`);
+  console.log('Qwen absolute launcher passed from a workspace-local fauxnix shim');
 } finally {
   const temporaryParent = dirname(temporaryRoot);
   assert.equal(temporaryParent, tmpdir(), 'refusing to clean a non-temporary path');

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { resolveQwenLaunchTuple, sameQwenLaunchTuple } from './qwen-launch.js';
 
 export type DoctorOptions = {
   home?: string;
@@ -30,6 +31,7 @@ export async function collectDoctorReport(opts: DoctorOptions = {}): Promise<Doc
   lines.push(field('claude', detectClaude(home, cwd, env)));
   lines.push(field('codex', detectCodex(home, env)));
   lines.push(field('opencode', detectOpenCode(home, env)));
+  lines.push(field('qwen', detectQwen(home)));
   lines.push('');
 
   const mcp = await mcpLines(nodeVersion, opts.loadMcp);
@@ -176,6 +178,39 @@ function detectOpenCode(home: string, env: NodeJS.ProcessEnv): string {
   return `found ${path}, fauxnix MCP not listed — add mcp.fauxnix (see README)`;
 }
 
+function detectQwen(home: string): string {
+  const path = join(home, '.qwen', 'settings.json');
+  if (!existsSync(path)) return 'not detected — see README';
+  const text = readText(path);
+  if (text === undefined) return `found ${path} (unreadable) — see README`;
+  let data: unknown;
+  try {
+    data = JSON.parse(stripBom(text));
+  } catch {
+    return `found ${path} (unreadable JSON) — see README`;
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return `found ${path} (not a JSON object) — see README`;
+  }
+  const servers = (data as Record<string, unknown>).mcpServers;
+  if (!isServerMap(servers)) {
+    return `found ${path}, fauxnix MCP not listed — run: fauxnix install --qwen`;
+  }
+  const extraNames = fauxnixServerNames(servers).filter((name) => name !== 'fauxnix');
+  if (extraNames.length) {
+    return `found ${path}, additional fauxnix MCP entries (${extraNames.join(', ')}) — remove them, then run: fauxnix install --qwen`;
+  }
+  const config = (servers as Record<string, unknown>).fauxnix;
+  const expected = resolveQwenLaunchTuple();
+  if (expected.ok && sameQwenLaunchTuple(config, expected.value)) {
+    return `fauxnix MCP configured with an absolute launcher (${path})`;
+  }
+  if (config != null || serverMapHasFauxnix(servers)) {
+    return `found ${path}, fauxnix MCP launcher does not match this installation — run: fauxnix install --qwen`;
+  }
+  return `found ${path}, fauxnix MCP not listed — run: fauxnix install --qwen`;
+}
+
 export function hasOpenCodeFauxnix(data: unknown): boolean {
   if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
   const mcp = (data as Record<string, unknown>).mcp;
@@ -190,12 +225,17 @@ export function isServerMap(value: unknown): boolean {
 }
 
 export function serverMapHasFauxnix(value: unknown): boolean {
-  if (!isServerMap(value)) return false;
+  return fauxnixServerNames(value).length > 0;
+}
+
+export function fauxnixServerNames(value: unknown): string[] {
+  if (!isServerMap(value)) return [];
+  const names: string[] = [];
   for (const [name, cfg] of Object.entries(value as Record<string, unknown>)) {
     if (name === 'servers') continue;
-    if (looksLikeFauxnixServer(name, cfg)) return true;
+    if (looksLikeFauxnixServer(name, cfg)) names.push(name);
   }
-  return false;
+  return names;
 }
 
 function looksLikeFauxnixServer(name: string, cfg: unknown): boolean {

--- a/src/install.ts
+++ b/src/install.ts
@@ -4,12 +4,14 @@ import { dirname, join } from 'node:path';
 import {
   claudeUserConfigPath,
   codexConfigPath,
+  fauxnixServerNames,
   hasCodexFauxnix,
   hasOpenCodeFauxnix,
   isServerMap,
   openCodeConfigPath,
   serverMapHasFauxnix,
 } from './doctor.js';
+import { resolveQwenLaunchTuple, sameQwenLaunchTuple } from './qwen-launch.js';
 
 export type InstallOptions = {
   home?: string;
@@ -111,8 +113,56 @@ function installHarness(name: HarnessName, ctx: Ctx): One {
     case 'kimi':
       return patchMcpServers(kimiConfigPath(ctx.home, ctx.env), 'kimi');
     case 'qwen':
-      return patchMcpServers(qwenConfigPath(ctx.home, ctx.env), 'qwen');
+      return patchQwen(qwenConfigPath(ctx.home, ctx.env));
   }
+}
+
+function patchQwen(path: string): One {
+  const launch = resolveQwenLaunchTuple();
+  if (!launch.ok) return { ok: false, line: `qwen: ${launch.reason} — not modified` };
+
+  const read = readJsonObject(path);
+  if (read.state === 'invalid') {
+    return { ok: false, line: `qwen: ${path} is ${read.reason} — not modified` };
+  }
+  const existed = read.state !== 'missing';
+  const data = read.state === 'ok' ? read.data : {};
+  if (data.mcpServers != null && !isServerMap(data.mcpServers)) {
+    return { ok: false, line: `qwen: ${path} mcpServers is not an object — not modified` };
+  }
+  if (!isServerMap(data.mcpServers)) data.mcpServers = {};
+
+  const servers = data.mcpServers as Record<string, unknown>;
+  const extraNames = fauxnixServerNames(servers).filter((name) => name !== 'fauxnix');
+  if (extraNames.length) {
+    return {
+      ok: false,
+      line: `qwen: ${path} has another fauxnix MCP entry (${extraNames.join(', ')}) — remove the extra entry, then retry; not modified`,
+    };
+  }
+  const current = servers.fauxnix;
+  if (current != null && !isServerMap(current)) {
+    return {
+      ok: false,
+      line: `qwen: ${path} mcpServers.fauxnix is not an object — not modified`,
+    };
+  }
+  if (sameQwenLaunchTuple(current, launch.value)) {
+    return { ok: true, line: `qwen: already configured with an absolute launcher (${path})` };
+  }
+
+  servers.fauxnix = {
+    ...(isServerMap(current) ? (current as Record<string, unknown>) : {}),
+    command: launch.value.command,
+    args: [...launch.value.args],
+  };
+  return writeJson(
+    path,
+    data,
+    'qwen',
+    existed,
+    current == null ? 'added mcpServers.fauxnix' : 'updated mcpServers.fauxnix launcher',
+  );
 }
 
 function patchMcpServers(path: string, harness: HarnessName): One {

--- a/src/qwen-launch.ts
+++ b/src/qwen-launch.ts
@@ -1,0 +1,36 @@
+import { existsSync } from 'node:fs';
+import { isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type QwenLaunchTuple = { command: string; args: string[] };
+
+export function resolveQwenLaunchTuple():
+  | { ok: true; value: QwenLaunchTuple }
+  | { ok: false; reason: string } {
+  const command = process.execPath;
+  const entry = fileURLToPath(new URL('../dist/index.js', import.meta.url));
+  if (!isAbsolute(command) || !existsSync(command)) {
+    return {
+      ok: false,
+      reason: 'cannot locate the Node.js executable; reinstall Node.js, then retry `fauxnix install --qwen`',
+    };
+  }
+  if (!isAbsolute(entry) || !existsSync(entry)) {
+    return {
+      ok: false,
+      reason: `cannot locate the built fauxnix entry at ${entry}; run \`npm run build\` or reinstall fauxnix-cli, then retry \`fauxnix install --qwen\``,
+    };
+  }
+  return { ok: true, value: { command, args: [entry, 'mcp'] } };
+}
+
+export function sameQwenLaunchTuple(value: unknown, expected: QwenLaunchTuple): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const rec = value as Record<string, unknown>;
+  return (
+    rec.command === expected.command &&
+    Array.isArray(rec.args) &&
+    rec.args.length === expected.args.length &&
+    rec.args.every((part, index) => part === expected.args[index])
+  );
+}

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { homedir, tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, isAbsolute, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { runCli, USAGE } from '../src/cli.js';
 import { collectDoctorReport } from '../src/doctor.js';
@@ -26,6 +26,7 @@ import {
   SH_SCRIPT_WINDOWS_HINT,
 } from '../src/errors.js';
 import { decodeHostResponse, encodeHostRequest, parseHostLine } from '../src/ps-host.js';
+import { packageVersion } from '../src/version.js';
 import {
   bashToolResult,
   formatBashText,
@@ -2205,7 +2206,7 @@ describe('install harness config', () => {
     }
   });
 
-  it('writes Kimi ~/.kimi-code/mcp.json and Qwen ~/.qwen/settings.json', () => {
+  it('writes Kimi ~/.kimi-code/mcp.json and Qwen ~/.qwen/settings.json', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
     try {
       const kimiPath = kimiConfigPath(dir, {});
@@ -2237,13 +2238,150 @@ describe('install harness config', () => {
       };
       expect(qwenData.theme).toBe('dark');
       expect(qwenData.mcpServers.other).toEqual({ command: 'npx' });
-      expect(qwenData.mcpServers.fauxnix).toEqual({ command: 'fauxnix', args: ['mcp'] });
+      const qwenServer = qwenData.mcpServers.fauxnix as {
+        command: string;
+        args: string[];
+      };
+      expect(qwenServer.command).toBe(process.execPath);
+      expect(isAbsolute(qwenServer.command)).toBe(true);
+      expect(qwenServer.args).toEqual([join(process.cwd(), 'dist', 'index.js'), 'mcp']);
+      expect(isAbsolute(qwenServer.args[0])).toBe(true);
+      expect(await doctorText(dir)).toMatch(
+        /qwen\s+: fauxnix MCP configured with an absolute launcher/,
+      );
 
       const kimiHome = join(dir, 'kimi-home');
       const kimiEnv = { KIMI_CODE_HOME: kimiHome };
       const custom = runInstall(['--kimi'], opts(dir, kimiEnv));
       expect(custom.ok).toBe(true);
       expect(existsSync(join(kimiHome, 'mcp.json'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('upgrades a PATH-based Qwen entry, preserves fields, and launches outside project PATH', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    try {
+      const qwenPath = qwenConfigPath(dir, {});
+      const workspace = join(dir, 'workspace with spaces');
+      mkdirSync(join(dir, '.qwen'));
+      mkdirSync(workspace);
+      const marker = join(workspace, 'wrong-launcher.txt');
+      writeFileSync(
+        join(workspace, 'fauxnix.cmd'),
+        `@echo off\r\n>"${marker}" echo wrong\r\nexit /b 0\r\n`,
+      );
+      writeFileSync(
+        qwenPath,
+        JSON.stringify(
+          {
+            theme: 'dark',
+            mcpServers: {
+              other: { command: 'npx' },
+              fauxnix: {
+                command: 'fauxnix',
+                args: ['mcp'],
+                timeout: 30_000,
+                env: { KEEP: 'yes' },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      expect(await doctorText(dir)).toMatch(/qwen\s+: .*launcher does not match this installation/);
+      const installed = runInstall(['--qwen'], opts(dir));
+      expect(installed.ok).toBe(true);
+      expect(installed.lines[0]).toContain('updated mcpServers.fauxnix launcher');
+
+      const data = JSON.parse(readFileSync(qwenPath, 'utf8')) as {
+        theme: string;
+        mcpServers: Record<string, unknown>;
+      };
+      expect(data.theme).toBe('dark');
+      expect(data.mcpServers.other).toEqual({ command: 'npx' });
+      const server = data.mcpServers.fauxnix as {
+        command: string;
+        args: string[];
+        timeout: number;
+        env: Record<string, string>;
+      };
+      expect(server.timeout).toBe(30_000);
+      expect(server.env).toEqual({ KEEP: 'yes' });
+      expect(server.command).toBe(process.execPath);
+      expect(server.args.at(-1)).toBe('mcp');
+
+      const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+      const env = { ...process.env, [pathKey]: workspace + delimiter + (process.env[pathKey] ?? '') };
+      const launched = spawnSync(server.command, [...server.args.slice(0, -1), '--version'], {
+        cwd: workspace,
+        env,
+        encoding: 'utf8',
+        shell: false,
+      });
+      expect(launched.error).toBeUndefined();
+      expect(launched.status).toBe(0);
+      expect(launched.stdout.trim()).toBe(`fauxnix ${packageVersion}`);
+      expect(existsSync(marker)).toBe(false);
+
+      const before = readFileSync(qwenPath, 'utf8');
+      const again = runInstall(['--qwen'], opts(dir));
+      expect(again.ok).toBe(true);
+      expect(again.lines[0]).toContain('already configured with an absolute launcher');
+      expect(readFileSync(qwenPath, 'utf8')).toBe(before);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('doctor reports a Qwen launcher that does not match this installation', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    try {
+      const qwenPath = qwenConfigPath(dir, {});
+      mkdirSync(join(dir, '.qwen'));
+      writeFileSync(
+        qwenPath,
+        JSON.stringify({
+          mcpServers: {
+            fauxnix: {
+              command: join(dir, 'missing-node.exe'),
+              args: [join(dir, 'missing-package', 'dist', 'index.js'), 'mcp'],
+            },
+          },
+        }),
+      );
+      expect(await doctorText(dir)).toMatch(/qwen\s+: .*launcher does not match this installation/);
+      expect(await doctorText(dir)).toContain('fauxnix install --qwen');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not add a second Qwen launcher beside a differently named fauxnix entry', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-install-'));
+    try {
+      const qwenPath = qwenConfigPath(dir, {});
+      mkdirSync(join(dir, '.qwen'));
+      const original = JSON.stringify(
+        {
+          theme: 'dark',
+          mcpServers: {
+            legacy: { command: 'fauxnix', args: ['mcp'], timeout: 10_000 },
+          },
+        },
+        null,
+        2,
+      );
+      writeFileSync(qwenPath, original);
+
+      const installed = runInstall(['--qwen'], opts(dir));
+      expect(installed.ok).toBe(false);
+      expect(installed.lines[0]).toContain('another fauxnix MCP entry (legacy)');
+      expect(readFileSync(qwenPath, 'utf8')).toBe(original);
+      expect(await doctorText(dir)).toMatch(/qwen\s+: .*additional fauxnix MCP entries/);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -2316,6 +2454,7 @@ describe.skipIf(process.platform !== 'win32')('cli doctor spawn', () => {
     expect(r.stdout).toMatch(/claude\s+:/);
     expect(r.stdout).toMatch(/codex\s+:/);
     expect(r.stdout).toMatch(/opencode\s+:/);
+    expect(r.stdout).toMatch(/qwen\s+:/);
     expect(r.status).toBe(0);
   }, 30000);
 });


### PR DESCRIPTION
## Problem

`fauxnix install --qwen` writes `{ command: "fauxnix", args: ["mcp"] }` into a user-level config. Qwen starts that entry from the active project, so the result depends on cwd, PATH/PATHEXT order, and which global install happens to resolve first. A project-local same-named shim can win instead of the package that wrote the config.

## Fix

- generate an absolute launch tuple: current Node executable + this package's absolute `dist/index.js` + `mcp`
- support source builds, global installs, npm tarballs, spaces, and non-ASCII path serialization
- migrate the old bare-command Qwen entry in place
- preserve other MCP servers and extra fields such as `env` and `timeout`
- refuse ambiguous duplicate Fauxnix entries or malformed shapes without changing the file
- make `doctor` compare Qwen's entry with the current installation
- document the generated shape and the need to rerun after relocating Node/package files

## Verification

- 196/196 unit tests
- full suite: 321 passed, 1 opt-in oracle skipped
- npm run typecheck
- npm run test:package
- package smoke installs under a path containing spaces
- generated config launches the real package from a cwd containing a conflicting `fauxnix.cmd`
- source/global/tarball launch paths and idempotent upgrade covered
- independent review: no remaining blocker
- git diff --check