### PR TITLE
feat: execute preplanned MCP workflows in one batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,26 @@ positional parameters (`set --` / `$1` / `"$@"`) across tool calls — it behave
 shell, not a stateless `exec`. `$0` is the MCP tool name (`bash` / `FAUXNIX_TOOL_NAME`), not a
 Windows path.
 
+For a workflow whose commands are already known, the MCP server also exposes
+`bash_batch`. It compiles every step before execution, runs the plan atomically
+in the same session, and returns one structured result per step in a single MCP
+round trip. It stops on the first nonzero exit by default; use separate `bash`
+calls only when the model must inspect one result before deciding the next
+command. Byte-exact workflows should include `wc -c FILE` or `stat -c %s FILE`
+as a verification step instead of inferring CRLF byte counts.
+
+```json
+{
+  "steps": [
+    { "id": "write", "command": "printf 'a\\r\\nb' > data.txt" },
+    { "id": "measure", "command": "wc -c data.txt" }
+  ]
+}
+```
+
+See [compiled MCP batch plans](docs/rfc-mcp-batch-plans.md) for timeout,
+budget, cancellation, and preflight semantics.
+
 ## What's translated
 
 ~105 commands, all output-matched against real GNU coreutils on Windows (Git Bash) during

--- a/docs/rfc-mcp-batch-plans.md
+++ b/docs/rfc-mcp-batch-plans.md
@@ -1,0 +1,117 @@
+# RFC: compiled MCP batch plans
+
+## Motivation
+
+The resident PowerShell host removed most per-command process startup, but it
+did not remove the agent/model round trip around every MCP call. The existing
+Codex benchmark already exposes that distinction: bundled PowerShell used five
+tool calls and 159 seconds, while granular fauxnix use took eleven calls and
+213 seconds. The same document notes that models which batch known commands
+close most of the gap.
+
+The original `bash` tool can already execute `;`, `&&`, and `||`, but its
+current schema offers no explicit multi-step affordance or per-step result.
+The server also cannot safely guess that a future MCP request should have been
+merged: it must answer the current request before it knows the next command.
+
+## Contract
+
+`bash_batch` is an additive MCP tool; the existing `bash` schema and result stay
+unchanged.
+
+```json
+{
+  "steps": [
+    { "id": "prepare", "command": "mkdir -p out && cd out" },
+    { "id": "write", "command": "printf 'a\\r\\nb' > data.txt" },
+    { "id": "measure", "command": "wc -c data.txt" }
+  ],
+  "stop_on_error": true,
+  "timeout_ms": 120000,
+  "stdout_limit_bytes": 262144,
+  "stderr_limit_bytes": 65536
+}
+```
+
+- 1–32 steps; optional IDs are labels only. Each command is at most 16,384 characters.
+- Every command is parsed and translated before step 1 executes. A compile
+  error therefore produces zero command side effects.
+- Steps execute serially under one session lifecycle lock. No ordinary run or
+  reset can interleave, and later steps see earlier cwd, environment, and file
+  changes.
+- Timeout and stdout/stderr limits cover the complete batch, not each step.
+- Output defaults and maxima are 256 KiB stdout and 64 KiB stderr, leaving
+  room for duplicated text/structured output and JSON escaping in stdio.
+- `stop_on_error` defaults to true. Timeout, cancellation, and host startup
+  failure always stop; ordinary nonzero exits may continue when explicitly
+  requested.
+- Structured content reports every requested step as completed, failed,
+  timed-out, cancelled, infrastructure-error, compile-error, or skipped.
+  Ordinary shell failure is not an MCP protocol failure.
+
+## Compile and execute phases
+
+The compiler phase produces the existing deterministic `SegmentPlan` IR for
+every step. The executor then runs those groups through one atomic
+`FauxnixSession.runBatch()` call. This removes model/harness turns while
+preserving the mature parser, redirect, timeout, cancellation, and host-frame
+contracts.
+
+This first slice does **not** fuse every segment into one PowerShell frame.
+`runPlans()` still invokes the host per segment because redirects, cwd changes,
+and bash list status need their existing boundaries. Safe frame fusion can be
+a later optimization over the same batch IR.
+
+Batch compilation uses the existing pure translation context so it never reads
+operand files. `sed -f` is rejected with an inline `sed -e` alternative, including
+when nested in a compound command. This prevents preflight from reading scripts
+under the server's cwd instead of the evolving session cwd.
+
+## Byte-exact tasks
+
+Batching does not make a model better at mentally counting CRLF bytes. Both
+`bash` and `bash_batch` descriptions instead direct agents to measure the file
+with `wc -c` or `stat -c %s`. This turns an encoding inference into a
+deterministic verification step that can live in the same MCP request.
+
+## Failure modes
+
+| Event | Result |
+|---|---|
+| Any parse/translation failure | Zero steps execute; failing index/ID is returned |
+| Ordinary nonzero exit | Stop and mark later steps skipped by default; optionally continue |
+| Total deadline expires | Current step is timed out, remaining steps skipped, host recovery unchanged |
+| AbortSignal fires | Current step is cancelled, remaining steps skipped, next session call remains usable |
+| Host start failure | Stop as infrastructure error; do not execute later steps |
+| Caller output budget exhausted | Later side effects still run when policy allows, but returned output remains globally bounded |
+| Concurrent run/reset | Waits outside the one batch lifecycle lock; never interleaves between steps |
+
+## Local directional baseline
+
+Using the official MCP SDK on Windows PowerShell 5.1, a 15-round alternating
+microbenchmark after warmup measured ten separate calls at median 337.8 ms and
+one ten-step batch at 323.2 ms (about 4.5%). Shorter runs varied substantially;
+this is directional evidence, not a large execution-speed claim. The batch
+reduces ten tool turns to one when the agent submits the known sequence upfront.
+An end-to-end model benchmark is needed to measure that additional benefit.
+Run `npm run benchmark:mcp-batch` to repeat the local transport comparison.
+
+## Non-goals
+
+- Guessing or delaying future MCP calls to merge them automatically.
+- Transactional rollback of file/process side effects.
+- Hiding intermediate results when the model truly must interpret them.
+- Claiming a single PowerShell frame or a fix for model reasoning on CRLF.
+- Replacing shell pipelines, variables, loops, or `&&` when those are clearer.
+
+## Verification
+
+- whole-plan compile failure has zero side effects
+- cwd/environment/files persist across steps
+- stop/continue policy and skipped statuses
+- one total deadline and cancellation recovery
+- stdout/stderr budgets shared across all step results
+- file redirects remain complete outside response budgets
+- batch and ordinary session calls cannot interleave
+- official MCP client discovers `bash_batch` and verifies a CRLF file via
+  `wc -c` in one tool call

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "release:check": "node scripts/release-check.mjs",
     "test": "vitest run",
     "test:package": "node scripts/package-smoke.mjs",
