### PR TITLE
fix: widenable host ready timeout for contended CI runners (#220)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
     timeout-minutes: 20
     env:
       FAUXNIX_PS: ${{ matrix.fauxnix_ps }}
+      FAUXNIX_HOST_READY_TIMEOUT_MS: '90000'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/src/ps-host.ts
+++ b/src/ps-host.ts
@@ -35,7 +35,14 @@ class NativeStderrSpoolError extends Error {
   }
 }
 
-const READY_TIMEOUT_MS = 30_000;
+// First-ready-line budget. 30s covers every dev machine measured; contended CI
+// runners cold-booting powershell.exe under full test parallelism have exceeded it,
+// so FAUXNIX_HOST_READY_TIMEOUT_MS (milliseconds, minimum 1000) widens the budget
+// without changing the default.
+const READY_TIMEOUT_MS = (() => {
+  const raw = Number(process.env.FAUXNIX_HOST_READY_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw >= 1000 ? raw : 30_000;
+})();
 
 export const DEFAULT_STDOUT_LIMIT = 8_388_608;
 export const DEFAULT_STDERR_LIMIT = 1_048_576;


### PR DESCRIPTION
Root cause of the two consecutive mcp-batch failures on the PS5.1 lane (runs on b869e8d): the 30s first-ready-line budget is exceeded when the runner cold-boots powershell.exe under full test parallelism. The code between the earlier green run and the red runs is byte-identical (version fields only), so this is budget, not regression.

- \`READY_TIMEOUT_MS\` reads \`FAUXNIX_HOST_READY_TIMEOUT_MS\` (milliseconds, minimum 1000; invalid values keep the 30s default)
- CI sets 90s; shipped default and user behavior unchanged
- Verified locally: typecheck clean; mcp-batch passes with knob=90s and with no knob (default path)

Related: #220 (the 7490630 gzip-segment flake is the same cold-runner pressure class).