### PR TITLE
perf: compile session checkpoints and eliminate idle filesystem work

### DIFF
--- a/docs/rfc-runtime-checkpoint-fast-path.md
+++ b/docs/rfc-runtime-checkpoint-fast-path.md
@@ -1,0 +1,53 @@
+# Runtime checkpoint fast path
+
+Every translated segment currently resets cwd and rebuilds an environment
+snapshot through `Get-ChildItem Env:` and `ForEach-Object`, serializes it with
+`ConvertTo-Json`, and writes two files. This cost repeats even for a warmed
+`printf` that changes no session state. Batching MCP calls does not remove it.
+
+The resident host can compile this repeated work once alongside its existing
+bounded-stream helper. A small .NET helper enumerates environment strings,
+escapes them into JSON, orders the keys, and writes only changed checkpoints.
+The cwd checkpoint likewise writes only when its value changes. The command
+preamble avoids resetting an already matching PowerShell or .NET cwd.
+Native pipeline spool directories and raw-stderr files are created lazily on
+first use. A plain translated command no longer creates an unused directory
+and an empty stderr file merely to remove them at the end of its request.
+
+## Behavior
+
+- Every completed segment still checks for state changes. Updates and unsets
+  reach disk before the next segment; timeout recovery retains earlier state.
+- Only transport metadata is omitted from persistent environment snapshots:
+  FAUXNIX_CWD, FAUXNIX_PREV_EXIT, FAUXNIX_STDIN_FILE and FAUXNIX_NATIVE_SPOOL_DIR.
+  Node supplies these afresh on each request. User environment strings,
+  including quotes, control characters and Unicode, remain exact.
+- A deleted checkpoint is recreated even when the cached value is unchanged.
+  Caches are updated only after a successful write and are discarded when the
+  host process stops. The internal checkpoint files have a single writer.
+- One-shot translated scripts retain their self-contained PowerShell path.
+- No command-result caching, reordered side effects or host-frame fusion is
+  introduced. This optimizes the default runtime without changing the tool API.
+
+## Measurement
+
+Build both the baseline and candidate checkouts, then run:
+
+```powershell
+npm run build
+node scripts/benchmark-runtime-workloads.mjs C:/path/to/baseline .
+$env:FAUXNIX_PS = 'pwsh'
+node scripts/benchmark-runtime-workloads.mjs C:/path/to/baseline .
+```
+
+The benchmark alternates order, uses separate sessions and fixtures, excludes
+boot/setup/translation from execution timing, verifies outputs, and returns raw
+samples. It includes 32-segment reporting/state workloads and the supplied
+rename and city-count tasks. FAUXNIX_BENCH_ROUNDS defaults to 15;
+FAUXNIX_BENCH_ENV_COUNT optionally adds synthetic environment entries.
+
+These are runtime measurements. They must not be represented as reductions in
+model inference time or proof that a previously slow end-to-end agent run is
+fixed. Whole-plan fusion remains a separate compiler project: redirects and
+intermediate state checkpoints cannot simply be discarded when concatenating
+generated bodies.

