### PR TITLE
fix: bound output buffering across host execution

### DIFF
--- a/docs/rfc-bounded-cancellable-execution.md
+++ b/docs/rfc-bounded-cancellable-execution.md
@@ -5,7 +5,7 @@ Tracks [#129](https://github.com/20000419/fauxnix/issues/129) as the v0.8 wire/r
 
 ## Why the one-line host frame is now the bottleneck
 
-The resident `powershell.exe` delivered the latency win. The spawn-era convenience of “one JSON line per segment, flatten into one MCP text blob” now crosses several boundaries the suite did not exercise:
+The resident PowerShell host delivered the latency win. The spawn-era convenience of “one JSON line per segment, flatten into one MCP text blob” now crosses several boundaries the suite did not exercise:
 
 1. **Native stderr is outside the frame.** `[Console]::SetError()` captures PowerShell/.NET writes; `git`/`npm`/`node` still write the OS stderr handle. Node appends those bytes to `stderrChunks` and never reads them.
 2. **One result is unbounded.** PowerShell buffers both streams, base64-encodes them, and sends one JSON line. An 11 MB MCP result exceeds the SDK’s 10 MiB read buffer and closes the connection. PS 5.1 `ConvertTo-Json` itself caps at ~2 MiB (`MaxJsonLength`).
@@ -43,10 +43,10 @@ PR-B proposed frames (Node still reassembles into one `ExecResult`; MCP clients 
 
 ```json
 {"v":2,"type":"ready","capabilities":{"cancel":false,"maxChunkBytes":65536,"stderrMarker":true}}
-{"v":2,"type":"run","id":"r1","scriptB64":"…","env":{},"stdoutLimit":8388608,"stderrLimit":1048576}
+{"v":2,"type":"run","id":"r1","scriptB64":"…","env":{},"stdoutLimit":8388608,"stderrLimit":1048576,"stdoutMode":"capture","stderrMode":"capture"}
 {"v":2,"type":"stdout","id":"r1","seq":0,"dataB64":"…"}
 {"v":2,"type":"stderr","id":"r1","seq":0,"dataB64":"…"}
-{"v":2,"type":"end","id":"r1","exitCode":0,"timedOut":false,"cancelled":false,"truncated":false}
+{"v":2,"type":"end","id":"r1","exitCode":0,"timedOut":false,"cancelled":false,"truncated":false,"stdoutTruncated":false,"stderrTruncated":false}
 ```
 
 `capabilities.cancel: false` is honest until a nested runspace can read a cancel frame while `& $fx_sb` is running. Until then Node kills the host process, matching timeout recovery.
@@ -72,6 +72,26 @@ During migration, return both the current text content and versioned structured 
 - Whitespace-only stdout is byte-faithful in `structuredContent.stdout`. The text view may still strip a single trailing newline for display; it must not `.trim()`.
 - Cancel uses exit **130** (`128+SIGINT`). Timeout stays **124**.
 - Default budgets: 8 MiB stdout, 1 MiB stderr. Crossing a budget sets `truncated: true` and must not close the MCP connection.
+- Explicit budgets are non-negative integers up to 2,147,483,643 bytes; invalid
+  values fail before a host request is started.
+- Budgets are shared across every list segment. `capture` retains at most the
+  remaining logical stream budget plus a UTF-8 boundary suffix; `discard`
+  retains nothing. A file destination uses a host-owned disk `spool`, which
+  Node copies to the already-open redirect descriptor in 64 KiB chunks.
+- Once a caller stream crosses its budget, later list segments cannot fill a
+  UTF-8 boundary gap. Pipeline-object lines use LF in the resident host, while
+  exact writers and native text retain their own line endings.
+- The `end` frame reports stdout/stderr truncation separately so normalization
+  of one captured prefix cannot reopen that logical destination or close the
+  other stream.
+- For duplicated descriptors, the final returned byte count is capped by the
+  destination budget. The independently captured sources can each retain that
+  budget before replay; a single shared capture allocation and chronological
+  cross-pipe prefix/order remain the merge-policy follow-up in
+  [#129](https://github.com/20000419/fauxnix/issues/129).
+- Stdout and stderr select their modes independently. Redirecting one stream
+  never removes the caller budget from the other, and duplicated fds consume
+  the remaining budget of their logical destination.
 
 ## Failure modes
 
@@ -81,9 +101,10 @@ During migration, return both the current text content and versioned structured 
 | `ExecOptions.timeoutMs` | Unchanged: kill host, exit 124, session remains usable. |
 | Concurrent `reset` / `run` / `dispose` | One lifecycle lock. Exactly one live host after they settle. `reset()` mutates the existing `FauxnixSession` (does not allocate a second object). |
 | Stdio EOF / SIGINT / SIGTERM | Idempotent `dispose()`: stop host, unlink cwd/env/script/host temp files. |
-| Native stderr on the OS pipe | PR-A: concatenate whatever arrived on the pipe during the frame and **clear** `stderrChunks`. Not deterministic across two OS pipes (stated). PR-B: `FAUXNIX_ERR_END:<id>` marker. |
+| Native stderr on the OS pipe | PR-A: concatenate whatever arrived on the pipe during the frame and **clear** `stderrChunks`. PR-B: find `FAUXNIX_ERR_END:<id>` incrementally while retaining only a marker-length tail; capture shares the logical stderr remainder and file output is spooled. |
+| Native stderr spool open/write failure | Keep scanning in discard mode through this request's marker, fail the request, remove partial spools, and restart the host before the next request. |
 | ConvertTo-Json > ~2 MiB | Loud stderr on that frame (`exit 1`), host loop stays alive. PR-B chunks so this path is unused for payload. |
-| `powershell.exe` missing | Unchanged 127 + sandbox message. Marked as infrastructure in MCP. |
+| Selected PowerShell host missing or invalid | Exit 127 with the host-selection or startup message. Marked as infrastructure in MCP. |
 
 ## Non-goals
 

--- a/docs/rfc-native-argv-fidelity.md
+++ b/docs/rfc-native-argv-fidelity.md
@@ -22,10 +22,10 @@ That violates fail-loud / never silently-wrong.
   builds a Win32 command line (`fx-winargv`) and starts
   `System.Diagnostics.Process` with redirected stdio. Empty arguments become
   `""`; quotes follow the CRT quoting rules.
-- Stdout/stderr are `ReadToEndAsync` started **before** writing stdin (a
-  chatty child must not fill the 64KB pipe). PS 5.1 cannot run a scriptblock
-  on the thread pool, so `Task.Factory.StartNew({ $p.StandardOutput.ReadToEnd() })`
-  throws and the wrap catch turns that into exit 1.
+- Stdout/stderr start concurrent `FauxnixTextPump.CopyAsync` drains into
+  temporary disk spools **before** stdin is written (a chatty child must not
+  fill the 64KB pipe). After the child exits, the spools are replayed through
+  the bounded host capture or the next pipeline stage and then removed.
 - Empty `[object[]]` must not unwrap to `$null` (that became a phantom `""`
   argv). `.cmd`/`.bat` Applications go through `cmd.exe /d /s /c` because
   `CreateProcess` cannot launch them with `UseShellExecute = $false`. The

--- a/docs/rfc-persistent-powershell-host.md
+++ b/docs/rfc-persistent-powershell-host.md
@@ -47,7 +47,7 @@ Host → Node:
 {"id":"<uuid>","stdoutB64":"<bytes>","stderrB64":"<bytes>","exitCode":0}
 ```
 
-Captured command streams are the UTF-8 bytes of `[Console]::Out` / `[Console]::Error` after redirecting those writers for the frame. Pipeline objects (`Write-Output` / `fx-write` line mode) are `WriteLine`d to the same `Console.Out` as they arrive so `echo -n` / `printf` exact writes still interleave correctly. Node always decodes these framed bytes as UTF-8. Bytes written directly to the host's OS stderr pipe stay separate and use the selected native-tool decoder before both strings are normalized and joined.
+Captured command streams are the UTF-8 bytes of `[Console]::Out` / `[Console]::Error` after redirecting those writers for the frame. Pipeline objects (`Write-Output` / `fx-write` line mode) are `WriteLine`d with LF to the same `Console.Out` as they arrive so `echo -n` / `printf` exact writes still interleave correctly. Caller-bound streams use a bounded capture, `/dev/null` uses a discard stream, and file-bound streams use a host-owned disk spool that Node copies byte-for-byte to its pre-opened fd. Native child pipes are drained concurrently before bounded replay, so the protocol never needs a complete native `ReadToEnd` string. Node always decodes framed bytes as UTF-8; bytes written directly to the host's OS stderr pipe stay separate and use the selected native-tool decoder before the strings are joined.
 
 The per-frame script is `wrapScript(body, { mode: 'host' })`: same cwd/env persist files and try/catch as spawn mode, **no `exit`**, **no helper re-emit** (the bootstrap already defined every `fx-*`).
 

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,14 +1,24 @@
 import { randomUUID } from 'node:crypto';
-import { promises as fs, readFileSync, existsSync, openSync, closeSync, writeSync } from 'node:fs';
+import {
+  promises as fs,
+  readFileSync,
+  existsSync,
+  openSync,
+  closeSync,
+  readSync,
+  rmSync,
+  writeSync,
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { Redirect } from './ast.js';
 import { SegmentPlan, normalizeLiteralPath, wrapScript } from './translator.js';
-import { decodeOutput, normalizeHostNewlines, resolveNativePref } from './encoding.js';
+import { decodeOutput, resolveNativePref } from './encoding.js';
 import { normalizeStderr } from './errors.js';
 import {
   DEFAULT_STDERR_LIMIT,
   DEFAULT_STDOUT_LIMIT,
+  HostStreamMode,
   PowerShellHost,
 } from './ps-host.js';
 import { PowerShellSelection, resolvePowerShell } from './powershell.js';
@@ -34,6 +44,31 @@ export interface ExecOptions {
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_WINDOWS_PATHEXT = '.COM;.EXE;.BAT;.CMD';
+const MAX_HOST_CAPTURE_LIMIT = 0x7fffffff;
+const UTF8_BOUNDARY_SUFFIX = 4;
+const MAX_CALLER_OUTPUT_LIMIT = MAX_HOST_CAPTURE_LIMIT - UTF8_BOUNDARY_SUFFIX;
+
+function validateOutputLimit(name: 'stdoutLimit' | 'stderrLimit', value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0 || value > MAX_CALLER_OUTPUT_LIMIT) {
+    throw new RangeError(
+      'fauxnix: ' + name + ' must be an integer from 0 to ' + MAX_CALLER_OUTPUT_LIMIT,
+    );
+  }
+  return value;
+}
+
+/**
+ * Retain one complete codepoint beyond the logical caller budget so Node can
+ * detect truncation and clip at a UTF-8 boundary. The host itself stays
+ * bounded even when the caller has no remaining budget.
+ */
+function rawHostCaptureLimit(logicalBytes: number): number {
+  if (!Number.isFinite(logicalBytes)) {
+    return logicalBytes === Number.POSITIVE_INFINITY ? MAX_HOST_CAPTURE_LIMIT : 0;
+  }
+  const bytes = Math.max(0, Math.floor(logicalBytes));
+  return Math.min(MAX_HOST_CAPTURE_LIMIT, bytes + UTF8_BOUNDARY_SUFFIX);
+}
 
 function hasEnvKey(env: NodeJS.ProcessEnv, name: string): boolean {
   const normalized = name.toUpperCase();
@@ -386,17 +421,64 @@ async function runPlans(
 ): Promise<ExecResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const deadline = Date.now() + timeoutMs;
-  const stdoutLimit = opts.stdoutLimit ?? DEFAULT_STDOUT_LIMIT;
-  const stderrLimit = opts.stderrLimit ?? DEFAULT_STDERR_LIMIT;
+  const stdoutLimit = validateOutputLimit(
+    'stdoutLimit',
+    opts.stdoutLimit ?? DEFAULT_STDOUT_LIMIT,
+  );
+  const stderrLimit = validateOutputLimit(
+    'stderrLimit',
+    opts.stderrLimit ?? DEFAULT_STDERR_LIMIT,
+  );
   const timeoutMessage =
     '\nbash: command timed out after ' + Math.round(timeoutMs / 1000) + 's';
   let stdout = '';
   let stderr = '';
+  let stdoutBytes = 0;
+  let stderrBytes = 0;
+  let stdoutClosed = false;
+  let stderrClosed = false;
   let exitCode = 0;
   let timedOut = false;
   let cancelled = false;
   let truncated = false;
   let spawnError: ExecResult['spawnError'];
+  const appendCaller = (fd: 1 | 2, data: string): void => {
+    if (!data) return;
+    if (fd === 1 ? stdoutClosed : stderrClosed) return;
+    const used = fd === 1 ? stdoutBytes : stderrBytes;
+    const limit = fd === 1 ? stdoutLimit : stderrLimit;
+    const clipped = clipUtf8(data, Math.max(0, limit - used));
+    if (fd === 1) {
+      stdout += clipped.text;
+      stdoutBytes += Buffer.byteLength(clipped.text, 'utf8');
+    } else {
+      stderr += clipped.text;
+      stderrBytes += Buffer.byteLength(clipped.text, 'utf8');
+    }
+    if (clipped.truncated) {
+      if (fd === 1) stdoutClosed = true;
+      else stderrClosed = true;
+      truncated = true;
+    }
+  };
+  const remainingFor = (dest: FdDest): number => {
+    if (dest.kind !== 'caller') return 0;
+    if (dest.fd === 1 ? stdoutClosed : stderrClosed) return 0;
+    const limit = dest.fd === 1 ? stdoutLimit : stderrLimit;
+    const used = dest.fd === 1 ? stdoutBytes : stderrBytes;
+    return Math.max(0, limit - used);
+  };
+  const closeCallerDest = (dest: FdDest): void => {
+    if (dest.kind !== 'caller') return;
+    if (dest.fd === 1) stdoutClosed = true;
+    else stderrClosed = true;
+  };
+  const hostStream = (dest: FdDest): { mode: HostStreamMode; limit: number } => {
+    if (dest.kind === 'file') return { mode: 'spool', limit: 0 };
+    if (dest.kind === 'nul') return { mode: 'discard', limit: 0 };
+    if (dest.fd === 1 ? stdoutClosed : stderrClosed) return { mode: 'discard', limit: 0 };
+    return { mode: 'capture', limit: rawHostCaptureLimit(remainingFor(dest)) };
+  };
   // bash list semantics: `a && b ; c` runs c regardless of a; `a && b && c`
   // skips b AND c when a fails. chainOk models the value of the current
   // &&/|| chain; `;` segments always run and restart the chain.
@@ -419,7 +501,7 @@ async function runPlans(
       break;
     }
     if (Date.now() >= deadline) {
-      stderr += timeoutMessage;
+      appendCaller(2, timeoutMessage);
       exitCode = 124;
       timedOut = true;
       session.prevExit = exitCode;
@@ -449,10 +531,10 @@ async function runPlans(
     const emitPrepError = (msg: string) =>
       emitToPrepDest(prepStderr, msg, prepFds, {
         stdout: (s) => {
-          stdout += s;
+          appendCaller(1, s);
         },
         stderr: (s) => {
-          stderr += s;
+          appendCaller(2, s);
         },
       });
     for (const r of plan.redirects) {
@@ -506,7 +588,7 @@ async function runPlans(
       break;
     }
     if (remainingMs <= 0) {
-      stderr += timeoutMessage;
+      appendCaller(2, timeoutMessage);
       exitCode = 124;
       timedOut = true;
       session.prevExit = exitCode;
@@ -518,11 +600,11 @@ async function runPlans(
     // stderr onto the caller's stdout before stdout is pointed at NUL, so
     // captured stderr is still returned; `>/dev/null 2>&1` points both at NUL.
     const applyDests = lastStageOutputDests(plan.outputRedirects, resolveTarget);
-    // Response budgets cap what the CALLER receives — streams redirected to
-    // files must never be truncated by them (Codex-review P1: `printf … > f`
-    // with a small stdoutLimit was writing a clipped file). The final
-    // clipUtf8 below still enforces the returned-data budget.
-    const fileRedirected = applyDests.stdout.kind === 'file' || applyDests.stderr.kind === 'file';
+    // Each source stream is bounded according to its final destination.
+    // A file keeps the complete stream, /dev/null retains nothing, and a
+    // caller stream receives only the budget left by earlier list segments.
+    const hostStdout = hostStream(applyDests.stdout);
+    const hostStderr = hostStream(applyDests.stderr);
     const inv = await ensureHost().invoke(
       encoded,
       {
@@ -532,13 +614,19 @@ async function runPlans(
       },
       remainingMs,
       opts.signal,
-      fileRedirected
-        ? { stdoutLimit: 0, stderrLimit: 0 }
-        : { stdoutLimit, stderrLimit },
+      {
+        stdoutLimit: hostStdout.limit,
+        stderrLimit: hostStderr.limit,
+        stdoutMode: hostStdout.mode,
+        stderrMode: hostStderr.mode,
+      },
     );
 
     if (inv.spawnError === 'ENOENT' || inv.spawnError === 'START') {
-      stderr += inv.stderr.toString('utf8') || 'fauxnix: failed to start the selected PowerShell host\n';
+      appendCaller(
+        2,
+        inv.stderr.toString('utf8') || 'fauxnix: failed to start the selected PowerShell host\n',
+      );
       exitCode = 127;
       spawnError = inv.spawnError;
       session.prevExit = exitCode;
@@ -557,17 +645,14 @@ async function runPlans(
     afterSegment();
 
     const decodePref = resolveNativePref();
-    // GNU line discipline: the PS host terminates Write-Output lines with
-    // CRLF. Exact writers (fx-write / printf / echo -n) must keep embedded
-    // CR so `printf 'a\r\nb' > out` stays 4 bytes.
     // Captured protocol frames are always UTF-8. FAUXNIX_NATIVE_ENCODING is
     // consumed at the native-process boundary inside fx-native; applying it
     // again here double-decodes every translated/non-ASCII frame. Only bytes
     // written directly to the host's OS stderr pipe retain a native encoding.
-    const segOut = normalizeHostNewlines(decodeOutput(inv.stdout, 'utf8'));
+    const segOut = decodeOutput(inv.stdout, 'utf8');
     const framedErr = decodeOutput(inv.stderr, 'utf8');
     const nativeErr = decodeOutput(inv.nativeStderr ?? Buffer.alloc(0), decodePref);
-    let segErr = normalizeHostNewlines(normalizeStderr(framedErr + nativeErr));
+    let segErr = normalizeStderr(framedErr + nativeErr);
 
     if (inv.timedOut) {
       segErr += timeoutMessage;
@@ -586,23 +671,53 @@ async function runPlans(
           writeToPrepFd(prepFds, dest.path, data);
         } catch (e) {
           if (fromStdout) {
-            stderr += 'bash: ' + dest.path + ': cannot create: ' + (e as Error).message + '\n';
+            appendCaller(
+              2,
+              'bash: ' + dest.path + ': cannot create: ' + (e as Error).message + '\n',
+            );
             exitCode = 1;
             redirectOk = false;
-            stdout += data;
+            appendCaller(1, data);
           } else {
-            stderr += data;
+            appendCaller(2, data);
           }
         }
         return;
       }
-      if (dest.fd === 1) stdout += data;
-      else stderr += data;
+      appendCaller(dest.fd, data);
     };
-    deliverCaptured(applyDests.stdout, segOut, true);
-    deliverCaptured(applyDests.stderr, segErr, false);
+    const deliverSpool = (dest: FdDest, spool: string | undefined, fromStdout: boolean): void => {
+      if (!spool) return;
+      if (dest.kind !== 'file') {
+        throw new Error('fauxnix: host returned a spool for a non-file destination');
+      }
+      try {
+        writeSpoolToPrepFd(prepFds, spool, dest.path);
+      } catch (e) {
+        appendCaller(
+          2,
+          'bash: ' + dest.path + ': cannot write: ' + (e as Error).message + '\n',
+        );
+        exitCode = 1;
+        redirectOk = false;
+      }
+    };
+    const spools = [inv.stdoutSpool, inv.stderrSpool, inv.nativeStderrSpool].filter(
+      (file): file is string => !!file,
+    );
+    try {
+      deliverCaptured(applyDests.stdout, segOut, true);
+      if (inv.stdoutTruncated) closeCallerDest(applyDests.stdout);
+      deliverCaptured(applyDests.stderr, segErr, false);
+      if (inv.stderrTruncated) closeCallerDest(applyDests.stderr);
+      deliverSpool(applyDests.stdout, inv.stdoutSpool, true);
+      deliverSpool(applyDests.stderr, inv.stderrSpool, false);
+      deliverSpool(applyDests.stderr, inv.nativeStderrSpool, false);
+    } finally {
+      for (const spool of spools) rmSync(spool, { force: true });
+    }
     if (inv.truncated) truncated = true;
-    exitCode = inv.timedOut ? 124 : inv.cancelled ? 130 : inv.exitCode;
+    exitCode = !redirectOk ? 1 : inv.timedOut ? 124 : inv.cancelled ? 130 : inv.exitCode;
     if (inv.timedOut) timedOut = true;
     session.prevExit = exitCode;
     chainOk = exitCode === 0;
@@ -616,12 +731,9 @@ async function runPlans(
     }
   }
 
-  const clippedOut = clipUtf8(stdout, stdoutLimit);
-  const clippedErr = clipUtf8(stderr, stderrLimit);
-  if (clippedOut.truncated || clippedErr.truncated) truncated = true;
   return {
-    stdout: clippedOut.text,
-    stderr: clippedErr.text,
+    stdout,
+    stderr,
     exitCode,
     timedOut,
     cancelled,
@@ -632,7 +744,34 @@ async function runPlans(
 
 function clipUtf8(text: string, limit: number): { text: string; truncated: boolean } {
   if (Buffer.byteLength(text, 'utf8') <= limit) return { text, truncated: false };
-  let end = text.length;
-  while (end > 0 && Buffer.byteLength(text.slice(0, end), 'utf8') > limit) end--;
+  let used = 0;
+  let end = 0;
+  for (const codepoint of text) {
+    const size = Buffer.byteLength(codepoint, 'utf8');
+    if (used + size > limit) break;
+    used += size;
+    end += codepoint.length;
+  }
   return { text: text.slice(0, end), truncated: true };
+}
+
+/** Copy a host spool into an already-open redirect fd with bounded memory. */
+function writeSpoolToPrepFd(
+  fds: Map<string, number>,
+  file: string,
+  target: string,
+): void {
+  const outFd = fds.get(target);
+  if (outFd === undefined) throw new Error('fauxnix: redirect fd missing for ' + target);
+  const inFd = openSync(file, 'r');
+  const input = Buffer.allocUnsafe(65_536);
+  try {
+    while (true) {
+      const n = readSync(inFd, input, 0, input.length, null);
+      if (n <= 0) break;
+      writeAllSync(outFd, input.subarray(0, n));
+    }
+  } finally {
+    closeSync(inFd);
+  }
 }

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -1,5 +1,14 @@
 import { spawn, ChildProcess } from 'node:child_process';
-import { writeFileSync } from 'node:fs';
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs';
 import { hostBootstrapScript } from './translator.js';
 import {
   POWERSHELL_ARGS,
@@ -7,6 +16,25 @@ import {
   powerShellMissingMessage,
   resolvePowerShell,
 } from './powershell.js';
+
+type NativeSpoolWriter = (fd: number, buffer: Buffer, offset: number, length: number) => number;
+
+class NativeStderrSpoolError extends Error {
+  constructor(operation: 'open' | 'write', spoolPath: string | undefined, cause: unknown) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    const code = (cause as NodeJS.ErrnoException | undefined)?.code;
+    super(
+      'fauxnix: native stderr spool ' +
+        operation +
+        ' failed' +
+        (code ? ' (' + code + ')' : '') +
+        (spoolPath ? ' for ' + spoolPath : '') +
+        ': ' +
+        detail,
+    );
+    this.name = 'NativeStderrSpoolError';
+  }
+}
 
 const READY_TIMEOUT_MS = 30_000;
 
@@ -23,8 +51,27 @@ export interface HostInvokeResult {
   timedOut: boolean;
   cancelled: boolean;
   truncated: boolean;
+  /** The framed stdout source crossed its capture limit. */
+  stdoutTruncated?: boolean;
+  /** Framed or native stderr crossed the shared stderr capture limit. */
+  stderrTruncated?: boolean;
   spawnError?: 'ENOENT' | 'START';
   spawnMessage?: string;
+  stdoutSpool?: string;
+  stderrSpool?: string;
+  nativeStderrSpool?: string;
+}
+
+export type HostStreamMode = 'capture' | 'spool' | 'discard';
+
+export interface HostOutputLimits {
+  stdoutLimit?: number;
+  stderrLimit?: number;
+  stdoutMode?: HostStreamMode;
+  stderrMode?: HostStreamMode;
+  stdoutSpoolPath?: string;
+  stderrSpoolPath?: string;
+  nativeStderrSpoolPath?: string;
 }
 
 export interface HostRequestEnv {
@@ -35,7 +82,7 @@ export function encodeHostRequest(
   id: string,
   script: string,
   env: HostRequestEnv,
-  opts?: { v?: number; stdoutLimit?: number; stderrLimit?: number },
+  opts?: { v?: number } & HostOutputLimits,
 ): string {
   const body: Record<string, unknown> = {
     id,
@@ -47,6 +94,10 @@ export function encodeHostRequest(
     body.type = 'run';
     body.stdoutLimit = opts.stdoutLimit ?? DEFAULT_STDOUT_LIMIT;
     body.stderrLimit = opts.stderrLimit ?? DEFAULT_STDERR_LIMIT;
+    body.stdoutMode = opts.stdoutMode ?? 'capture';
+    body.stderrMode = opts.stderrMode ?? 'capture';
+    if (opts.stdoutSpoolPath) body.stdoutSpoolPath = opts.stdoutSpoolPath;
+    if (opts.stderrSpoolPath) body.stderrSpoolPath = opts.stderrSpoolPath;
   }
   return JSON.stringify(body);
 }
@@ -62,6 +113,8 @@ export type HostV2Frame =
       timedOut?: boolean;
       cancelled?: boolean;
       truncated?: boolean;
+      stdoutTruncated?: boolean;
+      stderrTruncated?: boolean;
     };
 
 export function parseHostLine(line: string): {
@@ -113,6 +166,21 @@ export class PowerShellHost {
     reject: (err: Error) => void;
   }> = [];
   private stderrChunks: Buffer[] = [];
+  private nativeCapture: {
+    id: string;
+    needle: Buffer;
+    mode: HostStreamMode;
+    limit: number;
+    tail: Buffer;
+    spoolPath?: string;
+    spoolFd?: number;
+    bytesWritten: number;
+    bytesSeen: number;
+    ioError?: NativeStderrSpoolError;
+    resolve: (value: { bytesSeen: number }) => void;
+    reject: (reason: Error) => void;
+    timer: NodeJS.Timeout;
+  } | null = null;
   private closeCode: number | null | undefined;
   private closeErr: Error | null = null;
   private closed = false;
@@ -124,6 +192,8 @@ export class PowerShellHost {
     private readonly hostFile: string,
     private readonly envFn: () => NodeJS.ProcessEnv,
     private readonly powerShell: PowerShellSelection = resolvePowerShell(),
+    private readonly nativeSpoolWrite: NativeSpoolWriter = (fd, buffer, offset, length) =>
+      writeSync(fd, buffer, offset, length),
   ) {}
 
   /** Start the resident process and wait for the ready handshake (B1 prewarm). */
@@ -136,7 +206,7 @@ export class PowerShellHost {
     env: HostRequestEnv,
     timeoutMs: number,
     signal?: AbortSignal,
-    limits?: { stdoutLimit?: number; stderrLimit?: number },
+    limits?: HostOutputLimits,
   ): Promise<HostInvokeResult> {
     const run = this.invokeLock.then(() =>
       this.invokeSerial(script, env, timeoutMs, signal, limits),
@@ -156,6 +226,7 @@ export class PowerShellHost {
   }
 
   async stop(): Promise<void> {
+    this.cancelNativeCapture();
     const proc = this.proc;
     this.proc = null;
     this.closed = true;
@@ -196,7 +267,7 @@ export class PowerShellHost {
     env: HostRequestEnv,
     timeoutMs: number,
     signal?: AbortSignal,
-    limits?: { stdoutLimit?: number; stderrLimit?: number },
+    limits?: HostOutputLimits,
   ): Promise<HostInvokeResult> {
     if (signal?.aborted) {
       await this.stop();
@@ -207,18 +278,35 @@ export class PowerShellHost {
     if (started) return { ...started, cancelled: false, truncated: false };
 
     const id = 'f' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+    const resolvedLimits: HostOutputLimits = { ...limits };
+    if (resolvedLimits.stdoutMode === 'spool') {
+      resolvedLimits.stdoutSpoolPath = this.hostFile + '.' + id + '.stdout';
+    }
+    if (resolvedLimits.stderrMode === 'spool') {
+      resolvedLimits.stderrSpoolPath = this.hostFile + '.' + id + '.stderr';
+    }
+    if (resolvedLimits.stderrMode !== 'discard') {
+      resolvedLimits.nativeStderrSpoolPath = this.hostFile + '.' + id + '.native-stderr';
+    }
+    const nativeSpoolDir = this.hostFile + '.' + id + '.native';
+    mkdirSync(nativeSpoolDir);
+    const requestEnv = { ...env, FAUXNIX_NATIVE_SPOOL_DIR: nativeSpoolDir };
     const line = encodeHostRequest(
       id,
       script,
-      env,
+      requestEnv,
       this.protocol === 2
-        ? { v: 2, stdoutLimit: limits?.stdoutLimit, stderrLimit: limits?.stderrLimit }
+        ? {
+            v: 2,
+            ...resolvedLimits,
+          }
         : undefined,
     );
     try {
       this.proc!.stdin!.write(line + '\n');
     } catch (e) {
       await this.deadRestart();
+      rmSync(nativeSpoolDir, { recursive: true, force: true });
       return {
         stdout: Buffer.alloc(0),
         stderr: Buffer.from('fauxnix: powershell host exited unexpectedly\n', 'utf8'),
@@ -238,7 +326,7 @@ export class PowerShellHost {
     signal?.addEventListener('abort', onAbort, { once: true });
     try {
       if (this.protocol === 2) {
-        return await this.collectV2(id, timeoutMs);
+        return await this.collectV2(id, timeoutMs, resolvedLimits);
       }
       const raw = await this.nextJsonLine(timeoutMs, id);
       const msg = decodeHostResponse(raw);
@@ -254,15 +342,28 @@ export class PowerShellHost {
       };
     } catch (e) {
       const timedOut = (e as { timedOut?: boolean }).timedOut === true;
+      const wasCancelled = cancelled || signal?.aborted === true;
+      const nativeSpoolError = e instanceof NativeStderrSpoolError ? e : null;
       await this.stop();
       this.drainNativeStderr();
-      if (cancelled || signal?.aborted) return this.cancelledResult();
+      this.removeRequestSpools(resolvedLimits);
+      if (wasCancelled) return this.cancelledResult();
       if (timedOut) {
         return {
           stdout: Buffer.alloc(0),
           stderr: Buffer.alloc(0),
           exitCode: 124,
           timedOut: true,
+          cancelled: false,
+          truncated: false,
+        };
+      }
+      if (nativeSpoolError) {
+        return {
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.from(nativeSpoolError.message + '\n', 'utf8'),
+          exitCode: 1,
+          timedOut: false,
           cancelled: false,
           truncated: false,
         };
@@ -294,6 +395,11 @@ export class PowerShellHost {
       };
     } finally {
       signal?.removeEventListener('abort', onAbort);
+      try {
+        rmSync(nativeSpoolDir, { recursive: true, force: true });
+      } catch {
+        /* best effort; never mask the request result */
+      }
     }
   }
 
@@ -372,7 +478,7 @@ export class PowerShellHost {
     });
     child.stderr!.on('data', (d: Buffer) => {
       if (this.proc !== child) return;
-      this.stderrChunks.push(d);
+      this.onNativeStderr(d);
     });
     child.on('error', (e) => {
       if (this.proc !== child) return;
@@ -479,13 +585,28 @@ export class PowerShellHost {
     throw err;
   }
 
-  private async collectV2(id: string, timeoutMs: number): Promise<HostInvokeResult> {
+  private async collectV2(
+    id: string,
+    timeoutMs: number,
+    limits?: HostOutputLimits,
+  ): Promise<HostInvokeResult> {
     const deadline = Date.now() + timeoutMs;
     const out: Buffer[] = [];
     const err: Buffer[] = [];
     let outSeq = 0;
     let errSeq = 0;
     let end: Extract<HostV2Frame, { type: 'end' }> | null = null;
+    const nativePromise = this.beginNativeCapture(
+      id,
+      limits?.stderrMode ?? 'capture',
+      limits?.stderrLimit ?? DEFAULT_STDERR_LIMIT,
+      limits?.nativeStderrSpoolPath,
+      timeoutMs + 2000,
+    );
+    // collectV2 can leave through a frame timeout before it reaches the await
+    // below. Attach a handler immediately so teardown never reports a stray
+    // promise rejection; the awaited path still receives the same failure.
+    void nativePromise.catch(() => undefined);
     while (!end) {
       const line = await this.nextLine(Math.max(1, deadline - Date.now()));
       if (!line.trim()) continue;
@@ -509,13 +630,42 @@ export class PowerShellHost {
         end = f;
       }
     }
-    let native = Buffer.alloc(0);
+    let nativeBytes = 0;
+    let markerTimer: NodeJS.Timeout | undefined;
     try {
-      native = Buffer.from(await this.waitNativeMarker(id, 2000));
-    } catch {
-      native = Buffer.from(this.drainNativeStderr());
+      const captured = await Promise.race([
+        nativePromise,
+        new Promise<never>((_, reject) => {
+          markerTimer = setTimeout(
+            () => reject(new Error('fauxnix: native stderr marker missing')),
+            2000,
+          );
+        }),
+      ]);
+      nativeBytes = captured.bytesSeen;
+    } catch (e) {
+      this.cancelNativeCapture();
+      if (e instanceof NativeStderrSpoolError) throw e;
+    } finally {
+      if (markerTimer) clearTimeout(markerTimer);
     }
     const capturedErr = Buffer.from(Buffer.concat(err));
+    let native = Buffer.alloc(0);
+    let nativeTruncated = false;
+    const nativeSpool = limits?.nativeStderrSpoolPath;
+    if ((limits?.stderrMode ?? 'capture') === 'capture' && nativeSpool) {
+      const remaining = Math.max(
+        0,
+        (limits?.stderrLimit ?? DEFAULT_STDERR_LIMIT) - capturedErr.length,
+      );
+      const clipped = this.readUtf8Prefix(nativeSpool, remaining, nativeBytes);
+      native = Buffer.from(clipped.data);
+      nativeTruncated = clipped.truncated;
+      rmSync(nativeSpool, { force: true });
+    }
+    if (limits?.stderrMode === 'spool' && nativeSpool && nativeBytes === 0) {
+      rmSync(nativeSpool, { force: true });
+    }
     const n = Number(end.exitCode);
     return {
       stdout: Buffer.from(Buffer.concat(out)),
@@ -524,25 +674,186 @@ export class PowerShellHost {
       exitCode: Number.isFinite(n) ? n : 0,
       timedOut: end.timedOut === true,
       cancelled: end.cancelled === true,
-      truncated: end.truncated === true,
+      truncated: end.truncated === true || nativeTruncated,
+      stdoutTruncated: end.stdoutTruncated === true,
+      stderrTruncated: end.stderrTruncated === true || nativeTruncated,
+      stdoutSpool: limits?.stdoutSpoolPath,
+      stderrSpool: limits?.stderrSpoolPath,
+      nativeStderrSpool:
+        limits?.stderrMode === 'spool' && nativeBytes > 0 ? nativeSpool : undefined,
     };
   }
 
-  private async waitNativeMarker(id: string, timeoutMs: number): Promise<Buffer> {
-    const needle = Buffer.from('FAUXNIX_ERR_END:' + id + '\n', 'utf8');
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() < deadline) {
-      const buf = Buffer.concat(this.stderrChunks);
-      const idx = buf.indexOf(needle);
-      if (idx >= 0) {
-        const before = buf.subarray(0, idx);
-        const after = buf.subarray(idx + needle.length);
-        this.stderrChunks = after.length ? [Buffer.from(after)] : [];
-        return Buffer.from(before) as Buffer;
+  private beginNativeCapture(
+    id: string,
+    mode: HostStreamMode,
+    limit: number,
+    spoolPath: string | undefined,
+    timeoutMs: number,
+  ): Promise<{ bytesSeen: number }> {
+    this.cancelNativeCapture();
+    return new Promise<{ bytesSeen: number }>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.nativeCapture?.id !== id) return;
+        const state = this.nativeCapture;
+        const failure = state.ioError ?? new Error('fauxnix: native stderr marker missing');
+        this.closeNativeSpool(state);
+        this.nativeCapture = null;
+        reject(failure);
+      }, timeoutMs);
+      let spoolFd: number | undefined;
+      let ioError: NativeStderrSpoolError | undefined;
+      if (mode !== 'discard' && spoolPath) {
+        try {
+          spoolFd = openSync(spoolPath, 'w');
+        } catch (e) {
+          ioError = new NativeStderrSpoolError('open', spoolPath, e);
+        }
       }
-      await new Promise((r) => setTimeout(r, 15));
+      this.nativeCapture = {
+        id,
+        needle: Buffer.from('FAUXNIX_ERR_END:' + id + '\n', 'utf8'),
+        mode,
+        limit: Math.max(0, limit),
+        tail: Buffer.alloc(0),
+        spoolPath,
+        spoolFd,
+        bytesWritten: 0,
+        bytesSeen: 0,
+        ioError,
+        resolve,
+        reject,
+        timer,
+      };
+      if (this.stderrChunks.length) {
+        const pending = Buffer.concat(this.stderrChunks);
+        this.stderrChunks = [];
+        this.onNativeStderr(pending);
+      }
+    });
+  }
+
+  private appendNativePayload(
+    state: NonNullable<PowerShellHost['nativeCapture']>,
+    data: Buffer,
+  ): void {
+    if (!data.length) return;
+    state.bytesSeen += data.length;
+    if (state.ioError || state.mode === 'discard' || state.spoolFd === undefined) return;
+    let retained = data;
+    if (state.mode === 'capture') {
+      const remaining = Math.max(0, state.limit + 3 - state.bytesWritten);
+      retained = data.subarray(0, remaining);
     }
-    throw new Error('fauxnix: native stderr marker missing');
+    try {
+      let offset = 0;
+      while (offset < retained.length) {
+        const remaining = retained.length - offset;
+        const written = this.nativeSpoolWrite(state.spoolFd, retained, offset, remaining);
+        if (!Number.isInteger(written) || written <= 0 || written > remaining) {
+          throw new Error('short write to native stderr spool');
+        }
+        offset += written;
+        state.bytesWritten += written;
+      }
+    } catch (e) {
+      state.ioError = new NativeStderrSpoolError('write', state.spoolPath, e);
+      this.closeNativeSpool(state);
+    }
+  }
+
+  private onNativeStderr(chunk: Buffer): void {
+    const state = this.nativeCapture;
+    if (!state) {
+      // Startup/teardown noise is diagnostic only. Keep a bounded tail so a
+      // noisy host cannot grow the resident Node process indefinitely.
+      const max = DEFAULT_STDERR_LIMIT;
+      const combined = Buffer.concat([...this.stderrChunks, chunk]);
+      this.stderrChunks = [Buffer.from(combined.subarray(Math.max(0, combined.length - max)))];
+      return;
+    }
+    const combined = state.tail.length ? Buffer.concat([state.tail, chunk]) : chunk;
+    const idx = combined.indexOf(state.needle);
+    if (idx >= 0) {
+      this.appendNativePayload(state, combined.subarray(0, idx));
+      const after = combined.subarray(idx + state.needle.length);
+      const ioError = state.ioError;
+      clearTimeout(state.timer);
+      this.closeNativeSpool(state);
+      this.nativeCapture = null;
+      if (after.length) this.onNativeStderr(after);
+      if (ioError) state.reject(ioError);
+      else state.resolve({ bytesSeen: state.bytesSeen });
+      return;
+    }
+    const keep = Math.min(state.needle.length - 1, combined.length);
+    const emit = combined.length - keep;
+    if (emit > 0) this.appendNativePayload(state, combined.subarray(0, emit));
+    state.tail = Buffer.from(combined.subarray(emit));
+  }
+
+  private cancelNativeCapture(): void {
+    const state = this.nativeCapture;
+    if (!state) return;
+    clearTimeout(state.timer);
+    this.appendNativePayload(state, state.tail);
+    const ioError = state.ioError;
+    this.closeNativeSpool(state);
+    this.nativeCapture = null;
+    state.reject(ioError ?? new Error('fauxnix: native stderr capture cancelled'));
+  }
+
+  private closeNativeSpool(state: NonNullable<PowerShellHost['nativeCapture']>): void {
+    if (state.spoolFd === undefined) return;
+    try {
+      closeSync(state.spoolFd);
+    } catch {
+      /* already closed */
+    }
+    state.spoolFd = undefined;
+  }
+
+  private readUtf8Prefix(
+    file: string,
+    limit: number,
+    totalBytes = statSync(file).size,
+  ): { data: Buffer; truncated: boolean } {
+    const size = statSync(file).size;
+    const wanted = Math.min(size, Math.max(0, limit) + 3);
+    const buf = Buffer.alloc(wanted);
+    if (wanted > 0) {
+      const fd = openSync(file, 'r');
+      try {
+        let offset = 0;
+        while (offset < wanted) {
+          const n = readSync(fd, buf, offset, wanted - offset, offset);
+          if (n <= 0) break;
+          offset += n;
+        }
+      } finally {
+        closeSync(fd);
+      }
+    }
+    let use = Math.min(limit, buf.length);
+    if (use < buf.length && use > 0 && (buf[use] & 0xc0) === 0x80) {
+      while (use > 0 && (buf[use] & 0xc0) === 0x80) use--;
+    }
+    return { data: Buffer.from(buf.subarray(0, use)), truncated: totalBytes > use };
+  }
+
+  private removeRequestSpools(limits: HostOutputLimits): void {
+    for (const file of [
+      limits.stdoutSpoolPath,
+      limits.stderrSpoolPath,
+      limits.nativeStderrSpoolPath,
+    ]) {
+      if (!file) continue;
+      try {
+        rmSync(file, { force: true });
+      } catch {
+        /* best effort; preserve the original transport error */
+      }
+    }
   }
 
   private failWaiters(err: Error): void {

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -663,6 +663,10 @@ export function translateSimple(
   hasStdin: boolean,
   translation: TranslationContext = EXECUTE_TRANSLATION,
 ): string {
+  const nativeTerm =
+    "(-not $script:fx_csub -and (($MyInvocation.MyCommand.Name -eq '') -or " +
+    (position === 'last' ? '$true' : '$false') +
+    '))';
   // assignment-only segment (`X=1; cmd`): bash semantics are "set for the
   // rest of the shell". Reuse the export code path — persist + env shadow —
   // so empty values (`X=`) and `[[ -v X ]]` behave like bash (documented
@@ -732,7 +736,10 @@ export function translateSimple(
       '  $fx_na = [object[]](' + argListExpr(cmd.args) + ')',
       '  $fx_cmd = [string]$fx_cw[0]',
       '  if ($fx_cw.Count -gt 1) { $fx_na = [object[]](@($fx_cw[1..($fx_cw.Count - 1)]) + $fx_na) }',
-      '  ' + (hasStdin ? '($input | fx-native $fx_cmd $fx_na)' : 'fx-native $fx_cmd $fx_na'),
+      '  ' +
+        (hasStdin
+          ? '($input | fx-native $fx_cmd $fx_na ' + nativeTerm + ')'
+          : 'fx-native $fx_cmd $fx_na ' + nativeTerm),
       '}',
     );
     body = emptyCmdLines.join('\n');
@@ -745,7 +752,7 @@ export function translateSimple(
       // via fx-native (Win32 command line + Process). `& name @array` on
       // PS 5.1 drops empty argv entries and eats embedded quotes.
       const nameExpr = psStr(nameLit);
-      const invoke = 'fx-native ' + nameExpr + ' $fx_na';
+      const invoke = 'fx-native ' + nameExpr + ' $fx_na ' + nativeTerm;
       body = [
         '$fx_na = [object[]](' + argListExpr(cmd.args) + ')',
         (hasStdin ? '($input | ' + invoke + ')' : invoke),
@@ -754,7 +761,7 @@ export function translateSimple(
   } else {
     // dynamic command name — evaluate it
     const nameExpr = exprOfWord(cmd.name);
-    const invoke = 'fx-native (' + nameExpr + ') $fx_na';
+    const invoke = 'fx-native (' + nameExpr + ') $fx_na ' + nativeTerm;
     body = [
       '$fx_na = [object[]](' + argListExpr(cmd.args) + ')',
       (hasStdin ? '($input | ' + invoke + ')' : invoke),
@@ -1897,7 +1904,30 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '}',
     ],
     'fx-native': [
-      'function fx-native($name, $argv) {',
+      "if (-not ('FauxnixTextPump' -as [type])) {",
+      "  Add-Type -TypeDefinition @'",
+      'using System;',
+      'using System.IO;',
+      'using System.Text;',
+      'using System.Threading.Tasks;',
+      'public static class FauxnixTextPump {',
+      '  public static async Task CopyAsync(TextReader reader, TextWriter writer) {',
+      '    var buffer = new char[4096];',
+      '    int read;',
+      '    while ((read = await reader.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0) {',
+      '      await writer.WriteAsync(buffer, 0, read).ConfigureAwait(false);',
+      '    }',
+      '    await writer.FlushAsync().ConfigureAwait(false);',
+      '  }',
+      '  public static async Task CopyFileAsync(TextReader reader, string path) {',
+      '    using (var writer = new StreamWriter(path, false, new UTF8Encoding(false))) {',
+      '      await CopyAsync(reader, writer).ConfigureAwait(false);',
+      '    }',
+      '  }',
+      '}',
+      "'@",
+      '}',
+      'function fx-native($name, $argv, $term) {',
       '  if ($null -eq $argv) { $argv = @() } else { $argv = [object[]]@($argv) }',
       '  $app = Get-Command -Name $name -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1',
       '  if ($null -eq $app) {',
@@ -1956,35 +1986,40 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '  $psi.RedirectStandardError = $true',
       '  $psi.CreateNoWindow = $true',
       '  $psi.WorkingDirectory = [Environment]::CurrentDirectory',
-      // StreamReader.ReadToEndAsync is .NET 4.5 (PS 5.1). Start readers
-      // before writing stdin so a chatty child cannot fill the 64KB pipe.
+      // Drain both child pipes concurrently into disk-backed spools before
+      // replaying them. This prevents either 64KB OS pipe from blocking the
+      // child and avoids retaining the complete output in a .NET string.
       "  if ($env:FAUXNIX_NATIVE_ENCODING -eq 'ansi') { $enc = [System.Text.Encoding]::GetEncoding(936) } else { $enc = New-Object System.Text.UTF8Encoding $false }",
       '  $psi.StandardOutputEncoding = $enc',
       '  $psi.StandardErrorEncoding = $enc',
       '  $p = New-Object System.Diagnostics.Process',
       '  $p.StartInfo = $psi',
-      '  [void]$p.Start()',
-      '  $outTask = $p.StandardOutput.ReadToEndAsync()',
-      '  $errTask = $p.StandardError.ReadToEndAsync()',
-      '  $ins = @($input)',
-      '  if ($ins.Count -gt 0) {',
-      '    foreach ($fx_ln in $ins) { $p.StandardInput.WriteLine([string]$fx_ln) }',
+      '  $fx_no = $null',
+      '  $fx_spoolUtf8 = New-Object System.Text.UTF8Encoding $false',
+      '  try {',
+      '    if (-not $term) {',
+      "      if ($env:FAUXNIX_NATIVE_SPOOL_DIR) { $fx_no = Join-Path $env:FAUXNIX_NATIVE_SPOOL_DIR (([guid]::NewGuid().ToString('N')) + '.out') }",
+      '      else { $fx_no = [IO.Path]::GetTempFileName() }',
+      '    }',
+      '    [void]$p.Start()',
+      '    if ($term) { $outTask = [FauxnixTextPump]::CopyAsync($p.StandardOutput, [Console]::Out) }',
+      '    else { $outTask = [FauxnixTextPump]::CopyFileAsync($p.StandardOutput, $fx_no) }',
+      '    $errTask = [FauxnixTextPump]::CopyAsync($p.StandardError, [Console]::Error)',
+      '    foreach ($fx_ln in $input) { $p.StandardInput.WriteLine([string]$fx_ln) }',
+      '    $p.StandardInput.Close()',
+      '    [void][System.Threading.Tasks.Task]::WaitAll(@($outTask, $errTask))',
+      '    [void]$p.WaitForExit()',
+      '    if (-not $term) {',
+      '      $fx_or = New-Object System.IO.StreamReader($fx_no, $fx_spoolUtf8)',
+      '      try { while (($fx_line = $fx_or.ReadLine()) -ne $null) { $fx_line } }',
+      '      finally { $fx_or.Dispose() }',
+      '    }',
+      '    $code = [int]$p.ExitCode',
+      '    if ($code -gt 0) { $script:fx_exit = $code } elseif ($code -lt 0) { $script:fx_exit = 1 }',
+      '  } finally {',
+      '    try { $p.Close() } catch {}',
+      '    if ($null -ne $fx_no) { Remove-Item -LiteralPath $fx_no -Force -ErrorAction SilentlyContinue }',
       '  }',
-      '  $p.StandardInput.Close()',
-      '  [void][System.Threading.Tasks.Task]::WaitAll(@($outTask, $errTask))',
-      '  [void]$p.WaitForExit()',
-      '  $errt = [string]$errTask.Result',
-      '  if ($errt.Length -gt 0) { [Console]::Error.Write($errt) }',
-      '  $t = [string]$outTask.Result',
-      "  $t = $t.Replace(([string][char]13 + [string][char]10), [string][char]10).Replace([string][char]13, [string][char]10)",
-      "  if ($t -ne '') {",
-      '    $parts = @($t.Split([char]10))',
-      "    if ($parts.Count -gt 0 -and $parts[$parts.Count - 1] -eq '') { $parts = $parts[0..($parts.Count - 2)] }",
-      '    foreach ($fx_ol in $parts) { $fx_ol }',
-      '  }',
-      '  $code = [int]$p.ExitCode',
-      '  if ($code -gt 0) { $script:fx_exit = $code } elseif ($code -lt 0) { $script:fx_exit = 1 }',
-      '  try { $p.Close() } catch {}',
       '}',
     ],
   };
@@ -2021,6 +2056,46 @@ export function hostBootstrapScript(): string {
 
 /** Raw UTF-8 JSON lines on stdin/stdout; command streams captured per frame. */
 const HOST_RPC_LOOP = `
+if (-not ('FauxnixBoundedStream' -as [type])) {
+  Add-Type -TypeDefinition @'
+using System;
+using System.IO;
+public sealed class FauxnixBoundedStream : Stream {
+  private readonly MemoryStream inner;
+  private readonly long limit;
+  private readonly long storageLimit;
+  private long totalWritten;
+  public bool Truncated { get; private set; }
+  public FauxnixBoundedStream(long limit) {
+    this.limit = Math.Max(0, limit);
+    this.storageLimit = this.limit + 3;
+    this.inner = new MemoryStream((int)Math.Min(this.storageLimit, 65536));
+  }
+  public byte[] ToArray() { return inner.ToArray(); }
+  public override bool CanRead { get { return false; } }
+  public override bool CanSeek { get { return false; } }
+  public override bool CanWrite { get { return true; } }
+  public override long Length { get { return inner.Length; } }
+  public override long Position { get { return inner.Position; } set { throw new NotSupportedException(); } }
+  public override void Flush() { }
+  public override int Read(byte[] buffer, int offset, int count) { throw new NotSupportedException(); }
+  public override long Seek(long offset, SeekOrigin origin) { throw new NotSupportedException(); }
+  public override void SetLength(long value) { throw new NotSupportedException(); }
+  public override void Write(byte[] buffer, int offset, int count) {
+    long remaining = Math.Max(0, storageLimit - inner.Length);
+    int keep = (int)Math.Min((long)count, remaining);
+    if (keep > 0) inner.Write(buffer, offset, keep);
+    totalWritten += count;
+    if (totalWritten > limit) Truncated = true;
+  }
+  public override void WriteByte(byte value) {
+    if (inner.Length < storageLimit) inner.WriteByte(value);
+    totalWritten++;
+    if (totalWritten > limit) Truncated = true;
+  }
+}
+'@
+}
 $fx_utf8 = New-Object System.Text.UTF8Encoding $false
 $fx_in = [Console]::OpenStandardInput()
 $fx_out = [Console]::OpenStandardOutput()
@@ -2040,8 +2115,8 @@ function fx-emit-chunks($type, $id, [byte[]]$bytes, $limit, [ref]$seq) {
   if ($null -ne $bytes) { $n = $bytes.Length }
   $use = $n
   $trunc = $false
-  # limit 0 = uncapped (file-redirected streams must never be budget-clipped)
-  if ($limit -gt 0 -and $use -gt $limit) {
+  # limit -1 = uncapped; zero is a real empty caller budget
+  if ($limit -ge 0 -and $use -gt $limit) {
     $use = $limit
     $trunc = $true
     # back the cut off to a valid UTF-8 boundary — a split codepoint makes
@@ -2066,6 +2141,18 @@ function fx-emit-chunks($type, $id, [byte[]]$bytes, $limit, [ref]$seq) {
     $off += $len
   }
   return $trunc
+}
+function fx-new-capture($mode, $limit, $spoolPath) {
+  if ([string]$mode -eq 'discard') { return [System.IO.Stream]::Null }
+  if ([string]$mode -eq 'spool') {
+    return (New-Object System.IO.FileStream([string]$spoolPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::Read))
+  }
+  return (New-Object FauxnixBoundedStream ([Math]::Max(0, [long]$limit)))
+}
+function fx-capture-bytes($stream) {
+  if ($stream -is [FauxnixBoundedStream]) { return $stream.ToArray() }
+  if ($stream -is [System.IO.MemoryStream]) { return $stream.ToArray() }
+  return (New-Object byte[] 0)
 }
 while ($true) {
   $fx_line = $fx_reader.ReadLine()
@@ -2094,12 +2181,24 @@ while ($true) {
       }
     }
     $fx_script = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String([string]$fx_req.scriptB64))
-    $fx_msOut = New-Object System.IO.MemoryStream
-    $fx_msErr = New-Object System.IO.MemoryStream
+    $fx_outLimit = 8388608
+    $fx_errLimit = 1048576
+    if ($null -ne $fx_req.PSObject.Properties['stdoutLimit']) { $fx_outLimit = [int]$fx_req.stdoutLimit }
+    if ($null -ne $fx_req.PSObject.Properties['stderrLimit']) { $fx_errLimit = [int]$fx_req.stderrLimit }
+    $fx_outMode = 'capture'
+    $fx_errMode = 'capture'
+    $fx_outSpool = ''
+    $fx_errSpool = ''
+    if ($null -ne $fx_req.PSObject.Properties['stdoutMode']) { $fx_outMode = [string]$fx_req.stdoutMode }
+    if ($null -ne $fx_req.PSObject.Properties['stderrMode']) { $fx_errMode = [string]$fx_req.stderrMode }
+    if ($null -ne $fx_req.PSObject.Properties['stdoutSpoolPath']) { $fx_outSpool = [string]$fx_req.stdoutSpoolPath }
+    if ($null -ne $fx_req.PSObject.Properties['stderrSpoolPath']) { $fx_errSpool = [string]$fx_req.stderrSpoolPath }
+    $fx_msOut = fx-new-capture $fx_outMode $fx_outLimit $fx_outSpool
+    $fx_msErr = fx-new-capture $fx_errMode $fx_errLimit $fx_errSpool
     $fx_outW = New-Object System.IO.StreamWriter($fx_msOut, $fx_utf8, 1024, $true)
     $fx_errW = New-Object System.IO.StreamWriter($fx_msErr, $fx_utf8, 1024, $true)
-    $fx_outW.NewLine = [string][char]13 + [string][char]10
-    $fx_errW.NewLine = [string][char]13 + [string][char]10
+    $fx_outW.NewLine = [string][char]10
+    $fx_errW.NewLine = [string][char]10
     $fx_outW.AutoFlush = $true
     $fx_errW.AutoFlush = $true
     [Console]::SetOut($fx_outW)
@@ -2127,24 +2226,29 @@ while ($true) {
   }
   $fx_outBytes = New-Object byte[] 0
   $fx_errBytes = New-Object byte[] 0
-  if ($null -ne $fx_msOut) { $fx_outBytes = $fx_msOut.ToArray() }
-  if ($null -ne $fx_msErr) { $fx_errBytes = $fx_msErr.ToArray() }
+  if ($null -ne $fx_msOut) { $fx_outBytes = fx-capture-bytes $fx_msOut }
+  if ($null -ne $fx_msErr) { $fx_errBytes = fx-capture-bytes $fx_msErr }
+  try { if ($null -ne $fx_outW) { $fx_outW.Dispose() } } catch {}
+  try { if ($null -ne $fx_errW) { $fx_errW.Dispose() } } catch {}
+  try { if ($null -ne $fx_msOut -and $fx_msOut -ne [System.IO.Stream]::Null) { $fx_msOut.Dispose() } } catch {}
+  try { if ($null -ne $fx_msErr -and $fx_msErr -ne [System.IO.Stream]::Null) { $fx_msErr.Dispose() } } catch {}
   if ($fx_v2) {
-    $fx_outLimit = 8388608
-    $fx_errLimit = 1048576
-    if ($null -ne $fx_req.PSObject.Properties['stdoutLimit']) { $fx_outLimit = [int]$fx_req.stdoutLimit }
-    if ($null -ne $fx_req.PSObject.Properties['stderrLimit']) { $fx_errLimit = [int]$fx_req.stderrLimit }
     $fx_outSeq = 0
     $fx_errSeq = 0
-    $fx_trunc = $false
-    if (fx-emit-chunks 'stdout' $fx_id $fx_outBytes $fx_outLimit ([ref]$fx_outSeq)) { $fx_trunc = $true }
-    if (fx-emit-chunks 'stderr' $fx_id $fx_errBytes $fx_errLimit ([ref]$fx_errSeq)) { $fx_trunc = $true }
+    $fx_outTrunc = $false
+    $fx_errTrunc = $false
+    if ($fx_msOut -is [FauxnixBoundedStream] -and $fx_msOut.Truncated) { $fx_outTrunc = $true }
+    if ($fx_msErr -is [FauxnixBoundedStream] -and $fx_msErr.Truncated) { $fx_errTrunc = $true }
+    $fx_outEmitLimit = $(if ($fx_outMode -eq 'capture') { $fx_outLimit } else { -1 })
+    $fx_errEmitLimit = $(if ($fx_errMode -eq 'capture') { $fx_errLimit } else { -1 })
+    if (fx-emit-chunks 'stdout' $fx_id $fx_outBytes $fx_outEmitLimit ([ref]$fx_outSeq)) { $fx_outTrunc = $true }
+    if (fx-emit-chunks 'stderr' $fx_id $fx_errBytes $fx_errEmitLimit ([ref]$fx_errSeq)) { $fx_errTrunc = $true }
     $fx_nativeErr = [Console]::OpenStandardError()
     $fx_mark = $fx_utf8.GetBytes(('FAUXNIX_ERR_END:' + $fx_id + [char]10))
     $fx_nativeErr.Write($fx_mark, 0, $fx_mark.Length)
     $fx_nativeErr.Flush()
-    $fx_end = '{"v":2,"type":"end","id":"' + $fx_id + '","exitCode":' + $fx_code + ',"timedOut":false,"cancelled":false,"truncated":'
-    if ($fx_trunc) { $fx_end = $fx_end + 'true}' } else { $fx_end = $fx_end + 'false}' }
+    $fx_trunc = $fx_outTrunc -or $fx_errTrunc
+    $fx_end = '{"v":2,"type":"end","id":"' + $fx_id + '","exitCode":' + $fx_code + ',"timedOut":false,"cancelled":false,"truncated":' + ([string]$fx_trunc).ToLowerInvariant() + ',"stdoutTruncated":' + ([string]$fx_outTrunc).ToLowerInvariant() + ',"stderrTruncated":' + ([string]$fx_errTrunc).ToLowerInvariant() + '}'
     $fx_proto.WriteLine($fx_end)
   } else {
     $fx_outB64 = ''

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -5,13 +5,26 @@
 import { beforeAll, afterAll, describe, expect, it } from 'vitest';
 import { getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync, appendFileSync, realpathSync } from 'node:fs';
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+  appendFileSync,
+  readdirSync,
+  statSync,
+  realpathSync,
+  writeSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parseCommand } from '../src/parser.js';
 import { translateCommandList } from '../src/translator.js';
 import { FauxnixSession } from '../src/executor.js';
 import { resolvePowerShell } from '../src/powershell.js';
+import { PowerShellHost } from '../src/ps-host.js';
 import '../src/commands/install-all.js';
 
 const onWindows = process.platform === 'win32';
@@ -901,6 +914,7 @@ describe.skipIf(!hasPs)(`integration (real ${selectedPowerShell.executable})`, {
     expect((await run('echo "$(echo a; echo b)"')).stdout).toBe('a\nb\n');
     expect((await run('echo $(false; echo x)')).stdout.trim()).toBe('x');
     expect((await run('echo $(true && echo y)')).stdout.trim()).toBe('y');
+    expect((await run('echo "$(node -p 21+21)"')).stdout).toBe('42\n');
   });
 
   it('VAR=value prefixes do not leak past the command', async () => {
@@ -1207,11 +1221,17 @@ describe.skipIf(!hasPs)(`integration (real ${selectedPowerShell.executable})`, {
     expect(stdout.stdout).toBe('');
   });
 
-  it('printf CRLF without a trailing LF is preserved on redirect', async () => {
-    const r = await run("printf 'a\\r\\nb' > cr.txt; wc -c cr.txt");
+  it('printf CRLF bytes are preserved for redirects and caller output', async () => {
+    const r = await run(
+      "printf 'a\\r\\nb' > cr.txt; printf 'x\\r\\n' > cr-tail.txt; wc -c cr.txt cr-tail.txt",
+    );
     expect(r.exitCode).toBe(0);
     expect(r.stdout.trim()).toMatch(/4 .*cr\.txt/);
+    expect(r.stdout.trim()).toMatch(/3 .*cr-tail\.txt/);
     expect(readFileSync(join(dir, 'cr.txt'))).toEqual(Buffer.from('a\r\nb'));
+    expect(readFileSync(join(dir, 'cr-tail.txt'))).toEqual(Buffer.from('x\r\n'));
+    const caller = await run("printf 'x\\r\\n'");
+    expect(caller.stdout).toBe('x\r\n');
   });
 
   it('cd then redirect writes under the new cwd, not the entry cwd', async () => {
@@ -2092,6 +2112,7 @@ describe.skipIf(!hasPs)(`integration (real ${selectedPowerShell.executable})`, {
       );
       expect(r.exitCode).toBe(0);
       expect(readFileSync(target, 'utf8')).toBe('AAAAAAAAAA');
+      expect(r.truncated).toBe(false);
     } finally {
       await extra.dispose();
     }
@@ -2113,6 +2134,220 @@ describe.skipIf(!hasPs)(`integration (real ${selectedPowerShell.executable})`, {
     }
   }, 30000);
 
+  it('applies output budgets across all list segments', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const r = await extra.run(
+        translateCommandList(parseCommand("printf 'AAAA'; printf 'BBBBBBBB'; printf 'CCCC'")),
+        { stdoutLimit: 8 },
+      );
+      expect(r.stdout).toBe('AAAABBBB');
+      expect(Buffer.byteLength(r.stdout, 'utf8')).toBe(8);
+      expect(r.truncated).toBe(true);
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('counts host line endings in caller bytes before truncating', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const r = await extra.run(translateCommandList(parseCommand('echo a; echo b')), {
+        stdoutLimit: 4,
+      });
+      expect(r.stdout).toBe('a\nb\n');
+      expect(Buffer.byteLength(r.stdout, 'utf8')).toBe(4);
+      expect(r.truncated).toBe(false);
+
+      const clipped = await extra.run(
+        translateCommandList(parseCommand('echo A; echo B; echo C')),
+        { stdoutLimit: 4 },
+      );
+      expect(clipped.stdout).toBe('A\nB\n');
+      expect(Buffer.byteLength(clipped.stdout, 'utf8')).toBe(4);
+      expect(clipped.truncated).toBe(true);
+
+      const objectLines = await extra.run(
+        [
+          {
+            op: ';',
+            script: '',
+            body: "'A'; 'B'; 'C'",
+            redirects: [],
+            outputRedirects: [],
+            stdinRedirects: [],
+          },
+        ],
+        { stdoutLimit: 4 },
+      );
+      expect(objectLines.stdout).toBe('A\nB\n');
+      expect(Buffer.byteLength(objectLines.stdout, 'utf8')).toBe(4);
+      expect(objectLines.truncated).toBe(true);
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('keeps stdout and stderr caller budgets independent under sustained output', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const r = await extra.run(
+        translateCommandList(
+          parseCommand(
+            `node -e "process.stdout.write('O'.repeat(262144));process.stderr.write('E'.repeat(262144))"`,
+          ),
+        ),
+        { stdoutLimit: 31, stderrLimit: 47 },
+      );
+      expect(r.stdout).toBe('O'.repeat(31));
+      expect(r.stderr).toBe('E'.repeat(47));
+      expect(r.truncated).toBe(true);
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('a stdout file redirect does not disable the stderr caller budget', async () => {
+    const extra = new FauxnixSession();
+    const target = join(dir, 'budget-large-stdout.txt');
+    try {
+      await extra.prewarm();
+      const r = await extra.run(
+        translateCommandList(
+          parseCommand(
+            `node -e "process.stdout.write('O'.repeat(262144));process.stderr.write('E'.repeat(262144))" > ${JSON.stringify(target)}`,
+          ),
+        ),
+        { stdoutLimit: 9, stderrLimit: 53 },
+      );
+      expect(readFileSync(target, 'utf8')).toBe('O'.repeat(262144));
+      expect(r.stdout).toBe('');
+      expect(r.stderr).toBe('E'.repeat(53));
+      expect(r.truncated).toBe(true);
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('a stderr file redirect does not disable the stdout caller budget', async () => {
+    const extra = new FauxnixSession();
+    const target = join(dir, 'budget-large-stderr.txt');
+    try {
+      await extra.prewarm();
+      const r = await extra.run(
+        translateCommandList(
+          parseCommand(
+            `node -e "process.stdout.write('O'.repeat(262144));process.stderr.write('E'.repeat(262144))" 2> ${JSON.stringify(target)}`,
+          ),
+        ),
+        { stdoutLimit: 59, stderrLimit: 11 },
+      );
+      expect(readFileSync(target, 'utf8')).toBe('E'.repeat(262144));
+      expect(r.stdout).toBe('O'.repeat(59));
+      expect(r.stderr).toBe('');
+      expect(r.truncated).toBe(true);
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('keeps UTF-8 boundaries while spending a shared multi-segment budget', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const r = await extra.run(
+        translateCommandList(parseCommand(`printf '你'; printf '好世界'`)),
+        { stdoutLimit: 7 },
+      );
+      expect(r.stdout).toBe('你好');
+      expect(Buffer.byteLength(r.stdout, 'utf8')).toBe(6);
+      expect(r.truncated).toBe(true);
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('does not fill a clipped UTF-8 prefix gap with later segments', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      for (const [limit, expected] of [
+        [1, ''],
+        [2, ''],
+        [3, '你'],
+      ] as const) {
+        const r = await extra.run(
+          translateCommandList(parseCommand(`printf '你'; printf 'X'`)),
+          { stdoutLimit: limit },
+        );
+        expect(r.stdout).toBe(expected);
+        expect(r.truncated).toBe(true);
+      }
+
+      const stderrPlans = ["[Console]::Error.Write('你')", "[Console]::Error.Write('X')"].map(
+        (body) => ({
+          op: ';' as const,
+          script: '',
+          body,
+          redirects: [],
+          outputRedirects: [],
+          stdinRedirects: [],
+        }),
+      );
+      const stderr = await extra.run(stderrPlans, { stderrLimit: 2 });
+      expect(stderr.stderr).toBe('');
+      expect(stderr.truncated).toBe(true);
+
+      const normalizedAway = [
+        {
+          op: ';' as const,
+          script: '',
+          body: "[Console]::Error.Write((' ' * 100) + 'X')",
+          redirects: [],
+          outputRedirects: [],
+          stdinRedirects: [],
+        },
+        {
+          op: ';' as const,
+          script: '',
+          body: "[Console]::Error.Write('Y')",
+          redirects: [],
+          outputRedirects: [],
+          stdinRedirects: [],
+        },
+      ];
+      const normalized = await extra.run(normalizedAway, { stderrLimit: 1 });
+      expect(normalized.stderr).toBe('');
+      expect(normalized.truncated).toBe(true);
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('validates caller output budgets and honors zero and the supported maximum', async () => {
+    const extra = new FauxnixSession();
+    const plans = translateCommandList(parseCommand("printf 'X'"));
+    try {
+      for (const value of [-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_644]) {
+        await expect(extra.run(plans, { stdoutLimit: value })).rejects.toThrow(/stdoutLimit/);
+      }
+      await expect(extra.run(plans, { stderrLimit: -1 })).rejects.toThrow(/stderrLimit/);
+
+      const zero = await extra.run(plans, { stdoutLimit: 0 });
+      expect(zero.stdout).toBe('');
+      expect(zero.truncated).toBe(true);
+
+      const maximum = await extra.run(plans, { stdoutLimit: 2_147_483_643 });
+      expect(maximum.stdout).toBe('X');
+      expect(maximum.truncated).toBe(false);
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
   it('whitespace-only stdout is preserved', async () => {
     const r = await run("printf '   '");
     expect(r.exitCode).toBe(0);
@@ -2121,16 +2356,183 @@ describe.skipIf(!hasPs)(`integration (real ${selectedPowerShell.executable})`, {
     expect(r.timedOut).toBe(false);
   });
 
-  it('native stderr is returned once and does not leak into the next command', async () => {
-    const noisy = await run(`node -e "process.stderr.write('E'.repeat(4096)); process.exit(7)"`);
-    expect(noisy.exitCode).toBe(7);
-    expect(noisy.stderr).toContain('E'.repeat(64));
-    expect(noisy.stderr.split('E').length - 1).toBeGreaterThanOrEqual(4096);
-    const next = await run('echo hi');
-    expect(next.exitCode).toBe(0);
-    expect(next.stdout.trim()).toBe('hi');
-    expect(next.stderr).not.toContain('E'.repeat(64));
-  });
+  it('bounds native stderr while preserving the marker and next request', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const noisy = await extra.run(
+        translateCommandList(
+          parseCommand(`node -e "process.stderr.write('E'.repeat(1048576)); process.exit(7)"`),
+        ),
+        { stderrLimit: 65 },
+      );
+      expect(noisy.exitCode).toBe(7);
+      expect(noisy.stderr).toBe('E'.repeat(65));
+      expect(noisy.truncated).toBe(true);
+      const next = await extra.run(translateCommandList(parseCommand('echo hi')));
+      expect(next.exitCode).toBe(0);
+      expect(next.stdout.trim()).toBe('hi');
+      expect(next.stderr).not.toContain('E'.repeat(64));
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('keeps direct host capture bounded and preserves UTF-8 raw stderr framing', async () => {
+    const hostFile = join(dir, 'budget-direct-host.ps1');
+    const host = new PowerShellHost(hostFile, () => ({ ...process.env }));
+    try {
+      await host.ready();
+      const rawScript = [
+        "$fx_raw = [Text.Encoding]::UTF8.GetBytes(('你好世界' * 65536))",
+        '$fx_rawStream = [Console]::OpenStandardError()',
+        '$fx_off = 0',
+        'while ($fx_off -lt $fx_raw.Length) {',
+        '  $fx_take = [Math]::Min(4093, $fx_raw.Length - $fx_off)',
+        '  $fx_rawStream.Write($fx_raw, $fx_off, $fx_take)',
+        '  $fx_rawStream.Flush()',
+        '  $fx_off += $fx_take',
+        '}',
+      ].join('\n');
+      const raw = await host.invoke(rawScript, {}, 30_000, undefined, {
+        stdoutMode: 'capture',
+        stdoutLimit: 13,
+        stderrMode: 'capture',
+        stderrLimit: 7,
+      });
+      expect(raw.stdout.length).toBe(0);
+      expect(raw.stderr.length).toBe(0);
+      expect(raw.nativeStderr?.toString('utf8')).toBe('你好');
+      expect(raw.truncated).toBe(true);
+
+      const next = await host.invoke("[Console]::Out.Write('ok')", {}, 30_000, undefined, {
+        stdoutMode: 'capture',
+        stdoutLimit: 13,
+        stderrMode: 'capture',
+        stderrLimit: 13,
+      });
+      expect(next.stdout.toString('utf8')).toBe('ok');
+      expect(next.stderr.length).toBe(0);
+    } finally {
+      await host.stop();
+      rmSync(hostFile, { force: true });
+    }
+  }, 30000);
+
+  it('contains native stderr spool write failures and restarts a clean host', async () => {
+    for (const failure of ['ENOSPC', 'SHORT_WRITE'] as const) {
+      const hostFile = join(dir, 'budget-native-write-' + failure.toLowerCase() + '.ps1');
+      let failOnce = true;
+      const host = new PowerShellHost(
+        hostFile,
+        () => ({ ...process.env }),
+        resolvePowerShell(),
+        (fd, buffer, offset, length) => {
+          if (failOnce) {
+            failOnce = false;
+            if (failure === 'SHORT_WRITE') return 0;
+            throw Object.assign(new Error('simulated full device'), { code: 'ENOSPC' });
+          }
+          return writeSync(fd, buffer, offset, length);
+        },
+      );
+      try {
+        await host.ready();
+        const failed = await host.invoke(
+          [
+            "$fx_raw = [Text.Encoding]::UTF8.GetBytes('NATIVE-FAIL')",
+            '$fx_rawStream = [Console]::OpenStandardError()',
+            '$fx_rawStream.Write($fx_raw, 0, $fx_raw.Length)',
+            '$fx_rawStream.Flush()',
+          ].join('\n'),
+          {},
+          30_000,
+          undefined,
+          { stdoutMode: 'capture', stdoutLimit: 17, stderrMode: 'capture', stderrLimit: 17 },
+        );
+        expect(failed.exitCode).toBe(1);
+        expect(failed.timedOut).toBe(false);
+        expect(failed.cancelled).toBe(false);
+        expect(failed.stderr.toString('utf8')).toContain('native stderr spool write failed');
+        if (failure === 'ENOSPC') expect(failed.stderr.toString('utf8')).toContain('ENOSPC');
+        else expect(failed.stderr.toString('utf8')).toContain('short write');
+
+        const leftovers = readdirSync(dir).filter(
+          (name) =>
+            name.startsWith('budget-native-write-' + failure.toLowerCase() + '.ps1.') &&
+            (name.endsWith('.native-stderr') || name.endsWith('.stdout') ||
+              name.endsWith('.stderr') || name.endsWith('.native')),
+        );
+        expect(leftovers).toEqual([]);
+
+        const next = await host.invoke("[Console]::Out.Write('ok')", {}, 30_000, undefined, {
+          stdoutMode: 'capture',
+          stdoutLimit: 17,
+          stderrMode: 'capture',
+          stderrLimit: 17,
+        });
+        expect(next.exitCode).toBe(0);
+        expect(next.stdout.toString('utf8')).toBe('ok');
+        expect(next.stderr.toString('utf8')).not.toContain('NATIVE-FAIL');
+      } finally {
+        await host.stop();
+        rmSync(hostFile, { force: true });
+      }
+    }
+  }, 60000);
+
+  it('lands complete file output in a host spool without response buffering', async () => {
+    const hostFile = join(dir, 'budget-spool-host.ps1');
+    const host = new PowerShellHost(hostFile, () => ({ ...process.env }));
+    let spool: string | undefined;
+    try {
+      await host.ready();
+      const r = await host.invoke(
+        "[Console]::Out.Write(('Z' * 4194304))",
+        {},
+        30_000,
+        undefined,
+        {
+          stdoutMode: 'spool',
+          stdoutLimit: 17,
+          stderrMode: 'capture',
+          stderrLimit: 17,
+        },
+      );
+      spool = r.stdoutSpool;
+      expect(r.stdout.length).toBe(0);
+      expect(spool).toBeTruthy();
+      expect(statSync(spool!).size).toBe(4_194_304);
+      expect(readFileSync(spool!, 'utf8').slice(0, 64)).toBe('Z'.repeat(64));
+    } finally {
+      await host.stop();
+      if (spool) rmSync(spool, { force: true });
+      rmSync(hostFile, { force: true });
+    }
+  }, 30000);
+
+  it('removes native pipeline spools when a host request times out', async () => {
+    const hostFile = join(dir, 'budget-timeout-host.ps1');
+    const host = new PowerShellHost(hostFile, () => ({ ...process.env }));
+    try {
+      await host.ready();
+      const r = await host.invoke(
+        "fx-native 'node' ([object[]]@('-e', 'setTimeout(()=>{},10000)')) $false",
+        {},
+        500,
+        undefined,
+        { stdoutMode: 'capture', stdoutLimit: 17, stderrMode: 'capture', stderrLimit: 17 },
+      );
+      expect(r.timedOut).toBe(true);
+      const leaked = readdirSync(dir).filter(
+        (name) => name.startsWith('budget-timeout-host.ps1.') && name.endsWith('.native'),
+      );
+      expect(leaked).toEqual([]);
+    } finally {
+      await host.stop();
+      rmSync(hostFile, { force: true });
+    }
+  }, 30000);
 
   it('AbortSignal cancel unblocks the next request without running later segments', async () => {
     const extra = new FauxnixSession();

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -768,6 +768,9 @@ describe('translator', () => {
     expect(boot).toContain('"type":"ready"');
     expect(boot).toContain('FAUXNIX_ERR_END:');
     expect(boot).toContain('maxChunkBytes');
+    expect(boot).toContain('FauxnixBoundedStream');
+    expect(boot).toContain("$fx_outMode = 'capture'");
+    expect(boot).toContain("if ([string]$mode -eq 'discard')");
     expect(boot).toContain('ConvertFrom-Json');
     expect(boot).toContain('MaxJsonLength');
     expect(boot).not.toContain('exit $script:fx_exit');
@@ -853,7 +856,10 @@ describe('translator', () => {
     expect(body).toContain('fx-native');
     expect(body).not.toContain('@fx_na');
     const script = translateCommandList(parse('node --version'))[0].script;
-    expect(script).toContain('ReadToEndAsync');
+    expect(script).toContain('FauxnixTextPump');
+    expect(script).toContain('CopyAsync');
+    expect(script).toContain('GetTempFileName');
+    expect(script).not.toContain('ReadToEndAsync');
     expect(script).not.toContain('StartNew');
     expect(script).toContain("'.cmd'");
     expect(script).toContain("if ($null -eq $argv) { $argv = @() }");
@@ -1171,11 +1177,25 @@ describe('persistent PowerShell host protocol', () => {
   });
 
   it('encodes v2 run frames and parses v2 ready / v1 ready', () => {
-    const line = encodeHostRequest('r1', 'echo', { FAUXNIX_CWD: 'D:\\tmp' }, { v: 2, stdoutLimit: 10, stderrLimit: 4 });
-    const parsed = JSON.parse(line) as { v: number; type: string; stdoutLimit: number };
+    const line = encodeHostRequest('r1', 'echo', { FAUXNIX_CWD: 'D:\\tmp' }, {
+      v: 2,
+      stdoutLimit: 10,
+      stderrLimit: 4,
+      stdoutMode: 'capture',
+      stderrMode: 'discard',
+    });
+    const parsed = JSON.parse(line) as {
+      v: number;
+      type: string;
+      stdoutLimit: number;
+      stdoutMode: string;
+      stderrMode: string;
+    };
     expect(parsed.v).toBe(2);
     expect(parsed.type).toBe('run');
     expect(parsed.stdoutLimit).toBe(10);
+    expect(parsed.stdoutMode).toBe('capture');
+    expect(parsed.stderrMode).toBe('discard');
     expect(parseHostLine('{"v":2,"type":"ready","capabilities":{"cancel":false}}').v2?.type).toBe(
       'ready',
     );


### PR DESCRIPTION
## Problem

The response limits were applied only after several complete buffers already existed. Large native output, host frames, redirected files, command lists, and raw stderr could therefore consume far more memory than the returned result suggested.

## Fix

- drain native stdout/stderr concurrently into disk-backed spools
- retain only the remaining caller budget plus a four-byte UTF-8 boundary lookahead
- discard `/dev/null` output without retaining it
- stream file destinations from host spools into the already-open redirect descriptor
- enforce aggregate caller budgets across list segments and seal a stream after truncation
- emit host-generated line endings as LF while preserving explicit CRLF bytes
- report stdout/stderr truncation independently in the v2 end frame
- scan raw-stderr markers with constant tail memory
- contain native spool open/write failures, clean partial files, and restart the host
- clean request/native spools during timeout and cancellation recovery

## Scope

Duplicated descriptors are capped by the final destination budget, but stdout/stderr are still captured independently and replayed stdout-first. Chronological cross-pipe interleaving remains the merge-policy follow-up in #129; this PR does not claim to reconstruct that order.

## Verification

- rebased onto `main@deb836f`
- `npm audit`: 0
- release check, typecheck, and build: pass
- Windows PowerShell 5.1: 428 passed, 1 optional oracle skipped
- PowerShell 7.6: 428 passed, 1 optional oracle skipped
- package smoke: clean source install, packed install, and Qwen launcher pass
- Git Bash oracle: 249/253 identical (98.4%), with only the four documented mismatches
- CRLF, UTF-8 boundary, zero/maximum limit, fd-destination, spool-failure recovery, timeout, and next-request tests pass
- two independent latest-diff reviews: pass
- `git diff --check`: pass