### PR TITLE
fix: make batch argv handling fail loud

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ fauxnix mcp
 ```
 
 Unknown commands (git, node, npm, python, cargo, gh, docker, ...) are **passed through natively**
-with argv-style quoting — no string re-parsing, no quoting bugs.
+with argv-style quoting. Windows `.cmd`/`.bat` shims necessarily pass through `cmd.exe`; fauxnix
+preserves its supported punctuation and fails loudly for `%`, embedded double quotes, NUL, and
+line breaks rather than passing a different argument.
 
 ## Use with your agent harness
 

--- a/docs/rfc-native-argv-fidelity.md
+++ b/docs/rfc-native-argv-fidelity.md
@@ -29,8 +29,11 @@ That violates fail-loud / never silently-wrong.
 - Empty `[object[]]` must not unwrap to `$null` (that became a phantom `""`
   argv). `.cmd`/`.bat` Applications go through `cmd.exe /d /s /c` because
   `CreateProcess` cannot launch them with `UseShellExecute = $false`. The
-  `/c` tail is wrapped in extra quotes (`/s` strips that pair); arguments
-  containing `& | ( ) < > ^` are CRT-quoted so cmd.exe does not split them.
+  `/c` tail is wrapped in extra quotes (`/s` strips that pair), delayed
+  expansion is forced off, and arguments containing `! ^ & | ( ) < >` are
+  quoted so cmd.exe does not split them. A separate `fx-cmdargv` boundary
+  rejects `%`, embedded double quotes, CR/LF, and NUL because cmd.exe cannot
+  represent those values losslessly in this command-string path.
 - Pipelines still work: `$input` is copied to the child stdin; stdout/stderr
   are captured without the `& @array` splat.
 - Dynamic/`[@]` command names use the same helper. If the name is not an
@@ -44,8 +47,8 @@ That violates fail-loud / never silently-wrong.
 
 ## Non-goals
 
-- Byte-identical cmd.exe quirks beyond that quoting (`%VAR%` expansion,
-  delayed-expansion `!`, nested quote encoding).
+- Lossless `.cmd`/`.bat` arguments outside the documented `fx-cmdargv`
+  character contract; they fail loudly instead of being rewritten.
 - `pwsh` 7 `ArgumentList`.
 - Version bump / npm publish.
 
@@ -56,6 +59,9 @@ empty arg, space, embedded `"`, leading `--foo`.
 (`node -e` is a bad oracle on Windows: `-e` is omitted from `process.argv`,
 so `slice(2)` drops the first user argument.)
 `printf -- 'a b\n' | xargs node dump-argv.js` → `["a","b"]` (xargs splits on blanks).
+Direct `.cmd`/`.bat` plus xargs default/`-n`/`-I` cover preserved empty,
+space, backslash, parentheses, `! ^ & | < >` arguments and fail-loud `%`,
+double-quote, CR/LF, and NUL boundaries.
   });
 
 `.cmd` that echoes `%*`: `'a&b'` / `'--flag=a&b'` stay one argument containing `&`.

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1206,6 +1206,7 @@ const WRAP_HELPER_ORDER = [
   'fx-subst',
   'fx-slice',
   'fx-winargv',
+  'fx-cmdargv',
   'fx-native',
 ] as const;
 
@@ -1234,7 +1235,8 @@ const WRAP_HELPER_DEPS: Record<WrapHelper, WrapHelper[]> = {
   'fx-subst': [],
   'fx-slice': [],
   'fx-winargv': [],
-  'fx-native': ['fx-winargv'],
+  'fx-cmdargv': ['fx-winargv'],
+  'fx-native': ['fx-cmdargv'],
 };
 
 /** Helpers the body calls that wrapScript still has to emit (not already defined there). */
@@ -1676,6 +1678,23 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       "  return (($parts.ToArray()) -join ' ')",
       '}',
     ],