+    "benchmark:mcp-batch": "npm run build && node scripts/benchmark-mcp-batch.mjs",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "dev": "tsx src/index.ts"

--- a/scripts/benchmark-mcp-batch.mjs
+++ b/scripts/benchmark-mcp-batch.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const entry = join(root, 'dist', 'index.js');
+const stepCount = Number.parseInt(process.env.FAUXNIX_BENCH_STEPS ?? '10', 10);
+const roundCount = Number.parseInt(process.env.FAUXNIX_BENCH_ROUNDS ?? '3', 10);
+assert.ok(Number.isInteger(stepCount) && stepCount > 1 && stepCount <= 32);
+assert.ok(Number.isInteger(roundCount) && roundCount > 0 && roundCount <= 20);
+
+const client = new Client({ name: 'fauxnix-batch-benchmark', version: '1.0.0' });
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [entry, 'mcp'],
+  cwd: root,
+  env: process.env,
+  stderr: 'pipe',
+});
+transport.stderr?.on('data', () => undefined);
+
+async function timed(fn) {
+  const start = performance.now();
+  await fn();
+  return performance.now() - start;
+}
+
+async function runSeparate() {
+  for (let index = 0; index < stepCount; index++) {
+    const result = await client.callTool({
+      name: 'bash',
+      arguments: { command: `printf 's${index}\\n'` },
+    });
+    assert.equal(result.structuredContent?.exitCode, 0);
+  }
+}
+
+async function runBatch() {
+  const result = await client.callTool({
+    name: 'bash_batch',
+    arguments: {
+      steps: Array.from({ length: stepCount }, (_, index) => ({
+        id: 's' + String(index),
+        command: `printf 's${index}\\n'`,
+      })),
+    },
+  });
+  assert.equal(result.structuredContent?.stopReason, 'completed');
+  assert.equal(result.structuredContent?.stepsCompleted, stepCount);
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+try {
+  const connectMs = await timed(() => client.connect(transport));
+  const tools = await client.listTools();
+  assert.ok(tools.tools.some((tool) => tool.name === 'bash_batch'));
+  const warmupMs = await timed(() =>
+    client.callTool({ name: 'bash', arguments: { command: ':' } }),
+  );
+
+  const rounds = [];
+  for (let round = 0; round < roundCount; round++) {
+    let separateMs;
+    let batchMs;
+    if (round % 2 === 0) {
+      separateMs = await timed(runSeparate);
+      batchMs = await timed(runBatch);
+    } else {
+      batchMs = await timed(runBatch);
+      separateMs = await timed(runSeparate);
+    }
+    rounds.push({ round: round + 1, separateMs, batchMs });
+  }
+
+  const separateMedianMs = median(rounds.map((round) => round.separateMs));
+  const batchMedianMs = median(rounds.map((round) => round.batchMs));
+  process.stdout.write(
+    JSON.stringify(
+      {
+        node: process.version,
+        powerShell: process.env.FAUXNIX_PS || 'powershell-5.1-default',
+        stepCount,
+        roundCount,
+        connectMs,
+        warmupMs,
+        rounds,
+        separateMedianMs,
+        batchMedianMs,
+        speedup: separateMedianMs / batchMedianMs,
+        note: 'Measures MCP/server overhead only; eliminated model turns are not represented.',
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+} finally {
+  await client.close();
+}

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -30,6 +30,11 @@ export interface ExecResult {
   timedOut: boolean;
   cancelled: boolean;
   truncated: boolean;
+  /** True when caller-visible stdout crossed its byte budget. */
+  stdoutTruncated?: boolean;
+  /** True when caller-visible stderr crossed its byte budget. */
+  stderrTruncated?: boolean;
+  infrastructureError?: boolean;
   spawnError?: 'ENOENT' | 'START';
 }
 
@@ -40,6 +45,22 @@ export interface ExecOptions {
   signal?: AbortSignal;
   stdoutLimit?: number;
   stderrLimit?: number;
+}
+
+export type BatchStopReason =
+  | 'completed'
+  | 'command_failed'
+  | 'timed_out'
+  | 'cancelled'
+  | 'infrastructure';
+
+export interface BatchExecOptions extends ExecOptions {
+  stopOnError?: boolean;
+}
+
+export interface BatchExecResult {
+  results: ExecResult[];
+  stopReason: BatchStopReason;
 }
 
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -410,6 +431,85 @@ export class FauxnixSession {
       runPlans(plans, this, opts, () => this.syncFromDisk(), () => this.ensureHost()),
     );
   }
+
+  /**
+   * Execute precompiled steps atomically in one session turn. Each step keeps
+   * its own result, while timeout and caller-output budgets cover the complete
+   * batch. No run/reset/dispose request can interleave between steps.
+   */
+  runBatch(planGroups: SegmentPlan[][], opts: BatchExecOptions = {}): Promise<BatchExecResult> {
+    return this.withLock(async () => {
+      const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      const deadline = Date.now() + timeoutMs;
+      let stdoutRemaining = validateOutputLimit(
+        'stdoutLimit',
+        opts.stdoutLimit ?? DEFAULT_STDOUT_LIMIT,
+      );
+      let stderrRemaining = validateOutputLimit(
+        'stderrLimit',
+        opts.stderrLimit ?? DEFAULT_STDERR_LIMIT,
+      );
+      const results: ExecResult[] = [];
+      let stopReason: BatchStopReason = 'completed';
+
+      for (const plans of planGroups) {
+        let result: ExecResult;
+        try {
+          result = await runPlans(
+            plans,
+            this,
+            {
+              ...opts,
+              timeoutMs: Math.max(0, deadline - Date.now()),
+              stdoutLimit: stdoutRemaining,
+              stderrLimit: stderrRemaining,
+            },
+            () => this.syncFromDisk(),
+            () => this.ensureHost(),
+          );
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          const clipped = clipUtf8(message, stderrRemaining);
+          result = {
+            stdout: '', stderr: clipped.text, exitCode: 1,
+            timedOut: false, cancelled: false, truncated: clipped.truncated,
+            infrastructureError: true,
+          };
+        }
+        results.push(result);
+
+        stdoutRemaining = Math.max(
+          0,
+          stdoutRemaining - Buffer.byteLength(result.stdout, 'utf8'),
+        );
+        stderrRemaining = Math.max(
+          0,
+          stderrRemaining - Buffer.byteLength(result.stderr, 'utf8'),
+        );
+        if (result.stdoutTruncated) stdoutRemaining = 0;
+        if (result.stderrTruncated) stderrRemaining = 0;
+
+        if (result.cancelled) {
+          stopReason = 'cancelled';
+          break;
+        }
+        if (result.timedOut) {
+          stopReason = 'timed_out';
+          break;
+        }
+        if (result.spawnError || result.infrastructureError) {
+          stopReason = 'infrastructure';
+          break;
+        }
+        if ((opts.stopOnError ?? true) && result.exitCode !== 0) {
+          stopReason = 'command_failed';
+          break;
+        }
+      }
+
+      return { results, stopReason };
+    });
+  }
 }
 
 async function runPlans(
@@ -442,6 +542,7 @@ async function runPlans(
   let cancelled = false;
   let truncated = false;
   let spawnError: ExecResult['spawnError'];
+  let infrastructureError = false;
   const appendCaller = (fd: 1 | 2, data: string): void => {
     if (!data) return;
     if (fd === 1 ? stdoutClosed : stderrClosed) return;
@@ -622,6 +723,14 @@ async function runPlans(
       },
     );
 
+    if (inv.infrastructureError) {
+      appendCaller(2, inv.stderr.toString('utf8'));
+      exitCode = inv.exitCode;
+      session.prevExit = exitCode;
+      infrastructureError = true;
+      break;
+    }
+
     if (inv.spawnError === 'ENOENT' || inv.spawnError === 'START') {
       appendCaller(
         2,
@@ -738,6 +847,9 @@ async function runPlans(
     timedOut,
     cancelled,
     truncated,
+    stdoutTruncated: stdoutClosed,
+    stderrTruncated: stderrClosed,
+    infrastructureError,
     spawnError,
   };
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import { ExecResult, FauxnixSession } from './executor.js';
+import { BatchExecResult, ExecResult, FauxnixSession } from './executor.js';
 import { parseCommand } from './parser.js';
 import {
   EXECUTE_TRANSLATION,
@@ -16,6 +16,11 @@ import { packageVersion } from './version.js';
 import './commands/install-all.js';
 
 const TOOL_NAME = process.env.FAUXNIX_TOOL_NAME || 'bash';
+const BATCH_TOOL_NAME = TOOL_NAME + '_batch';
+// Text and structured output both appear in the JSON response. Leave room for
+// worst-case JSON escaping below the official stdio client's 10 MiB limit.
+const BATCH_STDOUT_LIMIT = 262_144;
+const BATCH_STDERR_LIMIT = 65_536;
 
 const EXEC_ANNOTATIONS: ToolAnnotations = {
   readOnlyHint: false,
@@ -47,9 +52,130 @@ Supported: pipes (|), && / || / ;, redirections (> >> 2> 2>&1 < /dev/null), vari
 Unknown commands (git, node, npm, python, cargo...) are passed through and executed natively with argv-style quoting.
 Not supported: heredocs, env -i/--ignore-environment, background jobs. if/then/elif/else/fi, for-in loops, while/until, case ... esac, and word-level \$((...)) arithmetic expansion are supported.
 CWD, environment variables, export/unset, cd, and positional parameters (set -- / $1 / "$@") persist across calls within this session — a resident PowerShell 5.1 host is started when the MCP session begins (and after reset), so the first bash tool call is already warm.
+Efficiency: when two or more commands or verification steps are already known, prefer ${BATCH_TOOL_NAME} once instead of making several ${TOOL_NAME} calls. Keep separate calls only when the next command requires model interpretation of the previous output. For byte-exact work, measure with wc -c or stat -c %s instead of inferring CRLF byte counts from displayed text.
 Exit codes follow bash conventions (0 ok, 1 fail, 2 usage/serious, 127 command not found, 124 timeout, 130 cancelled). The tool also returns structuredContent (schemaVersion 1) with stdout/stderr/exitCode/timedOut/cancelled/truncated/sessionId.
 
 Platform requirement: the execution backend is native Windows PowerShell 5.1+. On hosts without PowerShell on PATH (e.g. Linux containers/sandboxes), the bash tool returns exit code 127 with an actionable error instead of running the command.`;
+
+const BATCH_TOOL_DESCRIPTION = `Compile and execute a preplanned multi-step bash workflow in one MCP round trip.
+
+Use this instead of repeated ${TOOL_NAME} calls when the complete sequence is already known. Steps run serially and atomically in the same persistent session: later steps see cwd, environment, and files from earlier steps, while run/reset requests cannot interleave. Every command is parsed and translated before step 1 runs, and the result reports each step separately.
+
+By default the batch stops after the first nonzero exit. Set stop_on_error=false only when later steps should still run. timeout_ms and both output limits apply to the whole batch, not once per step. Output defaults to 256 KiB stdout and 64 KiB stderr; redirect larger artifacts to files. Preflight performs no operand-file reads: use sed -e with inline script text instead of sed -f. If a later command depends on model interpretation of an earlier result, use separate ${TOOL_NAME} calls instead. For byte counts, include wc -c or stat -c %s as a verification step rather than calculating CRLF bytes mentally.`;
+
+export interface BatchStepInput {
+  id?: string;
+  command: string;
+}
+
+export class BatchCompileError extends Error {
+  constructor(
+    readonly stepIndex: number,
+    readonly stepId: string | undefined,
+    cause: unknown,
+  ) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(
+      'fauxnix: batch compile failed at step ' +
+        String(stepIndex + 1) +
+        (stepId ? ' (' + stepId + ')' : '') +
+        ': ' +
+        detail,
+    );
+    this.name = 'BatchCompileError';
+  }
+}
+
+export function compileBatchSteps(steps: BatchStepInput[]) {
+  return steps.map((step, index) => {
+    try {
+      return translateCommandList(parseCommand(step.command), PURE_TRANSLATION);
+    } catch (e) {
+      throw new BatchCompileError(index, step.id, e);
+    }
+  });
+}
+
+function batchStepStatus(
+  r: ExecResult,
+): 'completed' | 'failed' | 'timed_out' | 'cancelled' | 'infrastructure_error' {
+  if (r.spawnError || r.infrastructureError) return 'infrastructure_error';
+  if (r.cancelled) return 'cancelled';
+  if (r.timedOut) return 'timed_out';
+  return r.exitCode === 0 ? 'completed' : 'failed';
+}
+
+export function batchToolResult(
+  inputs: BatchStepInput[],
+  batch: BatchExecResult,
+  sessionId: string,
+) {
+  const steps = inputs.map((input, index) => {
+    const result = batch.results[index];
+    if (!result) return { index, ...(input.id ? { id: input.id } : {}), status: 'skipped' as const };
+    return {
+      index,
+      ...(input.id ? { id: input.id } : {}),
+      status: batchStepStatus(result),
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+      timedOut: result.timedOut,
+      cancelled: result.cancelled,
+      truncated: result.truncated,
+    };
+  });
+  const text = steps
+    .map((step, index) => {
+      const label = '[' + String(index + 1) + '/' + String(steps.length) + (step.id ? ' ' + step.id : '') + ']';
+      if (step.status === 'skipped') return label + ' skipped';
+      const result = batch.results[index];
+      return label + ' ' + step.status + ' (exit ' + String(result.exitCode) + ')\n' + formatBashText(result);
+    })
+    .join('\n');
+  const structuredContent = {
+    schemaVersion: 1 as const,
+    sessionId,
+    preflightOk: true,
+    stopReason: batch.stopReason,
+    stepsRequested: inputs.length,
+    stepsCompleted: batch.results.length,
+    timedOut: batch.stopReason === 'timed_out',
+    cancelled: batch.stopReason === 'cancelled',
+    truncated: batch.results.some((result) => result.truncated),
+    steps,
+  };
+  return {
+    content: [{ type: 'text' as const, text }],
+    structuredContent,
+    ...(batch.stopReason === 'infrastructure' ? { isError: true as const } : {}),
+  };
+}
+
+export function batchCompileErrorResult(
+  inputs: BatchStepInput[],
+  error: BatchCompileError,
+  sessionId: string,
+) {
+  return {
+    content: [{ type: 'text' as const, text: error.message }],
+    structuredContent: {
+      schemaVersion: 1 as const,
+      sessionId,
+      preflightOk: false,
+      stopReason: 'compile_error' as const,
+      stepsRequested: inputs.length,
+      stepsCompleted: 0,
+      failedStep: error.stepIndex,
+      steps: inputs.map((input, index) => ({
+        index,
+        ...(input.id ? { id: input.id } : {}),
+        status: index === error.stepIndex ? ('compile_error' as const) : ('skipped' as const),
+      })),
+    },
+    isError: true as const,
+  };
+}
 
 export function formatBashText(
   r: Pick<ExecResult, 'stdout' | 'stderr' | 'exitCode' | 'timedOut' | 'cancelled'>,
@@ -174,6 +300,91 @@ export async function startMcpServer(): Promise<void> {
           session.id,
           true,
         );
+      }
+    },
+  );
+
+  server.tool(
+    BATCH_TOOL_NAME,
+    BATCH_TOOL_DESCRIPTION,
+    {
+      steps: z
+        .array(
+          z.object({
+            id: z.string().min(1).max(64).optional().describe('Optional short step label'),
+            command: z.string().min(1).max(16384).describe('Bash-style command for this step'),
+          }),
+        )
+        .min(1)
+        .max(32)
+        .describe('Ordered workflow steps; all are compiled before execution begins'),
+      stop_on_error: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe('Stop after the first nonzero exit (default true)'),
+      timeout_ms: z
+        .number()
+        .int()
+        .min(1000)
+        .max(600_000)
+        .optional()
+        .describe('Total timeout for the complete batch (default 120000)'),
+      stdout_limit_bytes: z
+        .number()
+        .int()
+        .min(0)
+        .max(BATCH_STDOUT_LIMIT)
+        .optional()
+        .describe('Total stdout budget shared by every step (default 262144)'),
+      stderr_limit_bytes: z
+        .number()
+        .int()
+        .min(0)
+        .max(BATCH_STDERR_LIMIT)
+        .optional()
+        .describe('Total stderr budget shared by every step (default 65536)'),
+    },
+    EXEC_ANNOTATIONS,
+    async (
+      { steps, stop_on_error, timeout_ms, stdout_limit_bytes, stderr_limit_bytes },
+      extra,
+    ) => {
+      try {
+        const compiled = compileBatchSteps(steps);
+        const result = await session.runBatch(compiled, {
+          stopOnError: stop_on_error,
+          timeoutMs: timeout_ms,
+          stdoutLimit: stdout_limit_bytes ?? BATCH_STDOUT_LIMIT,
+          stderrLimit: stderr_limit_bytes ?? BATCH_STDERR_LIMIT,
+          signal: extra.signal,
+        });
+        return batchToolResult(steps, result, session.id);
+      } catch (e) {
+        if (e instanceof BatchCompileError) {
+          return batchCompileErrorResult(steps, e, session.id);
+        }
+        const message = e instanceof Error ? e.message : String(e);
+        return {
+          content: [{ type: 'text' as const, text: message }],
+          structuredContent: {
+            schemaVersion: 1 as const,
+            sessionId: session.id,
+            preflightOk: true,
+            stopReason: 'infrastructure' as const,
+            stepsRequested: steps.length,
+            stepsCompleted: 0,
+            timedOut: false,
+            cancelled: false,
+            truncated: false,
+            steps: steps.map((step, index) => ({
+              index,
+              ...(step.id ? { id: step.id } : {}),
+              status: 'skipped' as const,
+            })),
+          },
+          isError: true as const,
+        };
       }
     },
   );

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -57,6 +57,7 @@ export interface HostInvokeResult {
   stderrTruncated?: boolean;
   spawnError?: 'ENOENT' | 'START';
   spawnMessage?: string;
+  infrastructureError?: boolean;
   stdoutSpool?: string;
   stderrSpool?: string;
   nativeStderrSpool?: string;
@@ -315,6 +316,7 @@ export class PowerShellHost {
         cancelled: false,
         truncated: false,
         spawnMessage: (e as Error).message,
+        infrastructureError: true,
       };
     }
 
@@ -362,6 +364,7 @@ export class PowerShellHost {
         return {
           stdout: Buffer.alloc(0),
           stderr: Buffer.from(nativeSpoolError.message + '\n', 'utf8'),
+          infrastructureError: true,
           exitCode: 1,
           timedOut: false,
           cancelled: false,
@@ -389,6 +392,7 @@ export class PowerShellHost {
           'utf8',
         ),
         exitCode: code === 0 ? 1 : code,
+        infrastructureError: true,
         timedOut: false,
         cancelled: false,
         truncated: false,

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -2628,6 +2628,179 @@ describe.skipIf(!hasPs)(`integration (real ${selectedPowerShell.executable})`, {
       await extra.dispose();
     }
   }, 30000);
+
+  it('runs a compiled batch atomically before a concurrent session call', async () => {
+    const extra = new FauxnixSession();
+    const target = join(dir, 'batch-order.txt');
+    try {
+      await extra.prewarm();
+      const batch = extra.runBatch([
+        translateCommandList(
+          parseCommand(`printf A > ${JSON.stringify(target)}; sleep 1`),
+        ),
+        translateCommandList(parseCommand(`printf B >> ${JSON.stringify(target)}`)),
+      ]);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const outside = extra.run(
+        translateCommandList(parseCommand(`printf X >> ${JSON.stringify(target)}`)),
+      );
+      const [batched, ordinary] = await Promise.all([batch, outside]);
+      expect(batched.stopReason).toBe('completed');
+      expect(batched.results).toHaveLength(2);
+      expect(ordinary.exitCode).toBe(0);
+      expect(readFileSync(target, 'utf8')).toBe('ABX');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('applies stop policy and output budgets across compiled batch steps', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const output = await extra.runBatch(
+        ["printf 'AAA'", "printf 'BBB'", "printf 'CCC'"].map((command) =>
+          translateCommandList(parseCommand(command)),
+        ),
+        { stdoutLimit: 5, stopOnError: false },
+      );
+      expect(output.stopReason).toBe('completed');
+      expect(output.results.map((result) => result.stdout)).toEqual(['AAA', 'BB', '']);
+      expect(output.results.map((result) => result.truncated)).toEqual([false, true, true]);
+
+      const stderr = await extra.runBatch(
+        ["printf 'EEE' 1>&2", "printf 'EEE' 1>&2", "printf 'EEE' 1>&2"].map((command) =>
+          translateCommandList(parseCommand(command)),
+        ),
+        { stderrLimit: 5, stopOnError: false },
+      );
+      expect(stderr.results.map((result) => result.stderr)).toEqual(['EEE', 'EE', '']);
+      expect(stderr.results.map((result) => result.truncated)).toEqual([false, true, true]);
+
+      const utf8 = await extra.runBatch(
+        ["printf '你'", "printf 'X'"].map((command) =>
+          translateCommandList(parseCommand(command)),
+        ),
+        { stdoutLimit: 2, stopOnError: false },
+      );
+      expect(utf8.results.map((result) => result.stdout)).toEqual(['', '']);
+      expect(utf8.results.map((result) => result.truncated)).toEqual([true, true]);
+
+      const redirected = join(dir, 'batch-budget-file.txt');
+      const file = await extra.runBatch(
+        [
+          `printf 'AAAAAAAAAA' > ${JSON.stringify(redirected)}`,
+          `wc -c ${JSON.stringify(redirected)} > /dev/null`,
+        ].map((command) => translateCommandList(parseCommand(command))),
+        { stdoutLimit: 0 },
+      );
+      expect(readFileSync(redirected, 'utf8')).toBe('AAAAAAAAAA');
+      expect(file.results.map((result) => result.truncated)).toEqual([false, false]);
+
+      const stopped = await extra.runBatch(
+        ['false', "printf 'SHOULD_NOT_RUN'"].map((command) =>
+          translateCommandList(parseCommand(command)),
+        ),
+      );
+      expect(stopped.stopReason).toBe('command_failed');
+      expect(stopped.results).toHaveLength(1);
+      expect(stopped.results[0].exitCode).toBe(1);
+
+      const continued = await extra.runBatch(
+        ['false', "printf 'continued'"].map((command) =>
+          translateCommandList(parseCommand(command)),
+        ),
+        { stopOnError: false },
+      );
+      expect(continued.stopReason).toBe('completed');
+      expect(continued.results).toHaveLength(2);
+      expect(continued.results[1].stdout).toBe('continued');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('keeps cwd and environment changes visible across batch steps', async () => {
+    const extra = new FauxnixSession();
+    const target = join(dir, 'sub', 'batch-state.txt');
+    try {
+      await extra.prewarm();
+      const batch = await extra.runBatch(
+        [
+          `cd ${JSON.stringify(dir)}; export FX_BATCH_STATE=ready`,
+          'cd sub',
+          `printf "$FX_BATCH_STATE" > ${JSON.stringify(target)}`,
+          `wc -c ${JSON.stringify(target)}`,
+        ].map((command) => translateCommandList(parseCommand(command))),
+      );
+      expect(batch.stopReason).toBe('completed');
+      expect(batch.results).toHaveLength(4);
+      expect(readFileSync(target, 'utf8')).toBe('ready');
+      expect(batch.results[3].stdout).toMatch(/^5\s+/);
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('shares one batch deadline and cancellation boundary, then restarts cleanly', async () => {
+    const extra = new FauxnixSession();
+    try {
+      await extra.prewarm();
+      const timed = await extra.runBatch(
+        ['sleep 1', 'sleep 2', "printf 'late'"].map((command) =>
+          translateCommandList(parseCommand(command)),
+        ),
+        { timeoutMs: 2500 },
+      );
+      expect(timed.stopReason).toBe('timed_out');
+      expect(timed.results).toHaveLength(2);
+      expect(timed.results[0].exitCode).toBe(0);
+      expect(timed.results[1].timedOut).toBe(true);
+
+      const afterTimeout = await extra.run(translateCommandList(parseCommand('echo after-timeout')));
+      expect(afterTimeout.stdout.trim()).toBe('after-timeout');
+
+      const controller = new AbortController();
+      const pending = extra.runBatch(
+        ['sleep 5', "printf 'late'"].map((command) =>
+          translateCommandList(parseCommand(command)),
+        ),
+        { timeoutMs: 30_000, signal: controller.signal },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      controller.abort();
+      const cancelled = await pending;
+      expect(cancelled.stopReason).toBe('cancelled');
+      expect(cancelled.results).toHaveLength(1);
+      expect(cancelled.results[0].cancelled).toBe(true);
+
+      const afterCancel = await extra.run(translateCommandList(parseCommand('echo after-cancel')));
+      expect(afterCancel.stdout.trim()).toBe('after-cancel');
+    } finally {
+      await extra.dispose();
+    }
+  }, 60_000);
+
+  it('preserves completed batch results after host failure even with continue enabled', async () => {
+    const extra = new FauxnixSession();
+    try {
+      const stoppedHost = translateCommandList(parseCommand(':'));
+      stoppedHost[0].body = 'exit 0';
+      const batch = await extra.runBatch([
+        translateCommandList(parseCommand('printf first')),
+        stoppedHost,
+        translateCommandList(parseCommand('printf later')),
+      ], { stopOnError: false });
+      expect(batch.stopReason).toBe('infrastructure');
+      expect(batch.results).toHaveLength(2);
+      expect(batch.results[0].stdout).toBe('first');
+      expect(batch.results[1].infrastructureError).toBe(true);
+      const recovered = await extra.run(translateCommandList(parseCommand('printf recovered')));
+      expect(recovered.stdout).toBe('recovered');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
 });
 
 // RFC 1.0 U-8 (#118): CI budgets so the 15× warm-host win cannot regress

--- a/test/mcp-batch.windows.test.ts
+++ b/test/mcp-batch.windows.test.ts
@@ -1,0 +1,89 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import {
+  getDefaultEnvironment,
+  StdioClientTransport,
+} from '@modelcontextprotocol/sdk/client/stdio.js';
+import { describe, expect, it } from 'vitest';
+
+const onWindows = process.platform === 'win32';
+
+describe.skipIf(!onWindows)('MCP compiled batch tool', () => {
+  it('preflights every step and returns byte-exact per-step results in one call', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fauxnix-mcp-batch-'));
+    const tsx = join(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs');
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [tsx, 'src/index.ts', 'mcp'],
+      cwd: process.cwd(),
+      env: {
+        ...getDefaultEnvironment(),
+        FAUXNIX_PS: process.env.FAUXNIX_PS ?? '',
+      },
+      stderr: 'pipe',
+    });
+    transport.stderr?.on('data', () => undefined);
+    const client = new Client({ name: 'fauxnix-batch-test', version: '1.0.0' });
+
+    try {
+      await client.connect(transport);
+      const tools = await client.listTools();
+      const batchTool = tools.tools.find((tool) => tool.name === 'bash_batch');
+      expect(batchTool?.description).toContain('one MCP round trip');
+      expect(batchTool?.description).toContain('wc -c');
+
+      const result = await client.callTool({
+        name: 'bash_batch',
+        arguments: {
+          steps: [
+            { id: 'enter', command: 'cd ' + JSON.stringify(dir) },
+            { id: 'write', command: "printf 'a\\r\\nb' > bytes.txt" },
+            { id: 'measure', command: 'wc -c bytes.txt' },
+            { id: 'stop', command: 'false' },
+            { id: 'skipped', command: "printf 'bad' > should-not-exist.txt" },
+          ],
+        },
+      });
+      const structured = result.structuredContent as {
+        stopReason: string;
+        stepsCompleted: number;
+        steps: Array<{ id?: string; status: string; stdout?: string; exitCode?: number }>;
+      };
+      expect(result.isError).not.toBe(true);
+      expect(structured.stopReason).toBe('command_failed');
+      expect(structured.stepsCompleted).toBe(4);
+      expect(structured.steps[2].id).toBe('measure');
+      expect(structured.steps[2].stdout).toMatch(/^4\s+bytes\.txt\s*$/);
+      expect(structured.steps[3]).toMatchObject({ status: 'failed', exitCode: 1 });
+      expect(structured.steps[4].status).toBe('skipped');
+      expect(existsSync(join(dir, 'should-not-exist.txt'))).toBe(false);
+
+      const compileFailure = await client.callTool({
+        name: 'bash_batch',
+        arguments: {
+          steps: [
+            { id: 'must-not-run', command: "printf 'bad' > compile-marker.txt" },
+            { id: 'invalid', command: 'echo "unterminated' },
+          ],
+        },
+      });
+      const failed = compileFailure.structuredContent as {
+        stopReason: string;
+        stepsCompleted: number;
+        failedStep: number;
+      };
+      expect(compileFailure.isError).toBe(true);
+      expect(failed).toMatchObject({
+        stopReason: 'compile_error',
+        stepsCompleted: 0,
+        failedStep: 1,
+      });
+      expect(existsSync(join(dir, 'compile-marker.txt'))).toBe(false);
+    } finally {
+      await client.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 120_000);
+});

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -48,7 +48,11 @@ import {
 } from '../src/powershell.js';
 import { packageVersion } from '../src/version.js';
 import {
+  BatchCompileError,
+  batchCompileErrorResult,
+  batchToolResult,
   bashToolResult,
+  compileBatchSteps,
   formatBashText,
   formatSessionStatus,
   positionalCountFromEnv,
@@ -2095,6 +2099,89 @@ describe('MCP structured results (#129)', () => {
         id: 'abcd1234',
       });
     expect(withPos).toMatch(/positionals: 3/);
+  });
+
+  it('compiles every batch step before execution and identifies a bad step', () => {
+    const steps = [
+      { id: 'prepare', command: "printf 'would-run' > batch-marker.txt" },
+      { id: 'invalid', command: 'echo "unterminated' },
+    ];
+    let error: BatchCompileError | undefined;
+    try {
+      compileBatchSteps(steps);
+    } catch (e) {
+      error = e as BatchCompileError;
+    }
+    expect(error).toBeInstanceOf(BatchCompileError);
+    expect(error?.stepIndex).toBe(1);
+    expect(error?.stepId).toBe('invalid');
+    expect(error?.message).toMatch(/step 2 \(invalid\)/);
+    expect(existsSync('batch-marker.txt')).toBe(false);
+    const result = batchCompileErrorResult(steps, error!, 'batch123');
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.preflightOk).toBe(false);
+    expect(result.structuredContent.stepsCompleted).toBe(0);
+    expect(result.structuredContent.steps.map((step) => step.status)).toEqual([
+      'skipped',
+      'compile_error',
+    ]);
+  });
+
+  it('formats per-step batch results without treating a shell failure as MCP failure', () => {
+    const result = batchToolResult(
+      [
+        { id: 'one', command: 'echo one' },
+        { id: 'stop', command: 'false' },
+        { id: 'later', command: 'echo later' },
+      ],
+      {
+        stopReason: 'command_failed',
+        results: [
+          {
+            stdout: 'one\n',
+            stderr: '',
+            exitCode: 0,
+            timedOut: false,
+            cancelled: false,
+            truncated: false,
+          },
+          {
+            stdout: '',
+            stderr: '',
+            exitCode: 1,
+            timedOut: false,
+            cancelled: false,
+            truncated: false,
+          },
+        ],
+      },
+      'batch123',
+    );
+    expect(result.structuredContent.stepsCompleted).toBe(2);
+    expect(result.structuredContent.preflightOk).toBe(true);
+    expect(result.structuredContent.steps.map((step) => step.status)).toEqual([
+      'completed',
+      'failed',
+      'skipped',
+    ]);
+    expect(result.content[0].text).toContain('[3/3 later] skipped');
+    expect('isError' in result && result.isError).toBeFalsy();
+  });
+
+  it('rejects file-reading translation during batch preflight', () => {
+    expect(() => compileBatchSteps([{ command: 'sed -f rules.sed input.txt' }]))
+      .toThrow(BatchCompileError);
+    expect(() => compileBatchSteps([{ command: 'if true; then sed -f rules.sed input.txt; fi' }]))
+      .toThrow(BatchCompileError);
+  });
+
+  it('keeps a worst-case escaped batch response below the SDK buffer', () => {
+    const result = batchToolResult([{ command: 'fixture' }], {
+      stopReason: 'completed',
+      results: [{ stdout: '\u0000'.repeat(262144), stderr: '\u0000'.repeat(65536),
+        exitCode: 0, timedOut: false, cancelled: false, truncated: false }],
+    }, 'session');
+    expect(Buffer.byteLength(JSON.stringify(result), 'utf8')).toBeLessThan(10 * 1024 * 1024);
   });
 });
 


### PR DESCRIPTION
Known multi-step workflows currently require repeated MCP calls or a hand-written compound command with one combined result. This adds `bash_batch`: up to 32 labeled commands are precompiled, run serially under one session lock, and returned as individual completed/failed/skipped results.

The whole batch shares a deadline and separate stdout/stderr budgets. It stops on failure by default, preserves completed results when the host fails, and prevents concurrent run/reset calls from interleaving. Pure preflight rejects `sed -f` with an inline alternative rather than reading scripts under the wrong cwd. Response limits account for duplicated text/structured content and JSON escaping.

Implements the first slice of #214. The existing `bash` schema remains available. This removes model/tool turns for known workflows; it still uses the current per-segment host executor and does not claim host-frame fusion. A reproducible official-SDK benchmark is included; 15 alternating local rounds measured only about 4.5% transport/execution improvement, so model-turn reduction is the primary benefit of this slice.

Validation: typecheck, release metadata check, clean source and package install smoke, full Windows test suite, and official MCP-client tests. Coverage includes CRLF file measurement, compile-before-effects, stop/continue policy, shared UTF-8 budgets, total deadline, cancellation, host failure and next-request recovery, and non-interleaving with ordinary session calls. PS7 runs the same suite.
