### PR TITLE
feat: rebuild awk records on literal field assignment

### DIFF
--- a/docs/rfc-awk-field-assignment.md
+++ b/docs/rfc-awk-field-assignment.md
@@ -1,0 +1,30 @@
+# Awk field assignment for record normalization
+
+An observed agent run attempted `awk '{$1=$1; print}'` while preparing a
+tabular result. The current parser rejects the first `$`; the agent then
+removed its formatting stage. This proposal adds the common field-rebuild
+operation so that this valid idiom executes directly.
+
+Supported statements are `$N = expression`, with a literal field index from
+1 through 65535. Evaluate the right-hand side before changing the record,
+extend missing fields with empty strings, update NF, and rebuild $0 with OFS.
+OFS defaults to a space and can be supplied through `-v` or a normal assignment.
+Comma-separated print arguments use the same OFS.
+
+`$0` assignment, computed field indices, compound assignment and changing NF
+are not implemented by this slice. Unsupported field-assignment syntax fails
+explicitly with a print-based alternative. There is no command execution or
+new external dependency in the implementation.
+
+Validation covers whitespace normalization, subsequent field reordering,
+extension beyond NF, custom OFS, and preservation of an untouched record.
+The corresponding GNU oracle programs are:
+
+```sh
+printf '   1    LA\n   2    NYC\n' | awk '{$1=$1; print}'
+printf '   1    LA\n   2    NYC\n' | awk '{$1=$1; print $2, $1}'
+printf 'a b\n' | awk 'BEGIN {OFS=":"} {$4="x"; print NF, $0}'
+```
+
+This removes a demonstrated failed tool call. It does not guarantee that a
+model will choose the required column order or reduce every task's wall time.

--- a/src/commands/text-filters.ts
+++ b/src/commands/text-filters.ts
@@ -1369,6 +1369,7 @@ type AStmt =
   | { k: 'print'; args: AExpr[] }
   | { k: 'printf'; fmt: string; args: AExpr[] }
   | { k: 'assign'; name: string; op: string; e: AExpr }