+    'fx-cmdargv': [
+      'function fx-cmdargv($argv) {',
+      // cmd.exe performs percent expansion even inside quotes, and embedded
+      // quotes can reopen its metacharacter grammar. CR/LF/NUL cannot be
+      // represented as one batch argument. Reject those values instead of
+      // silently handing a different argv to the shim.
+      '  if ($null -eq $argv) { $argv = @() }',
+      '  foreach ($a in @($argv)) {',
+      '    $s = [string]$a',
+      "    if ($s.IndexOf('%') -ge 0) { throw \"fauxnix: cannot pass '%' to a .cmd/.bat file without changing the argument; invoke the underlying executable directly\" }",
+      '    if ($s.IndexOf([char]34) -ge 0) { throw \'fauxnix: cannot pass a double quote to a .cmd/.bat file without changing the argument; invoke the underlying executable directly\' }',
+      '    if ($s.IndexOf([char]13) -ge 0 -or $s.IndexOf([char]10) -ge 0) { throw \'fauxnix: cannot pass a line break to a .cmd/.bat file as one argument; invoke the underlying executable directly\' }',
+      '    if ($s.IndexOf([char]0) -ge 0) { throw \'fauxnix: cannot pass NUL to a .cmd/.bat file as one argument; invoke the underlying executable directly\' }',
+      '  }',
+      '  return (fx-winargv $argv $true)',
+      '}',
+    ],
     'fx-native': [
       'function fx-native($name, $argv) {',
       '  if ($null -eq $argv) { $argv = @() } else { $argv = [object[]]@($argv) }',
@@ -1706,8 +1725,8 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '  $psi = New-Object System.Diagnostics.ProcessStartInfo',
       '  $ext = [IO.Path]::GetExtension([string]$app.Source)',
       // CreateProcess cannot launch .cmd/.bat with UseShellExecute=false (npm.cmd).
-      // /s strips one outer quote pair from the /c tail; CRT-quote cmd
-      // metacharacters so `&`/`|`/`()` do not start a second command.
+      // /s strips one outer quote pair from the /c tail. Build only the
+      // subset of batch argv that cmd.exe can pass through unchanged.
       "  if ($ext -eq '.cmd' -or $ext -eq '.bat') {",
       '    $comspec = Get-Command -Name cmd -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1',
       '    if ($null -eq $comspec) {',
@@ -1716,10 +1735,16 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '      return',
       '    }',
       '    $psi.FileName = $comspec.Source',
-      '    $fx_app = fx-winargv $app.Source $true',
-      '    $fx_rest = fx-winargv $argv $true',
+      '    try {',
+      '      $fx_app = fx-cmdargv $app.Source',
+      '      $fx_rest = fx-cmdargv $argv',
+      '    } catch {',
+      // Let the common wrapper report the validation error and stop the
+      // current pipeline. Returning here would let xargs mask the failure.
+      '      throw $_.Exception',
+      '    }',
       "    if ($fx_rest.Length -gt 0) { $fx_tail = $fx_app + ' ' + $fx_rest } else { $fx_tail = $fx_app }",
-      '    $psi.Arguments = \'/d /s /c "\' + $fx_tail + \'"\'',
+      '    $psi.Arguments = \'/d /s /v:off /c "\' + $fx_tail + \'"\'',
       '  } else {',
       '    $psi.FileName = $app.Source',
       '    $psi.Arguments = fx-winargv $argv',

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -32,6 +32,16 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     );
     writeFileSync(join(dir, 'hit.cmd'), '@echo off\r\necho CMDHIT\r\n');
     writeFileSync(join(dir, 'dump-args.cmd'), '@echo off\r\necho ARGS:%*\r\necho DONE\r\n');
+    writeFileSync(
+      join(dir, 'forward-args.cmd'),
+      '@echo off\r\nnode "%~dp0dump-argv.js" %*\r\n',
+      'utf8',
+    );
+    writeFileSync(
+      join(dir, 'forward-args.bat'),
+      '@echo off\r\nnode "%~dp0dump-argv.js" %*\r\n',
+      'utf8',
+    );
     writeFileSync(join(dir, 'letters.txt'), 'a\nb\nc\n', 'utf8');
     writeFileSync(join(dir, 'nums.txt'), '1 2\n3 4\n5 6\n', 'utf8');
     writeFileSync(join(dir, 'dups.txt'), 'aaa\naaa\nbbb\n', 'utf8');
