### PR TITLE
fix: keep translate mode side-effect free

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ fauxnix install --claude
 fauxnix mcp
 ```
 
+`translate` only renders a script and does not read command operands. Because
+`sed -f` needs a script file, translate-only mode asks you to use `-e` with
+inline script text; normal command execution continues to support `sed -f`.
+
 Unknown commands (git, node, npm, python, cargo, gh, docker, ...) are **passed through natively**
 with argv-style quoting. Windows `.cmd`/`.bat` shims necessarily pass through `cmd.exe`; fauxnix
 preserves its supported punctuation and fails loudly for `%`, embedded double quotes, NUL, and
@@ -179,8 +183,9 @@ Windows path.
 development:
 
 - **files**: `ls cp mv rm mkdir rmdir touch mktemp ln readlink realpath basename dirname stat file du df find chmod chown diff`
-- **text filters**: `grep egrep sed awk sort uniq cut tr` — sed/awk scripts are parsed at
-  translate time (unsupported constructs throw named errors, never silently misbehave)
+- **text filters**: `grep egrep sed awk sort uniq cut tr` — sed/awk scripts are parsed while
+  preparing an executable plan (unsupported constructs throw named errors, never silently
+  misbehave); inspect-only `translate` keeps `sed -f` file reads out of that path
 - **text I/O**: `echo printf cat head tail wc tee nl tac md5sum sha1sum sha256sum base64 seq yes xargs`
 
 The curated **agent-daily 60** carry a `CommandSpec`: unknown options fail with a GNU-style

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,11 @@
 import { spawn } from 'node:child_process';
 import { FauxnixSession } from './executor.js';
 import { parseCommand } from './parser.js';
-import { translateCommandList } from './translator.js';
+import {
+  EXECUTE_TRANSLATION,
+  PURE_TRANSLATION,
+  translateCommandList,
+} from './translator.js';
 import { listCommandsJson, registeredNames, specsMarkdown } from './registry.js';
 import { encodeCommand } from './encoding.js';
 import { startMcpServer } from './mcp.js';
@@ -82,7 +86,7 @@ export async function runCli(argv: string[]): Promise<void> {
   if (verb === 'translate') {
     const cmd = rest.join(' ');
     const list = parseCommand(cmd);
-    const plans = translateCommandList(list);
+    const plans = translateCommandList(list, PURE_TRANSLATION);
     console.log(plans.map((p) => p.script).join('\n# ---- next segment ----\n'));
     return;
   }
@@ -94,7 +98,7 @@ export async function runCli(argv: string[]): Promise<void> {
   }
 
   const list = parseCommand(cmd);
-  const plans = translateCommandList(list);
+  const plans = translateCommandList(list, EXECUTE_TRANSLATION);
   const session = new FauxnixSession();
   const result = await session.run(plans);
   if (result.stdout) process.stdout.write(result.stdout);

--- a/src/commands/sysinfo.ts
+++ b/src/commands/sysinfo.ts
@@ -18,6 +18,8 @@ import {
   arithExpr,
   setArithHelperPreamble,
   isSpecialShellVar,
+  EXECUTE_TRANSLATION,
+  PURE_TRANSLATION,
 } from '../translator.js';
 import { handlers as textIoHandlers } from './text-io.js';
 
@@ -363,6 +365,7 @@ const env: Handler = (args, ctx) => {
         { kind: 'SimpleCommand', assignments: [], name: cmdWords[0], args: cmdWords.slice(1), redirects: [] },
         ctx.position,
         ctx.hasStdin,
+        ctx.translationMode === 'pure' ? PURE_TRANSLATION : EXECUTE_TRANSLATION,
       ),
     );
   } else {
@@ -737,6 +740,7 @@ const commandCmd: Handler = (args, ctx) => {
     },
     ctx.position,
     ctx.hasStdin,
+    ctx.translationMode === 'pure' ? PURE_TRANSLATION : EXECUTE_TRANSLATION,
   );
 };
 
@@ -2627,6 +2631,7 @@ const timeout: Handler = (args, ctx) => {
     { kind: 'SimpleCommand', assignments: [], name: cmdWords[0], args: cmdWords.slice(1), redirects: [] },
     ctx.position,
     false,
+    ctx.translationMode === 'pure' ? PURE_TRANSLATION : EXECUTE_TRANSLATION,
   );
   const innerLines = inner.split('\n').map((l) => (l ? '    ' + l : l));
   return [

--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -3,7 +3,13 @@ import os from 'node:os';
 import path from 'node:path';
 import { FauxnixParseError, Word, wordToString } from '../ast.js';
 import { CommandSpec, Handler, parseWords, psStr } from '../registry.js';
-import { argListExpr, exprOfWord, literalOfWord, operandExpr } from '../translator.js';
+import {
+  argListExpr,
+  exprOfWord,
+  literalOfWord,
+  operandExpr,
+  PURE_SED_FILE_MESSAGE,
+} from '../translator.js';
 
 /* ------------------------------------------------------------------ */
 /* Shared PS snippets (same shape as files.ts)                         */
@@ -1056,7 +1062,7 @@ function parseSedScript(src: string, isEre: boolean): SedCmd[] {
   return out;
 }
 
-const sed: Handler = (args) => {
+const sed: Handler = (args, ctx) => {
   // custom argv parse: -i takes an ATTACHED suffix; -e/-f take attached or next
   const raw = args.map((w) => wordToString(w));
   let noPrint = false;
@@ -1095,6 +1101,9 @@ const sed: Handler = (args) => {
             throw new FauxnixParseError('fauxnix: sed -' + ch + ' requires an argument');
           }
           if (ch === 'f') {
+            if (ctx.translationMode === 'pure') {
+              throw new FauxnixParseError(PURE_SED_FILE_MESSAGE);
+            }
             try {
               val = readFileSync(nodePathOf(val), 'utf8');
             } catch {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -4,7 +4,13 @@ import { z } from 'zod';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { ExecResult, FauxnixSession } from './executor.js';
 import { parseCommand } from './parser.js';
-import { translateCommandList, wrapScript, translatePipelineBody } from './translator.js';
+import {
+  EXECUTE_TRANSLATION,
+  PURE_TRANSLATION,
+  translateCommandList,
+  wrapScript,
+  translatePipelineBody,
+} from './translator.js';
 import { registeredNames } from './registry.js';
 import { packageVersion } from './version.js';
 import './commands/install-all.js';
@@ -75,6 +81,18 @@ export function bashToolResult(r: ExecResult, sessionId: string, infra: boolean)
   };
 }
 
+export function translateToolResult(command: string) {
+  try {
+    const list = parseCommand(command);
+    const plans = translateCommandList(list, PURE_TRANSLATION);
+    const script = wrapScript(plans.map((p) => p.script).join('\n# ---- next segment ----\n'));
+    return { content: [{ type: 'text' as const, text: script }] };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { content: [{ type: 'text' as const, text: msg }], isError: true as const };
+  }
+}
+
 /** Packed FAUXNIX_POS uses char-30 separators (same as array sidecar). */
 const POS_SEP = '\x1e';
 
@@ -135,7 +153,7 @@ export async function startMcpServer(): Promise<void> {
     EXEC_ANNOTATIONS,
     async ({ command, timeout_ms }, extra) => {
       try {
-        const plans = translateCommandList(parseCommand(command));
+        const plans = translateCommandList(parseCommand(command), EXECUTE_TRANSLATION);
         const result = await session.run(plans, {
           timeoutMs: timeout_ms,
           signal: extra.signal,
@@ -165,17 +183,7 @@ export async function startMcpServer(): Promise<void> {
     'Translate a bash-style command into the equivalent PowerShell script WITHOUT executing it. Useful for learning/debugging what fauxnix does under the hood.',
     { command: z.string().describe('The bash-style command line to translate (never executed)') },
     TRANSLATE_ANNOTATIONS,
-    async ({ command }) => {
-      try {
-        const list = parseCommand(command);
-        const plans = translateCommandList(list);
-        const script = wrapScript(plans.map((p) => p.script).join('\n# ---- next segment ----\n'));
-        return { content: [{ type: 'text', text: script }] };
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return { content: [{ type: 'text', text: msg }], isError: true };
-      }
-    },
+    async ({ command }) => translateToolResult(command),
   );
 
   server.tool(

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -34,6 +34,8 @@ export interface PipelineCtx {
   position: 'first' | 'middle' | 'last';
   /** True when stdin is available (piped input or `< file` redirect). */
   hasStdin: boolean;
+  /** Whether translation is preparing an executable plan or only rendering it. */
+  translationMode?: 'execute' | 'pure';
 }
 
 export type Handler = (args: Word[], ctx: PipelineCtx) => string;

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -12,10 +12,176 @@ import {
   Word,
   WordPart,
   isUnquotedLiteral,
+  wordToString,
 } from './ast.js';
 import { parseCommand } from './parser.js';
 import { PipelineCtx, lookup, psStr } from './registry.js';
 import { PYTHON3_WINDOWS_HINT, SH_SCRIPT_WINDOWS_HINT } from './errors.js';
+
+export interface TranslationContext {
+  /** `pure` renders a script without consulting command operands on disk. */
+  mode: 'execute' | 'pure';
+}
+
+export const EXECUTE_TRANSLATION: TranslationContext = Object.freeze({ mode: 'execute' });
+export const PURE_TRANSLATION: TranslationContext = Object.freeze({ mode: 'pure' });
+
+export const PURE_SED_FILE_MESSAGE =
+  'fauxnix: translate does not read sed script files; use -e with the script text, or run the command to use -f';
+
+/** Match the sed option rules without opening the referenced script file. */
+function sedUsesScriptFile(args: Word[]): boolean {
+  const raw = args.map((word) => wordToString(word));
+  let onlyOperands = false;
+  for (let i = 0; i < raw.length; i++) {
+    const arg = raw[i];
+    if (!onlyOperands && arg === '--') {
+      onlyOperands = true;
+      continue;
+    }
+    if (onlyOperands || !arg.startsWith('-') || arg.length === 1 || arg.startsWith('--')) {
+      continue;
+    }
+    const body = arg.slice(1);
+    for (let c = 0; c < body.length; c++) {
+      const flag = body[c];
+      if (flag === 'f') return c < body.length - 1 || i + 1 < raw.length;
+      if (flag === 'e') {
+        if (c === body.length - 1) i++;
+        break;
+      }
+      if (flag === 'i') break;
+      if (!['n', 'E', 'r', 's', 'u', 'z'].includes(flag)) return false;
+    }
+  }
+  return false;
+}
+
+function assertPureWord(word: Word): void {
+  const visitPart = (part: WordPart): void => {
+    if (part.kind === 'CmdSub') {
+      assertPureCommandList(parseCommand(part.cmd));
+    } else if (part.kind === 'DoubleQuoted' || part.kind === 'Arith') {
+      for (const nested of part.parts) visitPart(nested);
+    }
+  };
+  for (const part of word) visitPart(part);
+}
+
+function wrappedSimpleCommand(command: SimpleCommand, name: string): SimpleCommand | null {
+  const raw = command.args.map((word) => wordToString(word));
+  let commandIndex = -1;
+  if (name === 'env') {
+    for (let i = 0; i < raw.length; ) {
+      const arg = raw[i];
+      if (arg === '--') {
+        commandIndex = i + 1;
+        break;
+      }
+      if (arg === '-i' || arg === '--ignore-environment') return null;
+      if (arg === '-u' || arg === '--unset') {
+        i += 2;
+        continue;
+      }
+      if (arg.startsWith('-u=') || arg.startsWith('--unset=')) {
+        i++;
+        continue;
+      }
+      if (arg.startsWith('-')) {
+        i++;
+        continue;
+      }
+      if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(arg)) {
+        i++;
+        continue;
+      }
+      commandIndex = i;
+      break;
+    }
+  } else if (name === 'command') {
+    let identify = false;
+    let i = 0;
+    while (i < raw.length) {
+      const arg = raw[i];
+      if (arg === '-v' || arg === '-V') {
+        identify = true;
+        i++;
+        continue;
+      }
+      if (arg === '--') {
+        i++;
+        break;
+      }
+      if (arg.startsWith('-')) {
+        i++;
+        continue;
+      }
+      break;
+    }
+    if (identify) return null;
+    commandIndex = i;
+  } else if (name === 'timeout') {
+    let i = 0;
+    while (i < raw.length && raw[i].startsWith('-') && raw[i] !== '-' && raw[i] !== '--') i++;
+    if (i < raw.length && raw[i] === '--') i++;
+    commandIndex = i + 1;
+  }
+  if (commandIndex < 0 || commandIndex >= command.args.length) return null;
+  return {
+    kind: 'SimpleCommand',
+    assignments: [],
+    name: command.args[commandIndex],
+    args: command.args.slice(commandIndex + 1),
+    redirects: [],
+  };
+}
+
+function assertPureShellCommand(command: ShellCommand): void {
+  if (command.kind === 'SimpleCommand') {
+    const name = command.name === null ? null : literalOfWord(command.name);
+    if (name === 'sed' && sedUsesScriptFile(command.args)) {
+      throw new FauxnixParseError(PURE_SED_FILE_MESSAGE);
+    }
+    if (command.name) assertPureWord(command.name);
+    for (const arg of command.args) assertPureWord(arg);
+    for (const assignment of command.assignments) {
+      assertPureWord(assignment.value);
+      for (const value of assignment.values ?? []) assertPureWord(value);
+    }
+    if (name === 'env' || name === 'command' || name === 'timeout') {
+      const nested = wrappedSimpleCommand(command, name);
+      if (nested) assertPureShellCommand(nested);
+    }
+    return;
+  }
+  if (command.kind === 'If') {
+    assertPureCommandList(command.test);
+    assertPureCommandList(command.then);
+    if (command.else) assertPureCommandList(command.else);
+    return;
+  }
+  if (command.kind === 'For') {
+    for (const word of command.words) assertPureWord(word);
+    assertPureCommandList(command.body);
+    return;
+  }
+  if (command.kind === 'While') {
+    assertPureCommandList(command.test);
+    assertPureCommandList(command.body);
+    return;
+  }
+  assertPureWord(command.word);
+  for (const arm of command.arms) {
+    for (const pattern of arm.patterns) assertPureWord(pattern);
+    assertPureCommandList(arm.body);
+  }
+}
+
+function assertPureCommandList(list: CommandList): void {
+  for (const segment of list.segments) {
+    for (const command of segment.pipeline.commands) assertPureShellCommand(command);
+  }
+}
 
 /* ------------------------------------------------------------------ */
 /* Variable mapping                                                    */
@@ -465,8 +631,12 @@ export function argListExpr(words: Word[], fn: (w: Word) => string = exprOfWord)
  * Lists (`;` `&&` `||`) reuse translateListInline inside the fx-csub
  * scriptblock so the newline contract is unchanged.
  */
-export function translateCmdSub(cmdText: string, keepNl = false): string {
-  const inner = translateListInline(parseCommand(cmdText));
+export function translateCmdSub(
+  cmdText: string,
+  keepNl = false,
+  translation: TranslationContext = EXECUTE_TRANSLATION,
+): string {
+  const inner = translateListInline(parseCommand(cmdText), translation);
   const collected = '(fx-csub { ' + inner + ' })';
   if (keepNl) return collected;
   return (
@@ -491,6 +661,7 @@ export function translateSimple(
   cmd: SimpleCommand,
   position: PipelineCtx['position'],
   hasStdin: boolean,
+  translation: TranslationContext = EXECUTE_TRANSLATION,
 ): string {
   // assignment-only segment (`X=1; cmd`): bash semantics are "set for the
   // rest of the shell". Reuse the export code path — persist + env shadow —
@@ -509,7 +680,9 @@ export function translateSimple(
         );
       } else {
         const words = [[{ kind: 'Text' as const, text: a.name + '=' }, ...a.value]];
-        if (exportHandler) chunks.push(exportHandler(words, { position, hasStdin }));
+        if (exportHandler) {
+          chunks.push(exportHandler(words, { position, hasStdin, translationMode: translation.mode }));
+        }
       }
     }
     return chunks.join('\n');
@@ -534,6 +707,7 @@ export function translateSimple(
             },
             position,
             hasStdin,
+            translation,
           );
     const emptyCmdLines: string[] = [
       '$fx_cw = @(' + splatLoadCall(nameSplat.name) + ')',
@@ -565,7 +739,7 @@ export function translateSimple(
   } else if (nameLit !== null) {
     const handler = lookup(nameLit);
     if (handler && !(nameLit === '[[' && !isUnquotedLiteral(cmd.name, '[['))) {
-      body = handler(cmd.args, { position, hasStdin });
+      body = handler(cmd.args, { position, hasStdin, translationMode: translation.mode });
     } else {
       // passthrough: native command (git, node, npm, python, cargo, ...)
       // via fx-native (Win32 command line + Process). `& name @array` on
@@ -926,10 +1100,13 @@ export interface PipelineParts {
  * multi-command pipelines become generated functions chained with `|`
  * (PS 5.1 forbids parenthesized expressions as non-first pipeline elements).
  */
-function translateListInline(list: CommandList): string {
+function translateListInline(
+  list: CommandList,
+  translation: TranslationContext = EXECUTE_TRANSLATION,
+): string {
   const chunks: string[] = [];
   for (const seg of list.segments) {
-    const { defs, call } = translatePipelineBody(seg.pipeline);
+    const { defs, call } = translatePipelineBody(seg.pipeline, translation);
     const body = (defs ? defs + '\n' : '') + call;
     if (seg.op === '&&') {
       chunks.push('if ($script:fx_exit -eq 0) {\n' + body + '\n}');
@@ -942,28 +1119,28 @@ function translateListInline(list: CommandList): string {
   return chunks.join('\n');
 }
 
-function translateIf(cmd: IfCommand): string {
+function translateIf(cmd: IfCommand, translation: TranslationContext): string {
   // Branch bodies reset fx_exit first: the compound's exit status must come
   // from the taken branch's last command (bash semantics), not leak the test's
   // failure — `if false; then A; else B; fi` exits 0 in bash.
-  const lines = [translateListInline(cmd.test), 'if ($script:fx_exit -eq 0) {', '  $script:fx_exit = 0'];
-  for (const l of translateListInline(cmd.then).split('\n')) lines.push(l ? '  ' + l : l);
+  const lines = [translateListInline(cmd.test, translation), 'if ($script:fx_exit -eq 0) {', '  $script:fx_exit = 0'];
+  for (const l of translateListInline(cmd.then, translation).split('\n')) lines.push(l ? '  ' + l : l);
   lines.push('} else {', '  $script:fx_exit = 0');
   if (cmd.else) {
-    for (const l of translateListInline(cmd.else).split('\n')) lines.push(l ? '  ' + l : l);
+    for (const l of translateListInline(cmd.else, translation).split('\n')) lines.push(l ? '  ' + l : l);
   }
   lines.push('}');
   return lines.join('\n');
 }
 
-function translateCase(cmd: CaseCommand): string {
+function translateCase(cmd: CaseCommand, translation: TranslationContext): string {
   const lines = ['$script:fx_exit = 0', '$fx_cw = ' + exprOfWord(cmd.word)];
   for (let i = 0; i < cmd.arms.length; i++) {
     const arm = cmd.arms[i];
     const pats = arm.patterns.map((w) => exprOfWord(w)).join(',');
     const head = i === 0 ? 'if' : 'elseif';
     lines.push(head + ' (fx-casematch $fx_cw @(' + pats + ')) {');
-    const body = translateListInline(arm.body);
+    const body = translateListInline(arm.body, translation);
     if (body) {
       for (const l of body.split('\n')) lines.push(l ? '  ' + l : l);
     }
@@ -972,7 +1149,7 @@ function translateCase(cmd: CaseCommand): string {
   return lines.join('\n');
 }
 
-function translateFor(cmd: ForCommand): string {
+function translateFor(cmd: ForCommand, translation: TranslationContext): string {
   const n = cmd.name.replace(/'/g, "''");
   const lines = [
     '$fx_for = ' + argListExpr(cmd.words),
@@ -994,21 +1171,21 @@ function translateFor(cmd: ForCommand): string {
       n +
       "' + [string][char]61 + (fx-svenc ([string]$fx_it))); $env:FAUXNIX_SETVALS = ($fx_sv -join [string][char]10)",
   ];
-  for (const l of translateListInline(cmd.body).split('\n')) lines.push(l ? '  ' + l : l);
+  for (const l of translateListInline(cmd.body, translation).split('\n')) lines.push(l ? '  ' + l : l);
   lines.push('}');
   return lines.join('\n');
 }
 
-function translateWhile(cmd: WhileCommand): string {
+function translateWhile(cmd: WhileCommand, translation: TranslationContext): string {
   // Bash: last executed body owns status; a test that ends the loop does not.
   // Never-entered loops (`while false; do …; done`, `until true; do …; done`)
   // exit 0. Save the body status and restore it on the failing test.
   const fail = cmd.until ? '$script:fx_exit -eq 0' : '$script:fx_exit -ne 0';
   const lines = ['$fx_wst = 0', 'do {'];
-  for (const l of translateListInline(cmd.test).split('\n')) lines.push(l ? '  ' + l : l);
+  for (const l of translateListInline(cmd.test, translation).split('\n')) lines.push(l ? '  ' + l : l);
   lines.push('  if (' + fail + ') { $script:fx_exit = $fx_wst; break }');
   lines.push('  $script:fx_exit = 0');
-  for (const l of translateListInline(cmd.body).split('\n')) lines.push(l ? '  ' + l : l);
+  for (const l of translateListInline(cmd.body, translation).split('\n')) lines.push(l ? '  ' + l : l);
   lines.push('  $fx_wst = $script:fx_exit');
   lines.push('} while ($true)');
   return lines.join('\n');
@@ -1064,7 +1241,10 @@ function rejectNonLastFdRedirects(commands: ShellCommand[]): void {
 
 export function translatePipelineBody(p: {
   commands: Array<SimpleCommand | IfCommand | ForCommand | WhileCommand | CaseCommand>;
-}): PipelineParts {
+}, translation: TranslationContext = EXECUTE_TRANSLATION): PipelineParts {
+  if (translation.mode === 'pure') {
+    for (const command of p.commands) assertPureShellCommand(command);
+  }
   // Last-stage output fds are applied by Node. On an earlier stage they would
   // be prepared but not owned by that stage, so output would still reach the
   // wrong destination. Fail loud until routed in-stage fds land (#157).
@@ -1081,11 +1261,11 @@ export function translatePipelineBody(p: {
     const hasStdin = i > 0 || c.redirects.some((r) => r.op === '<');
     const position: PipelineCtx['position'] =
       i === 0 ? 'first' : i === p.commands.length - 1 ? 'last' : 'middle';
-    if (c.kind === 'If') bodies.push(translateIf(c));
-    else if (c.kind === 'For') bodies.push(translateFor(c));
-    else if (c.kind === 'While') bodies.push(translateWhile(c));
-    else if (c.kind === 'Case') bodies.push(translateCase(c));
-    else bodies.push(translateSimple(c, position, hasStdin));
+    if (c.kind === 'If') bodies.push(translateIf(c, translation));
+    else if (c.kind === 'For') bodies.push(translateFor(c, translation));
+    else if (c.kind === 'While') bodies.push(translateWhile(c, translation));
+    else if (c.kind === 'Case') bodies.push(translateCase(c, translation));
+    else bodies.push(translateSimple(c, position, hasStdin, translation));
   }
 
   if (bodies.length === 1) {
@@ -1163,7 +1343,10 @@ export interface SegmentPlan {
   stdinRedirects: Redirect[];
 }
 
-export function translateCommandList(list: CommandList): SegmentPlan[] {
+export function translateCommandList(
+  list: CommandList,
+  translation: TranslationContext = EXECUTE_TRANSLATION,
+): SegmentPlan[] {
   const plans: SegmentPlan[] = [];
   for (const seg of list.segments) {
     const cmds = seg.pipeline.commands;
@@ -1173,7 +1356,7 @@ export function translateCommandList(list: CommandList): SegmentPlan[] {
     const stdinRedirects = cmds.length
       ? cmds[0].redirects.filter((r) => r.op === '<')
       : [];
-    const { defs, call } = translatePipelineBody(seg.pipeline);
+    const { defs, call } = translatePipelineBody(seg.pipeline, translation);
     let body = defs ? defs + '\n' + call : call;
     // First-stage `< file` feeds stage zero via FAUXNIX_STDIN_FILE.
     // Later-stage `<` is owned inside the pipeline body, not this wrapper.

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -45,6 +45,7 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     writeFileSync(join(dir, 'letters.txt'), 'a\nb\nc\n', 'utf8');
     writeFileSync(join(dir, 'nums.txt'), '1 2\n3 4\n5 6\n', 'utf8');
     writeFileSync(join(dir, 'dups.txt'), 'aaa\naaa\nbbb\n', 'utf8');
+    writeFileSync(join(dir, 'replace-apple.sed'), 's/apple/PEAR/g\n', 'utf8');
     mkdirSync(join(dir, 'sub'));
     writeFileSync(join(dir, 'sub', 'b.txt'), 'third line\n', 'utf8');
     mkdirSync(join(dir, 'grep-tree', 'src'), { recursive: true });
@@ -215,6 +216,23 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     const r = await run("sed 's/apple/MANGO/g' fruits.txt");
     expect(r.stdout).toContain('MANGO pie');
     expect(r.stdout).not.toContain('apple');
+  });
+
+  it('sed script options execute while -- and -e keep their normal meanings', async () => {
+    const script = JSON.stringify(join(dir, 'replace-apple.sed'));
+    const attached = await run('sed -f' + script + ' fruits.txt');
+    const separate = await run('sed -f ' + script + ' fruits.txt');
+    const afterDashDash = await run("sed -- 's/apple/PLUM/g' fruits.txt");
+    const expression = await run("sed -e 's/apple/MANGO/g' fruits.txt");
+
+    for (const result of [attached, separate]) {
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('PEAR pie');
+    }
+    expect(afterDashDash.exitCode).toBe(0);
+    expect(afterDashDash.stdout).toContain('PLUM pie');
+    expect(expression.exitCode).toBe(0);
+    expect(expression.stdout).toContain('MANGO pie');
   });
 
   it('awk field printing and sum', async () => {

--- a/test/translate-pure.test.ts
+++ b/test/translate-pure.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+});
+
+import { readFileSync } from 'node:fs';
+import { runCli } from '../src/cli.js';
+import { translateToolResult } from '../src/mcp.js';
+import { parseCommand } from '../src/parser.js';
+import {
+  EXECUTE_TRANSLATION,
+  PURE_SED_FILE_MESSAGE,
+  PURE_TRANSLATION,
+  translateCommandList,
+} from '../src/translator.js';
+import '../src/commands/install-all.js';
+
+const readFileSpy = vi.mocked(readFileSync);
+
+describe('side-effect-free translation', () => {
+  beforeEach(() => {
+    readFileSpy.mockClear();
+  });
+
+  it.each([
+    'sed -frules.sed input.txt',
+    'sed -f rules.sed input.txt',
+    "sed -f '\\\\server\\share\\rules.sed' input.txt",
+    'sed -f CON input.txt',
+    'echo "$(sed -f rules.sed input.txt)"',
+    'env sed -f rules.sed input.txt',
+    'command sed -f rules.sed input.txt',
+    'timeout 1 sed -f rules.sed input.txt',
+    'echo "$(env sed -f rules.sed input.txt)"',
+    '[[ "$(env sed -f rules.sed input.txt)" == x ]]',
+    'echo $(( $(env sed -f rules.sed input.txt) + 1 ))',
+    'for x in "$(env sed -f rules.sed input.txt)"; do echo $x; done',
+    'case "$(env sed -f rules.sed input.txt)" in x) echo x;; esac',
+    'export X="$(env sed -f rules.sed input.txt)"',
+  ])('rejects %s before reading the script operand', (command) => {
+    expect(() => translateCommandList(parseCommand(command), PURE_TRANSLATION)).toThrow(
+      PURE_SED_FILE_MESSAGE,
+    );
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps -- operands and regular -e translation side-effect free', () => {
+    expect(() =>
+      translateCommandList(parseCommand("sed -- 's/f/x/' -f"), PURE_TRANSLATION),
+    ).not.toThrow();
+    expect(() =>
+      translateCommandList(parseCommand("sed -e 's/a/b/' input.txt"), PURE_TRANSLATION),
+    ).not.toThrow();
+    expect(() =>
+      translateCommandList(parseCommand('command -v sed -f'), PURE_TRANSLATION),
+    ).not.toThrow();
+    expect(() =>
+      translateCommandList(parseCommand('env -i sed -f rules.sed'), PURE_TRANSLATION),
+    ).not.toThrow();
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses pure translation in the CLI and MCP entry points', async () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+    try {
+      await expect(
+        runCli(['translate', 'echo "$(env sed -f rules.sed input.txt)"']),
+      ).rejects.toThrow(PURE_SED_FILE_MESSAGE);
+    } finally {
+      console.log = originalLog;
+    }
+    const result = translateToolResult('echo "$(timeout 1 sed -frules.sed input.txt)"');
+    expect(result).toMatchObject({ isError: true });
+    expect(result.content[0].text).toBe(PURE_SED_FILE_MESSAGE);
+    expect(logs).toEqual([]);
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps executable translation able to load a sed script file', () => {
+    readFileSpy.mockImplementationOnce(() => 's/a/b/');
+    expect(() =>
+      translateCommandList(parseCommand('sed -f rules.sed input.txt'), EXECUTE_TRANSLATION),
+    ).not.toThrow();
+    expect(readFileSpy).toHaveBeenCalledWith('rules.sed', 'utf8');
+  });
+});


### PR DESCRIPTION
## Problem

Both `fauxnix translate` surfaces promise to render PowerShell without executing the command, but they currently share the executable translation path. `sed -f FILE` calls `readFileSync` while the script is being prepared, so translate-only mode consults a command operand before it returns anything.

## Fix

- add an explicit `execute | pure` translation context
- use pure mode in CLI `translate` and MCP `fauxnix_translate`
- use execute mode in CLI/MCP command execution
- in pure mode, make `sed -f` fail with an actionable `use -e with inline script text` message before reading the path
- propagate the mode through pipelines, control constructs, command substitutions, assignments, and `env` / `command` / `timeout` wrappers
- keep normal `sed -f` execution behavior unchanged

This does not add the currently unsupported `sed --file` long option or change relative-path resolution.

## Verification

- 17 read-spy cases cover attached/separate/bundled `-f`, file/device/UNC-shaped operands, `--`, `-e`, command substitutions, arithmetic, `[[ ]]`, for/case/export, and wrapper nesting
- real PowerShell covers attached/separate script files, `--`, and `-e`
- npm ci
- npm run typecheck / build
- full suite: 336 passed, 1 opt-in oracle skipped
- npm run test:package
- Git Bash oracle: 125/126 identical (99.2%)
- independent patch review completed
- git diff --check