+  | { k: 'fieldassign'; index: number; e: AExpr }
   | { k: 'exit'; code: AExpr | null };
 
 interface AwkItem {
@@ -1474,6 +1475,14 @@ class AwkParser {
     if (c === undefined) throw new FauxnixParseError('fauxnix: awk unexpected end of program');
     if (c === '{') {
       throw new FauxnixParseError('fauxnix: awk nested blocks are not supported yet');
+    }
+    if (c === '$') {
+      const assignment = this.s.slice(this.i).match(/^\$([1-9]\d*)\s*=(?!=)/);
+      if (!assignment || Number(assignment[1]) > 65535) {
+        throw new FauxnixParseError('fauxnix: awk field assignment requires $1..$65535 = expression; use print to construct other records');
+      }
+      this.i += assignment[0].length;
+      return { k: 'fieldassign', index: Number(assignment[1]), e: this.parseExpr() };
     }
     if (this.atWord('print')) {
       this.i += 5;
@@ -2090,7 +2099,7 @@ const awk: Handler = (args) => {
         if (st.args.length === 0) {
           out.push('$fx_line');
         } else {
-          out.push('(' + st.args.map((a) => '(fx-str ' + gen(a).ps + ')').join(" + ' ' + ") + ')');
+          out.push('(' + st.args.map((a) => '(fx-str ' + gen(a).ps + ')').join(' + (fx-str $fxv_OFS) + ') + ')');
         }
       } else if (st.k === 'printf') {
         const f = awkFmtToPs(st.fmt);
@@ -2108,6 +2117,12 @@ const awk: Handler = (args) => {
         });
         const argList = argExprs.length ? ' ' + argExprs.join(', ') : '';
         out.push('(' + f.ps + ' -f' + argList + ')');
+      } else if (st.k === 'fieldassign') {
+        out.push('$fx_fieldValue = (fx-str ' + gen(st.e).ps + ')');
+        out.push('if ($fx_flds.Count -lt ' + st.index + ") { $fx_flds += @('') * (" + st.index + ' - $fx_flds.Count) }');
+        out.push('$fx_flds[' + (st.index - 1) + '] = $fx_fieldValue');
+        out.push('$fx_nf = $fx_flds.Count');
+        out.push('$fx_line = ($fx_flds -join (fx-str $fxv_OFS))');
       } else if (st.k === 'assign') {
         const rhs = gen(st.e).ps;
         if (st.op === '=') {
@@ -2198,6 +2213,7 @@ const awk: Handler = (args) => {
   lines.push(...hoistedRegex);
 
   for (const v of prog.vars) lines.push('$fxv_' + v + ' = $null');
+  lines.push("$fxv_OFS = ' '", "$fx_line = ''", '$fx_flds = @()', '$fx_nf = 0');
   for (const [n, v] of vvars) {
     lines.push(
       '$fxv_' + n + ' = ' + (/^-?(\d+\.?\d*|\.\d+)$/.test(v) ? '[double]' + v : psStr(v)),

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -156,6 +156,19 @@ describe.skipIf(!hasPs)(`integration (real ${selectedPowerShell.executable})`, {
     expect(r.stdout).toMatch(/drwxr-xr-x.*sub/);
   });
 
+  it('rebuilds awk records after field assignment', async () => {
+    const normalized = await run("printf '   1    LA\\n   2    NYC\\n' | awk '{$1=$1; print}'");
+    expect(normalized.exitCode).toBe(0);
+    expect(normalized.stdout).toBe('1 LA\n2 NYC\n');
+    const reordered = await run("printf '   1    LA\\n   2    NYC\\n' | awk '{$1=$1; print $2, $1}'");
+    expect(reordered.stdout).toBe('LA 1\nNYC 2\n');
+    const extended = await run("printf 'a b\\n' | awk 'BEGIN {OFS=\":\"} {$4=\"x\"; print NF, $0}'");
+    expect(extended.exitCode).toBe(0);
+    expect(extended.stdout).toBe('4:a:b::x\n');
+    const original = await run("printf '  a   b\\n' | awk '{print}'");
+    expect(original.stdout).toBe('  a   b\n');
+  });
+
   it('grep + exit codes', async () => {
     expect((await run('grep -n apple fruits.txt')).stdout).toContain('1:apple');
     expect((await run('grep apple fruits.txt')).exitCode).toBe(0);

--- a/test/mcp-batch.windows.test.ts
+++ b/test/mcp-batch.windows.test.ts
@@ -3,14 +3,36 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import {
-  getDefaultEnvironment,
+  DEFAULT_INHERITED_ENV_VARS,
   StdioClientTransport,
 } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { describe, expect, it } from 'vitest';
 
 const onWindows = process.platform === 'win32';
 
+// Windows worker environments use case-sensitive JS lookups even though native
+// process environments do not. Keep the SDK allow-list, but resolve mixed-case
+// keys such as SystemRoot and Path before launching the MCP child.
+function mcpTestEnvironment(source: NodeJS.ProcessEnv): Record<string, string> {
+  const normalized = new Map(Object.entries(source).map(([key, value]) => [key.toUpperCase(), value]));
+  const inherited: Record<string, string> = {};
+  for (const key of DEFAULT_INHERITED_ENV_VARS) {
+    const value = normalized.get(key.toUpperCase());
+    if (value !== undefined && !value.startsWith('()')) inherited[key] = value;
+  }
+  return inherited;
+}
+
 describe.skipIf(!onWindows)('MCP compiled batch tool', () => {
+  it('keeps mixed-case Windows launch variables within the SDK allow-list', () => {
+    expect(mcpTestEnvironment({
+      SystemRoot: 'C:\\Windows',
+      Path: 'C:\\Windows\\System32',
+      Temp: '() { ignored; }',
+      UNRELATED_VALUE: 'not inherited',
+    })).toEqual({ SYSTEMROOT: 'C:\\Windows', PATH: 'C:\\Windows\\System32' });
+  });
+
   it('preflights every step and returns byte-exact per-step results in one call', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'fauxnix-mcp-batch-'));
     const tsx = join(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs');
@@ -19,7 +41,7 @@ describe.skipIf(!onWindows)('MCP compiled batch tool', () => {
       args: [tsx, 'src/index.ts', 'mcp'],
       cwd: process.cwd(),
       env: {
-        ...getDefaultEnvironment(),
+        ...mcpTestEnvironment(process.env),
         FAUXNIX_PS: process.env.FAUXNIX_PS ?? '',
       },
       stderr: 'pipe',
@@ -51,7 +73,7 @@ describe.skipIf(!onWindows)('MCP compiled batch tool', () => {
         stepsCompleted: number;
         steps: Array<{ id?: string; status: string; stdout?: string; exitCode?: number }>;
       };
-      expect(result.isError).not.toBe(true);
+      expect(result.isError, JSON.stringify(result)).not.toBe(true);
       expect(structured.stopReason).toBe('command_failed');
       expect(structured.stepsCompleted).toBe(4);
       expect(structured.steps[2].id).toBe('measure');

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -61,6 +61,15 @@ import '../src/commands/install-all.js';
 
 /* ---------------------------- parser ---------------------------- */
 
+describe('awk field assignment compilation', () => {
+  it('accepts a literal field rebuild and rejects unsupported lvalues', () => {
+    expect(() => translateCommandList(parse("awk '{$1=$1; print}'"))).not.toThrow();
+    for (const command of ["awk '{$0=\"x\"}'", "awk '{$NF=1}'", "awk '{$65536=1}'", "awk '{$1+=1}'"]) {
+      expect(() => translateCommandList(parse(command))).toThrow(/field assignment/);
+    }
+  });
+});
+
 describe('parser', () => {
   it('parses a simple command with args', () => {
     const list = parse('ls -la /tmp');


### PR DESCRIPTION
An observed MiniMax workflow called `awk '{$1=$1; print}'`. The parser rejected the initial `$`, and the agent dropped its formatting stage. Add literal positive field assignment so this common normalization idiom can execute without a repair round.

`$N = expression` evaluates the value, extends missing fields, updates NF and rebuilds $0 using OFS. OFS defaults to a space; both rebuilt records and comma-separated print respect an explicit OFS. The supported field-index range is 1..65535. Record assignment, computed indices and compound assignments remain outside this slice with an explicit diagnostic.

Includes a short RFC and real PowerShell regressions for normalization, column reordering, extending a record, custom OFS and unchanged record preservation. GNU oracle programs are included in the RFC. This addresses a demonstrated failed tool call, not a claim that all model planning overhead is solved.