@@ -1331,6 +1341,116 @@ describe.skipIf(!hasPs)('integration (real PowerShell)', { timeout: 30000 }, () 
     expect(inject.stdout).toContain('a&echo INJECTED');
     expect(inject.stdout).toContain('DONE');
     expect(inject.stdout).not.toMatch(/^INJECTED$/m);
+  });
+
+  it('native .cmd argv keeps supported punctuation and rejects values cmd would rewrite', async () => {
+    const supported = [
+      '',
+      'a b',
+      'back\\slash',
+      'trail\\',
+      'a(b)',
+      'a!b',
+      'a^b',
+      'a&b',
+      'a|b',
+      'a<b',
+      'a>b',
+      'left!^&|<>right',
+    ];
+    const pass = await run(
+      './forward-args.cmd ' + supported.map((value) => "'" + value + "'").join(' '),
+    );
+    expect(pass.exitCode).toBe(0);
+    expect(JSON.parse(pass.stdout.trim())).toEqual(supported);
+
+    const percent = await run("FXPROBE=EXPANDED ./forward-args.cmd '%FXPROBE%'");
+    expect(percent.exitCode).not.toBe(0);
+    expect(percent.stdout).toBe('');
+    expect(percent.stderr).toContain("cannot pass '%' to a .cmd/.bat file");
+    expect(percent.stderr).not.toContain('EXPANDED');
+
+    const quote = await run('./forward-args.cmd \'a"&echo CHANGED\'');
+    expect(quote.exitCode).not.toBe(0);
+    expect(quote.stdout).toBe('');
+    expect(quote.stderr).toContain('cannot pass a double quote to a .cmd/.bat file');
+    expect(quote.stdout + quote.stderr).not.toMatch(/^CHANGED$/m);
+
+    const bat = await run("./forward-args.bat 'a!^&|<>b'");
+    expect(bat.exitCode).toBe(0);
+    expect(JSON.parse(bat.stdout.trim())).toEqual(['a!^&|<>b']);
+
+    for (const lineBreak of ['\r', '\n']) {
+      const broken = await run("./forward-args.cmd 'a" + lineBreak + "b'");
+      expect(broken.exitCode).not.toBe(0);
+      expect(broken.stderr).toContain('cannot pass a line break to a .cmd/.bat file');
+    }
+    const nul = await run("./forward-args.cmd 'a\0b'");
+    expect(nul.exitCode).not.toBe(0);
+    expect(nul.stdout).toBe('');
+    expect(nul.stderr).toContain('cannot pass NUL to a .cmd/.bat file');
+  });
+
+  it('xargs .cmd argv uses the same fidelity boundary in default, -n, and -I modes', async () => {
+    const expected = ['a!b', 'a^b', 'a&b', 'a|b', 'a<b', 'a>b'];
+    const ordinary = await run(
+      "printf -- '" + expected.join(' ') + "\\n' | xargs ./forward-args.cmd",
+    );
+    expect(ordinary.exitCode).toBe(0);
+    expect(JSON.parse(ordinary.stdout.trim())).toEqual(expected);
+
+    const batched = await run("printf -- 'a!b a^b a&b a|b\\n' | xargs -n 2 ./forward-args.cmd");
+    expect(batched.exitCode).toBe(0);
+    expect(batched.stdout.trim().split(/\r?\n/).map((line) => JSON.parse(line))).toEqual([
+      ['a!b', 'a^b'],
+      ['a&b', 'a|b'],
+    ]);
+
+    const replaced = await run(
+      "printf -- 'left!^&|<>right\\n' | xargs -I {} ./forward-args.cmd '{}'",
+    );
+    expect(replaced.exitCode).toBe(0);
+    expect(JSON.parse(replaced.stdout.trim())).toEqual(['left!^&|<>right']);
+
+    const forms = [
+      (value: string) => "printf -- '" + value + "\\n' | xargs ./forward-args.cmd",
+      (value: string) => "printf -- '" + value + "\\n' | xargs -n 1 ./forward-args.cmd",
+      (value: string) =>
+        "printf -- '" + value + "\\n' | xargs -I {} ./forward-args.cmd '{}'",
+    ];
+    for (const form of forms) {
+      for (const [value, message] of [
+        ['%FXPROBE%', "cannot pass '%' to a .cmd/.bat file"],
+        ['a"b', 'cannot pass a double quote to a .cmd/.bat file'],
+      ]) {
+        const cmd = 'FXPROBE=EXPANDED ' + form(value);
+        const rejected = await run(cmd);
+        expect(rejected.exitCode, cmd + ': ' + JSON.stringify(rejected)).not.toBe(0);
+        expect(rejected.stderr).toContain(message);
+        expect(rejected.stdout + rejected.stderr).not.toContain('EXPANDED');
+      }
+    }
+
+    const baseArgForms = [
+      (value: string) =>
+        "printf -- 'item\\n' | xargs ./forward-args.cmd '" + value + "'",
+      (value: string) =>
+        "printf -- 'item\\n' | xargs -n 1 ./forward-args.cmd '" + value + "'",
+      (value: string) =>
+        "printf -- 'item\\n' | xargs -I {} ./forward-args.cmd '" + value + "' '{}'",
+    ];
+    for (const form of baseArgForms) {
+      for (const [separator, message] of [
+        ['\r', 'cannot pass a line break to a .cmd/.bat file'],
+        ['\n', 'cannot pass a line break to a .cmd/.bat file'],
+        ['\0', 'cannot pass NUL to a .cmd/.bat file'],
+      ] as const) {
+        const cmd = form('a' + separator + 'b');
+        const rejected = await run(cmd);
+        expect(rejected.exitCode, cmd + ': ' + JSON.stringify(rejected)).not.toBe(0);
+        expect(rejected.stderr).toContain(message);
+      }
+    }
   });
 
   it('xargs runs native commands', async () => {

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -873,10 +873,15 @@ describe('translator', () => {
     expect(builtin).toContain('xargs currently passes arguments to native commands');
   });
 
-  it('quotes cmd metacharacters on the .cmd /c tail', () => {
+  it('uses a cmd-specific argv boundary for .cmd/.bat files', () => {
     const script = translateCommandList(parse('node --version'))[0].script;
-    expect(script).toContain('fx-winargv $argv $true');
-    expect(script).toContain('/d /s /c "');
+    expect(script).toContain('function fx-cmdargv');
+    expect(script).toContain('fx-cmdargv $argv');
+    expect(script).toContain('/d /s /v:off /c "');
+    expect(script).toContain("$s.IndexOf('%')");
+    expect(script).toContain('$s.IndexOf([char]34)');
+    expect(script).toContain('$s.IndexOf([char]13)');
+    expect(script).toContain('$s.IndexOf([char]10)');
     expect(script).toContain("'&'");
     expect(script).toContain("'|'");
     const list = parse("./hit.cmd 'a&b'");


### PR DESCRIPTION
## Problem

`.exe` passthrough uses a Win32/CRT argv encoder, but `.cmd` and `.bat` files must run through `cmd.exe /c`. Reusing the CRT rules for that command string is not lossless: `%NAME%` is expanded, an embedded quote can reopen cmd syntax, and line breaks cannot remain one argument.

## Fix

Add a separate `fx-cmdargv` boundary for batch shims:

- force `cmd.exe /v:off`
- preserve empty arguments, spaces, backslashes, parentheses, and `! ^ & | < >`
- reject `%`, embedded double quotes, CR/LF, and NUL with an actionable nonzero error before launching the shim
- use the same boundary for direct batch calls and xargs
- leave ordinary `.exe` argv handling unchanged

The RFC and README now state this exact character contract instead of implying every cmd string is representable.

## Verification

- real `.cmd` and `.bat` forwarders compare the final Node argv
- direct calls cover every preserved and rejected character family
- xargs default, `-n`, and `-I` cover both data records and base arguments
- values that would change are absent from stdout and the shim is not launched
- npm run typecheck / build
- full suite: 320 passed, 1 opt-in oracle skipped
- npm run test:package
- Git Bash oracle: 125/126 identical (99.2%)
- ordinary native `.exe` regression suite remains green
- git diff --check