--- a/scripts/benchmark-runtime-workloads.mjs
+++ b/scripts/benchmark-runtime-workloads.mjs
@@ -1,0 +1,83 @@
+// Compare two independently built checkouts; do not synthesize the baseline
+// by editing the optimized script. Timings exclude fixture setup and boot.
+import assert from 'node:assert/strict';
+import {mkdtempSync,mkdirSync,writeFileSync,readFileSync,rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join,resolve} from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {performance} from 'node:perf_hooks';
+import {execFileSync} from 'node:child_process';
+if(!process.argv[2])throw Error('Usage: node scripts/benchmark-runtime-workloads.mjs BASELINE_CHECKOUT [CANDIDATE_CHECKOUT]');
+const baselineRoot=resolve(process.argv[2]);
+const candidateRoot=resolve(process.argv[3]||'.');
+assert.notEqual(baselineRoot,candidateRoot,'use independently built baseline and candidate checkouts');
+const revision=repo=>execFileSync('git',['rev-parse','HEAD'],{cwd:repo,encoding:'utf8'}).trim();
+const root=mkdtempSync(join(tmpdir(),'fx-runtime-workloads-'));
+const rounds=Number(process.env.FAUXNIX_BENCH_ROUNDS ?? 15);
+const envCount=Number(process.env.FAUXNIX_BENCH_ENV_COUNT ?? 0);
+assert.ok(Number.isInteger(rounds) && rounds >= 3 && rounds <= 100);
+assert.ok(Number.isInteger(envCount) && envCount >= 0 && envCount <= 1000);
+const median=v=>[...v].sort((a,b)=>a-b)[Math.floor(v.length/2)];
+const environments={};
+async function prepare(name,repo){
+  const {FauxnixSession}=await import(pathToFileURL(join(repo,'dist/executor.js')));
+  const {parseCommand}=await import(pathToFileURL(join(repo,'dist/parser.js')));
+  const {translateCommandList}=await import(pathToFileURL(join(repo,'dist/translator.js')));
+  await import(pathToFileURL(join(repo,'dist/commands/install-all.js')));
+  const session=new FauxnixSession();
+  const directory=join(root,name);mkdirSync(directory);mkdirSync(join(directory,'src','lib'),{recursive:true});mkdirSync(join(directory,'data'));
+  for(let i=0;i<envCount;i++)session.env['FX_BENCH_'+i]='value-'+i;
+  await session.prewarm();
+  const compile=s=>translateCommandList(parseCommand(s));
+  await session.run(compile(':'),{cwd:directory});
+  environments[name]={session,directory,compile};
+}
+const workloads={
+  read_report:Array.from({length:32},(_,i)=>`printf 'line${i}\\n'`).join('; '),
+  state_updates:Array.from({length:16},(_,i)=>`FX_VAR=${i}; printf "$FX_VAR"`).join('; '),
+  rename:"sed -i 's/oldName/newName/g' src/a.ts src/b.ts && printf 'src/a.ts\\nsrc/b.ts\\n' > result6.txt",
+  table_pipeline:"tail -n +2 data/users.tsv | cut -f3 | sort | uniq -c | awk '{print $2, $1}' > result7.txt",
+};
+try{
+  await prepare('baseline',baselineRoot);await prepare('candidate',candidateRoot);
+  const reports=[];
+  for(const [workload,command] of Object.entries(workloads)){
+    const samples={baseline:[],candidate:[]};
+    for(let r=-3;r<rounds;r++){
+      const order=r%2?['candidate','baseline']:['baseline','candidate'];
+      const answers={};
+      for(const name of order){
+        const {session,directory,compile}=environments[name];
+        writeFileSync(join(directory,'src/a.ts'),'var oldName = 1;\nvar otherVar = 2;');
+        writeFileSync(join(directory,'src/b.ts'),'console.log(oldName);\nvar newName = 3;');
+        writeFileSync(join(directory,'src/lib/c.ts'),'export const oldName = "keep";');
+        writeFileSync(join(directory,'data/users.tsv'),'name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA\nCarol\t35\tNYC\n');
+        const plans=compile(command);
+        const started=performance.now();
+        const result=await session.run(plans,{cwd:directory});
+        const elapsed=performance.now()-started;
+        assert.equal(result.exitCode,0);
+        answers[name]=result.stdout;
+        if(workload==='rename'){
+          assert.equal(readFileSync(join(directory,'src/a.ts'),'utf8'),'var newName = 1;\nvar otherVar = 2;\n');
+          assert.equal(readFileSync(join(directory,'src/b.ts'),'utf8'),'console.log(newName);\nvar newName = 3;\n');
+          assert.equal(readFileSync(join(directory,'src/lib/c.ts'),'utf8'),'export const oldName = "keep";');
+          assert.equal(readFileSync(join(directory,'result6.txt'),'utf8'),'src/a.ts\nsrc/b.ts\n');
+        }
+        if(workload==='table_pipeline')assert.equal(readFileSync(join(directory,'result7.txt'),'utf8'),'LA 1\nNYC 2\n');
+        if(r>=0)samples[name].push(elapsed);
+      }
+      assert.equal(answers.baseline,answers.candidate);
+    }
+    const baselineMs=median(samples.baseline),candidateMs=median(samples.candidate);
+    const report={workload,rounds,extraEnvCount:envCount,baselineMs,candidateMs,speedup:baselineMs/candidateMs,samples};
+    reports.push(report);console.log(JSON.stringify(report));
+  }
+  const report={node:process.version,ps:process.env.FAUXNIX_PS||'desktop',
+    baselineRevision:revision(baselineRoot),candidateRevision:revision(candidateRoot),reports};
+  if(process.env.FAUXNIX_BENCH_OUTPUT)writeFileSync(process.env.FAUXNIX_BENCH_OUTPUT,JSON.stringify(report,null,2)+'\n');
+  console.log(JSON.stringify(report));
+}finally{
+  for(const {session} of Object.values(environments))await session.dispose();
+  rmSync(root,{recursive:true,force:true});
+}

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -1,7 +1,6 @@
 import { spawn, ChildProcess } from 'node:child_process';
 import {
   closeSync,
-  mkdirSync,
   openSync,
   readSync,
   rmSync,
@@ -290,7 +289,6 @@ export class PowerShellHost {
       resolvedLimits.nativeStderrSpoolPath = this.hostFile + '.' + id + '.native-stderr';
     }
     const nativeSpoolDir = this.hostFile + '.' + id + '.native';
-    mkdirSync(nativeSpoolDir);
     const requestEnv = { ...env, FAUXNIX_NATIVE_SPOOL_DIR: nativeSpoolDir };
     const line = encodeHostRequest(
       id,
@@ -657,7 +655,7 @@ export class PowerShellHost {
     let native = Buffer.alloc(0);
     let nativeTruncated = false;
     const nativeSpool = limits?.nativeStderrSpoolPath;
-    if ((limits?.stderrMode ?? 'capture') === 'capture' && nativeSpool) {
+    if ((limits?.stderrMode ?? 'capture') === 'capture' && nativeSpool && nativeBytes > 0) {
       const remaining = Math.max(
         0,
         (limits?.stderrLimit ?? DEFAULT_STDERR_LIMIT) - capturedErr.length,
@@ -665,9 +663,6 @@ export class PowerShellHost {
       const clipped = this.readUtf8Prefix(nativeSpool, remaining, nativeBytes);
       native = Buffer.from(clipped.data);
       nativeTruncated = clipped.truncated;
-      rmSync(nativeSpool, { force: true });
-    }
-    if (limits?.stderrMode === 'spool' && nativeSpool && nativeBytes === 0) {
       rmSync(nativeSpool, { force: true });
     }
     const n = Number(end.exitCode);
@@ -705,15 +700,6 @@ export class PowerShellHost {
         this.nativeCapture = null;
         reject(failure);
       }, timeoutMs);
-      let spoolFd: number | undefined;
-      let ioError: NativeStderrSpoolError | undefined;
-      if (mode !== 'discard' && spoolPath) {
-        try {
-          spoolFd = openSync(spoolPath, 'w');
-        } catch (e) {
-          ioError = new NativeStderrSpoolError('open', spoolPath, e);
-        }
-      }
       this.nativeCapture = {
         id,
         needle: Buffer.from('FAUXNIX_ERR_END:' + id + '\n', 'utf8'),
@@ -721,10 +707,8 @@ export class PowerShellHost {
         limit: Math.max(0, limit),
         tail: Buffer.alloc(0),
         spoolPath,
-        spoolFd,
         bytesWritten: 0,
         bytesSeen: 0,
-        ioError,
         resolve,
         reject,
         timer,
@@ -743,11 +727,21 @@ export class PowerShellHost {
   ): void {
     if (!data.length) return;
     state.bytesSeen += data.length;
-    if (state.ioError || state.mode === 'discard' || state.spoolFd === undefined) return;
+    if (state.ioError || state.mode === 'discard') return;
     let retained = data;
     if (state.mode === 'capture') {
       const remaining = Math.max(0, state.limit + 3 - state.bytesWritten);
       retained = data.subarray(0, remaining);
+    }
+    if (!retained.length) return;
+    if (state.spoolFd === undefined) {
+      if (!state.spoolPath) return;
+      try {
+        state.spoolFd = openSync(state.spoolPath, 'w');
+      } catch (e) {
+        state.ioError = new NativeStderrSpoolError('open', state.spoolPath, e);
+        return;
+      }
     }
     try {
       let offset = 0;

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1499,13 +1499,13 @@ function wrapCwdPreamble(): string[] {
     '$script:fx_exit = 0',
     '$fx_prev = 0',
     'if ($env:FAUXNIX_PREV_EXIT) { try { $fx_prev = [int]$env:FAUXNIX_PREV_EXIT } catch { $fx_prev = 0 } }',
-    'if ($env:FAUXNIX_CWD) { try { Set-Location -LiteralPath $env:FAUXNIX_CWD } catch {} }',
+    'if ($env:FAUXNIX_CWD -and (Get-Location).ProviderPath -cne $env:FAUXNIX_CWD) { try { Set-Location -LiteralPath $env:FAUXNIX_CWD } catch {} }',
     // capture AFTER the session cwd is applied — OLDPWD must refer to the
     // shell's previous directory, not the host process' startup directory
     '$fx_oldcwd = (Get-Location).ProviderPath',
     // .NET APIs (ReadAllBytes & friends) resolve relative paths against the
     // process working directory, NOT the PS location — keep them in sync.
-    'try { [Environment]::CurrentDirectory = (Get-Location).ProviderPath } catch {}',
+    'try { if ([Environment]::CurrentDirectory -cne $fx_oldcwd) { [Environment]::CurrentDirectory = $fx_oldcwd } } catch {}',
   ];
 }
 
@@ -1521,12 +1521,20 @@ function wrapBodyAndPersist(body: string, exitProcess: boolean): string[] {
     '  $script:fx_exit = 1',
     '}',
     '# persist session cwd and environment for the next segment',
-    'try { [IO.File]::WriteAllText($env:FAUXNIX_CWD_FILE, (Get-Location).Path) } catch {}',
+    ...(exitProcess ? [
+      'try { [IO.File]::WriteAllText($env:FAUXNIX_CWD_FILE, (Get-Location).Path) } catch {}',
+    ] : [
+      'try { [FauxnixSessionState]::SaveCwd($env:FAUXNIX_CWD_FILE, (Get-Location).Path) } catch {}',
+    ]),
     'if ((Get-Location).Path -ne $fx_oldcwd) { $env:FAUXNIX_OLDPWD = $fx_oldcwd }',
     'try {',
-    '  $envObj = @{}',
-    '  Get-ChildItem Env: | ForEach-Object { $envObj[$_.Name] = $_.Value }',
-    '  [IO.File]::WriteAllText($env:FAUXNIX_ENV_FILE, (ConvertTo-Json $envObj -Compress))',
+    ...(exitProcess ? [
+      '  $envObj = @{}',
+      '  Get-ChildItem Env: | ForEach-Object { $envObj[$_.Name] = $_.Value }',
+      '  [IO.File]::WriteAllText($env:FAUXNIX_ENV_FILE, (ConvertTo-Json $envObj -Compress))',
+    ] : [
+      '  [FauxnixSessionState]::SaveEnvironment($env:FAUXNIX_ENV_FILE)',
+    ]),
     '} catch {}',
   ];
   if (exitProcess) lines.push('exit $script:fx_exit');
@@ -1998,7 +2006,7 @@ export function wrapScript(body: string, opts: WrapScriptOptions = {}): string {
       '  $fx_spoolUtf8 = New-Object System.Text.UTF8Encoding $false',
       '  try {',
       '    if (-not $term) {',
-      "      if ($env:FAUXNIX_NATIVE_SPOOL_DIR) { $fx_no = Join-Path $env:FAUXNIX_NATIVE_SPOOL_DIR (([guid]::NewGuid().ToString('N')) + '.out') }",
+      "      if ($env:FAUXNIX_NATIVE_SPOOL_DIR) { [void][IO.Directory]::CreateDirectory($env:FAUXNIX_NATIVE_SPOOL_DIR); $fx_no = Join-Path $env:FAUXNIX_NATIVE_SPOOL_DIR (([guid]::NewGuid().ToString('N')) + '.out') }",
       '      else { $fx_no = [IO.Path]::GetTempFileName() }',
       '    }',
       '    [void]$p.Start()',
@@ -2060,6 +2068,63 @@ if (-not ('FauxnixBoundedStream' -as [type])) {
   Add-Type -TypeDefinition @'
 using System;
 using System.IO;
+using System.Collections;
+using System.Text;
+public static class FauxnixSessionState {
+  private static string previousCwdPath;
+  private static string previousCwd;
+  private static string previousEnvironmentPath;
+  private static string previousEnvironment;
+  public static void SaveCwd(string path, string cwd) {
+    if (path == previousCwdPath && cwd == previousCwd && File.Exists(path)) return;
+    File.WriteAllText(path, cwd, new UTF8Encoding(false));
+    previousCwdPath = path;
+    previousCwd = cwd;
+  }
+  private static void AppendJsonString(StringBuilder json, string value) {
+    json.Append((char)34);
+    foreach (char c in value) {
+      if (c == (char)34 || c == (char)92) {
+        json.Append((char)92).Append(c);
+      } else if (c < 32 || Char.IsSurrogate(c)) {
+        json.Append((char)92).Append('u').Append(((int)c).ToString("x4"));
+      } else {
+        json.Append(c);
+      }
+    }
+    json.Append((char)34);
+  }
+  public static void SaveEnvironment(string path) {
+    // Keep a complete snapshot: merging with the parent's environment on a
+    // later restart would resurrect values removed by unset.
+    IDictionary environment = Environment.GetEnvironmentVariables();
+    var json = new StringBuilder(4096);
+    json.Append('{');
+    bool first = true;
+    var keys = new string[environment.Count];
+    environment.Keys.CopyTo(keys, 0);
+    Array.Sort(keys, StringComparer.Ordinal);
+    foreach (string key in keys) {
+      // These values are request transport metadata and are always supplied
+      // afresh by Node; changing them does not change persistent shell state.
+      if (String.Equals(key, "FAUXNIX_NATIVE_SPOOL_DIR", StringComparison.OrdinalIgnoreCase) ||
+          String.Equals(key, "FAUXNIX_PREV_EXIT", StringComparison.OrdinalIgnoreCase) ||
+          String.Equals(key, "FAUXNIX_STDIN_FILE", StringComparison.OrdinalIgnoreCase) ||
+          String.Equals(key, "FAUXNIX_CWD", StringComparison.OrdinalIgnoreCase)) continue;
+      if (!first) json.Append(',');
+      first = false;
+      AppendJsonString(json, key);
+      json.Append(':');
+      AppendJsonString(json, (string)environment[key]);
+    }
+    json.Append('}');
+    string current = json.ToString();
+    if (path == previousEnvironmentPath && current == previousEnvironment && File.Exists(path)) return;
+    File.WriteAllText(path, current, new UTF8Encoding(false));
+    previousEnvironmentPath = path;
+    previousEnvironment = current;
+  }
+}
 public sealed class FauxnixBoundedStream : Stream {
   private readonly MemoryStream inner;
   private readonly long limit;

--- a/test/integration.windows.test.ts
+++ b/test/integration.windows.test.ts
@@ -133,6 +133,68 @@ describe.skipIf(!hasPs)(`integration (real ${selectedPowerShell.executable})`, {
     expect(mixed.stdout).toBe('layout/a.ts\n\nlayout/lib/:\nc.ts\n');
   });
 
+  it('avoids unchanged checkpoint writes while preserving changed and unset state', async () => {
+    const extra = new FauxnixSession();
+    const checkpoint = join(tmpdir(), 'fauxnix-' + extra.id + '-env.json');
+    const cwdCheckpoint = join(tmpdir(), 'fauxnix-' + extra.id + '-cwd.txt');
+    try {
+      await extra.run(translateCommandList(parseCommand('printf first')), { cwd: dir });
+      const firstEnvTime = statSync(checkpoint).mtimeMs;
+      const firstCwdTime = statSync(cwdCheckpoint).mtimeMs;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await extra.run(translateCommandList(parseCommand('printf second')));
+      expect(statSync(checkpoint).mtimeMs).toBe(firstEnvTime);
+      expect(statSync(cwdCheckpoint).mtimeMs).toBe(firstCwdTime);
+
+      await extra.run(translateCommandList(parseCommand("export FX_CHECKPOINT_VALUE='changed'")));
+      expect(JSON.parse(readFileSync(checkpoint, 'utf8')).FX_CHECKPOINT_VALUE).toBe('changed');
+      await extra.run(translateCommandList(parseCommand('unset FX_CHECKPOINT_VALUE')));
+      expect(JSON.parse(readFileSync(checkpoint, 'utf8')).FX_CHECKPOINT_VALUE).toBeUndefined();
+      await extra.run(translateCommandList(parseCommand('sleep 5')), { timeoutMs: 200 });
+      const resumed = await extra.run(translateCommandList(parseCommand("printf '%s' \"${FX_CHECKPOINT_VALUE:-absent}\"")));
+      expect(resumed.stdout).toBe('absent');
+    } finally {
+      await extra.dispose();
+    }
+  }, 30000);
+
+  it('serializes environment strings exactly in compiled checkpoints', async () => {
+    const hostFile = join(dir, 'checkpoint-encoding-host.ps1');
+    const envPath = join(dir, 'checkpoint-encoding.json');
+    const key = 'FX_JSON_KEY';
+    const value = 'quotes " \\ tabs\tlines\n中文😀';
+    // Match the other direct-host fixtures. In Vitest workers process.env is
+    // case-sensitive, so SDK uppercase allow-list lookups can omit SystemRoot
+    // from the mixed-case environment provided by Windows CI.
+    const host = new PowerShellHost(hostFile, () => ({ ...process.env, [key]: value }));
+    try {
+      expect(await host.ready()).toBeNull();
+      const result = await host.invoke('[FauxnixSessionState]::SaveEnvironment($env:FX_DEST)', { FX_DEST: envPath }, 30000);
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(readFileSync(envPath, 'utf8'))[key]).toBe(value);
+    } finally {
+      await host.stop();
+      rmSync(hostFile, { force: true });
+    }
+  }, 30000);
+
+  it('does not allocate native spool files for ordinary translated output', async () => {
+    const hostFile = join(dir, 'lazy-spool-host.ps1');
+    const host = new PowerShellHost(hostFile, () => ({ ...process.env }));
+    try {
+      const result = await host.invoke([
+        "[Console]::Out.Write([IO.Directory]::Exists($env:FAUXNIX_NATIVE_SPOOL_DIR))",
+        "[Console]::Out.Write([IO.File]::Exists($env:FX_HOST_PREFIX + '.' + $fx_id + '.native-stderr'))",
+      ].join('\n'), { FX_HOST_PREFIX: hostFile }, 30000);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.toString('utf8')).toBe('FalseFalse');
+      expect(result.nativeStderr?.length ?? 0).toBe(0);
+    } finally {
+      await host.stop();
+      rmSync(hostFile, { force: true });
+    }
+  }, 30000);
+
   it('cat reads files', async () => {
     const r = await run('cat fruits.txt');
     expect(r.stdout.split(/\r?\n/).filter(Boolean)).toEqual([

--- a/test/mcp-batch.windows.test.ts
+++ b/test/mcp-batch.windows.test.ts
@@ -3,14 +3,36 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import {
-  getDefaultEnvironment,
+  DEFAULT_INHERITED_ENV_VARS,
   StdioClientTransport,
 } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { describe, expect, it } from 'vitest';
 
 const onWindows = process.platform === 'win32';
 
+// Windows worker environments use case-sensitive JS lookups even though native
+// process environments do not. Keep the SDK allow-list, but resolve mixed-case
+// keys such as SystemRoot and Path before launching the MCP child.
+function mcpTestEnvironment(source: NodeJS.ProcessEnv): Record<string, string> {
+  const normalized = new Map(Object.entries(source).map(([key, value]) => [key.toUpperCase(), value]));
+  const inherited: Record<string, string> = {};
+  for (const key of DEFAULT_INHERITED_ENV_VARS) {
+    const value = normalized.get(key.toUpperCase());
+    if (value !== undefined && !value.startsWith('()')) inherited[key] = value;
+  }
+  return inherited;
+}
+
 describe.skipIf(!onWindows)('MCP compiled batch tool', () => {
+  it('keeps mixed-case Windows launch variables within the SDK allow-list', () => {
+    expect(mcpTestEnvironment({
+      SystemRoot: 'C:\\Windows',
+      Path: 'C:\\Windows\\System32',
+      Temp: '() { ignored; }',
+      UNRELATED_VALUE: 'not inherited',
+    })).toEqual({ SYSTEMROOT: 'C:\\Windows', PATH: 'C:\\Windows\\System32' });
+  });
+
   it('preflights every step and returns byte-exact per-step results in one call', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'fauxnix-mcp-batch-'));
     const tsx = join(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs');
@@ -19,7 +41,7 @@ describe.skipIf(!onWindows)('MCP compiled batch tool', () => {
       args: [tsx, 'src/index.ts', 'mcp'],
       cwd: process.cwd(),
       env: {
-        ...getDefaultEnvironment(),
+        ...mcpTestEnvironment(process.env),
         FAUXNIX_PS: process.env.FAUXNIX_PS ?? '',
       },
       stderr: 'pipe',
@@ -51,7 +73,7 @@ describe.skipIf(!onWindows)('MCP compiled batch tool', () => {
         stepsCompleted: number;
         steps: Array<{ id?: string; status: string; stdout?: string; exitCode?: number }>;
       };
-      expect(result.isError).not.toBe(true);
+      expect(result.isError, JSON.stringify(result)).not.toBe(true);
       expect(structured.stopReason).toBe('command_failed');
       expect(structured.stepsCompleted).toBe(4);
       expect(structured.steps[2].id).toBe('measure');


### PR DESCRIPTION
Every warm command currently pays for PowerShell environment-provider enumeration, JSON conversion, cwd resets, checkpoint writes and unused temporary files. This optimizes that default execution path, including ordinary `bash` calls and existing command lists.

Compile session snapshot serialization once with the resident host; use stable key ordering and skip unchanged checkpoint writes. Preserve changed/unset values before the next segment, omit only per-request transport metadata, and avoid redundant cwd setters. Allocate native spool directories and raw-stderr files only when needed.

Local alternating comparison against an independently built `cf57887` baseline, 15 measured rounds after warmup, no additional synthetic environment entries:

| Execution workload | Baseline median | Candidate median | Speedup |
|---|---:|---:|---:|
| 32-segment report | 700.6 ms | 197.7 ms | 3.54x |
| 32-segment state updates/report | 474.5 ms | 152.9 ms | 3.10x |
| T6 rename + manifest | 39.1 ms | 19.2 ms | 2.03x |
| T7 table pipeline | 39.0 ms | 29.8 ms | 1.31x |

These Windows PowerShell 5.1 measurements exclude model inference, boot, translation and fixture setup. They demonstrate execution improvement, not a claim that the reported 146/180-second agent sessions are solved. The included comparison script emits all raw samples; timing is not used as a flaky CI threshold.

Validation exercises unchanged-file mtimes, changed/unset values surviving a timeout restart, JSON string fidelity, absence of unused spool allocations, native output/error handling and the existing suite. Updated head `478f75e` is rebased onto main `5ee2fcc` and passes all three fresh CI lanes (x64 Desktop, x64 Core, ARM64 Desktop), including package smoke. The x64 Desktop suite reports 443 passed and one optional skip. CI: https://github.com/20000419/fauxnix/actions/runs/34175134984 . The rebase also corrects mixed-case Windows environment handling in the inherited MCP test fixture; runtime behavior and timeout thresholds are unchanged. The previously recorded GNU oracle remains 249/253 with four known mismatches; it was not rerun as a full corpus for this rebase.

The short RFC explains cache lifetime and semantics. There is no result caching or command reordering; full host-frame fusion remains separate. Related: #214 and #215.

